### PR TITLE
Fix CEP 12 bridge on Premiere Pro 26 (macOS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **Note:** This is a temporary fork for a bug fix PR. See the original at [leancoderkavy/premiere-pro-mcp](https://github.com/leancoderkavy/premiere-pro-mcp).
+
 <div align="center">
 
 # Premiere Pro MCP Server

--- a/cep-plugin/CSInterface.js
+++ b/cep-plugin/CSInterface.js
@@ -26,15 +26,10 @@ function CSInterface() {}
  */
 CSInterface.prototype.evalScript = function (script, callback) {
   if (typeof __adobe_cep__ !== "undefined") {
-    var result = __adobe_cep__.evalScript(script);
-    if (callback) {
-      // CSInterface v9+ uses async callback
-      if (typeof result === "undefined" || result === "undefined") {
-        // v9+ path: callback is registered and called asynchronously
-        // The __adobe_cep__.evalScript already handles the callback via internal mechanism
-      }
-      callback(result);
-    }
+    // CEP 9+ requires the callback to be passed directly to __adobe_cep__.evalScript.
+    // Calling it without a callback causes the result to be silently discarded,
+    // making every command return null/undefined.
+    __adobe_cep__.evalScript(script, callback || function () {});
   } else {
     // Running outside CEP (for testing)
     console.warn("[CSInterface] Not running in CEP environment");

--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -22,6 +22,7 @@
           <ScriptPath>./host.jsx</ScriptPath>
           <CEFCommandLine>
             <Parameter>--allow-file-access-from-files</Parameter>
+            <Parameter>--enable-nodejs</Parameter>
           </CEFCommandLine>
         </Resources>
         <Lifecycle>


### PR DESCRIPTION
Hi. I used your MCP server successfully after a fair amount of debug help from Claude. The MCP saved me some time, so I wanted to share what changes made the MCP work for me. The code changes and most of this text were written by Claude Code.  
Thanks,
Bryce (a mere human)

 
---                                                                                                
  Environment:                                                                                       
  - macOS 14.1 (Sonoma)                                                                              
  - Premiere Pro 26.0.2 (2026 release)                      
  - CEP 12                                                                                           
  - premiere-pro-mcp v1.1.1 installed via npm                                                        
                                                                                                     
  ---                                                                                                
  What does this PR do?

  Fixes two bugs that prevent the bridge from working on Premiere Pro 26 / CEP 12. Without both
  fixes, the bridge either fails to start or returns null for every command.                         
   
  Bug 1: require('fs') is undefined — missing --enable-nodejs in manifest                            
                                                            
  Symptom: The CEP panel loads but immediately shows:                                                
  Error creating dir: Cannot read properties of undefined (reading 'existsSync')
                                                                                                     
  Cause: CEP 12 requires an explicit --enable-nodejs flag. Without it, require('fs') returns         
  undefined.                                                                                         
                                                                                                     
  Fix: Added <Parameter>--enable-nodejs</Parameter> to CEFCommandLine in manifest.xml.               
                               
  Bug 2: All commands return null — CSInterface.evalScript missing callback argument                 
                                                            
  Symptom: Bridge connects, ping succeeds, but every command returns null.                           
  
  Cause: The shim called __adobe_cep__.evalScript(script) without passing the callback. CEP 9+ is    
  asynchronous — without a callback the result is silently discarded. The manifest already declares
  RequiredRuntime CSXS 9.0, so this async behavior applies to all supported versions.                
                                                            
  Fix: Changed to __adobe_cep__.evalScript(script, callback || function () {}).


## Type of Change

- [ ] New tool(s)
- [X] Bug fix
- [ ] Documentation
- [ ] Refactor
- [ ] Other


## Checklist

(many of these don't apply since only the CEP plugin was changed)

- [X] `npm run build` compiles without errors
- [ ] Tool descriptions are clear and useful for an LLM
- [ ] All parameters have descriptions
- [ ] ExtendScript uses ES3 syntax (`var`, no arrow functions, no `let`/`const`)
- [ ] User-provided strings are escaped with `escapeForExtendScript()`
- [ ] New module is exported from `getXTools()` and registered in `server.ts`
- [ ] No duplicate tool names introduced
- [X] Tested with Premiere Pro (if possible)
- [ ] `RESEARCH.md` updated (if adding new tools)
