### PR TITLE
Fix markers/proxies/presets/frame-export (#6, #7, #9) and release 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,70 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.2] - 2026-07-11
+
+The headline of this release is that the CEP 12 bridge fix from
+[#1](https://github.com/leancoderkavy/premiere-pro-mcp/pull/1) finally ships to npm. It has been on
+`main` since March but was never published, so everyone who installed with `npm install -g` still
+got a bridge that returned `null` for every tool call. If that was your symptom, upgrading is the
+whole fix.
+
+### Fixed
+
+- **The bridge returns data again on Premiere Pro 2023+ / CEP 12.** The published `CSInterface.js`
+  shim called `__adobe_cep__.evalScript(script)` without forwarding the callback. CEP 9+ is
+  async-only, so every result was silently discarded and every tool answered
+  `{"success":true,"data":null}` while the panel cheerfully logged "Result: OK". The manifest was
+  also missing `--enable-nodejs`, leaving `require("fs")` undefined in the panel.
+  ([#2](https://github.com/leancoderkavy/premiere-pro-mcp/issues/2),
+  [#5](https://github.com/leancoderkavy/premiere-pro-mcp/issues/5),
+  [#8](https://github.com/leancoderkavy/premiere-pro-mcp/issues/8))
+
+- **Markers landed at wildly wrong times.** `createMarker()` takes seconds, but was being handed
+  ticks — a marker requested at 2.0s was placed roughly 508 billion seconds down the timeline,
+  far past the end of any real sequence. `marker.end` had the same bug, and `list_markers` read
+  back nonsense as a result. ([#6](https://github.com/leancoderkavy/premiere-pro-mcp/issues/6))
+
+- **`manage_proxies` and `get_encoder_presets` called ExtendScript methods that do not exist.**
+  `ProjectItem` has no `createProxy()` and `EncoderManager` has no `getFormatList()`, so both threw
+  every time. `manage_proxies` with `action: "create"` now queues a real proxy encode through Media
+  Encoder instead of reporting "Proxy creation started" for work that never happened, and
+  `get_encoder_presets` discovers presets by scanning the `.epr` files Adobe ships on disk, returning
+  each preset's path so it can be passed straight to `export_sequence`.
+  ([#7](https://github.com/leancoderkavy/premiere-pro-mcp/issues/7))
+
+- **`capture_frame`, `export_frame`, and `freeze_frame` threw on every call.** `exportFramePNG`
+  exists only on the QE DOM sequence, not the public DOM one. These tools now go through the QE
+  sequence, and — because QE's return value is unreliable — decide success by checking that a file
+  actually exists on disk, falling back to a one-frame Media Encoder export. They can no longer
+  report success having written nothing.
+  ([#9](https://github.com/leancoderkavy/premiere-pro-mcp/issues/9))
+
+- **Six tools repaired for Premiere Pro 2026** via
+  [#3](https://github.com/leancoderkavy/premiere-pro-mcp/pull/3): `add_audio_keyframes` (used a
+  nonexistent `Property.addKeyframe`, and wrote dB into a property that stores amplitude),
+  `color_correct` (one unsettable Lumetri property aborted the whole script and lost every other
+  change), `add_transition` and friends (`getVideoTransitionList()` returns empty on 2026 even
+  though by-name lookup works), `add_adjustment_layer` (`qeSeq.addAdjustmentLayer` was removed in
+  2026), `export_sequence` (defaulted to a hardcoded macOS-only preset path), and `add_text_overlay`
+  (called `createCaptionTrack` with the wrong signature).
+
+- `manage_proxies` with `action: "toggle"` reported the inverse of the state it had just set.
+
+- The README described this repository as "a temporary fork" of itself — a fork banner that rode in
+  with the [#1](https://github.com/leancoderkavy/premiere-pro-mcp/pull/1) merge.
+
+### Notes
+
+- The frame-export and proxy-create paths are fixed against the documented API and covered by
+  regression tests, but have not yet been live-verified against a running Premiere Pro. If you can
+  test them, reports on
+  [#7](https://github.com/leancoderkavy/premiere-pro-mcp/issues/7) and
+  [#9](https://github.com/leancoderkavy/premiere-pro-mcp/issues/9) are very welcome.
+- Windows users on CEP 12 may additionally need to sign the extension (`ZXPSignCmd -sign`) — see
+  [#2](https://github.com/leancoderkavy/premiere-pro-mcp/issues/2) for details. That is an Adobe
+  signature-verification requirement, not a bug in this package.
+
 ## [1.0.0] - 2025-02-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-> **Note:** This is a temporary fork for a bug fix PR. See the original at [leancoderkavy/premiere-pro-mcp](https://github.com/leancoderkavy/premiere-pro-mcp).
-
 <div align="center">
 
 # Premiere Pro MCP Server

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "premiere-pro-mcp",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "MCP server for controlling Adobe Premiere Pro via CEP/ExtendScript — 269 tools for AI-driven video editing",
   "main": "dist/index.js",
   "type": "module",

--- a/src/bridge/script-builder.ts
+++ b/src/bridge/script-builder.ts
@@ -203,6 +203,25 @@ function __collectAllPresets() {
   return presets;
 }
 
+// Default export preset. "48323634" is hex for "H264" — the folder name AME uses
+// for the H.264 format bucket on disk.
+function __findH264Preset() {
+  var presets = __collectAllPresets();
+  var candidates = [];
+  for (var i = 0; i < presets.length; i++) {
+    var haystack = (presets[i].name + " " + presets[i].format).toLowerCase();
+    if (haystack.indexOf("h264") !== -1 || haystack.indexOf("h.264") !== -1 || haystack.indexOf("48323634") !== -1) {
+      candidates.push(presets[i]);
+    }
+  }
+  if (!candidates.length) return "";
+
+  for (var j = 0; j < candidates.length; j++) {
+    if (candidates[j].name.toLowerCase().indexOf("match source - high") !== -1) return candidates[j].path;
+  }
+  return candidates[0].path;
+}
+
 function __findProxyPreset() {
   var ppro = __adobeAppFolders("Adobe Premiere Pro");
   for (var i = 0; i < ppro.length; i++) {

--- a/src/bridge/script-builder.ts
+++ b/src/bridge/script-builder.ts
@@ -130,6 +130,244 @@ function __getAllClips(seq) {
   return clips;
 }
 
+// Premiere's ExtendScript API exposes no preset/format enumeration (there is no
+// encoder.getFormatList()), so presets have to be discovered by walking the .epr
+// files Adobe ships on disk.
+
+function __isMacOS() {
+  return !!($.os && $.os.toLowerCase().indexOf("mac") !== -1);
+}
+
+// Version-agnostic: returns install folders whose name starts with appNamePrefix,
+// e.g. "Adobe Premiere Pro" -> [.../Adobe Premiere Pro 2026, .../Adobe Premiere Pro 2025]
+function __adobeAppFolders(appNamePrefix) {
+  var base = new Folder(__isMacOS() ? "/Applications" : "C:\\\\Program Files\\\\Adobe");
+  if (!base.exists) return [];
+
+  var found = [];
+  var subs = base.getFiles(function(f) { return f instanceof Folder; });
+  for (var i = 0; i < subs.length; i++) {
+    if (subs[i].displayName.indexOf(appNamePrefix) === 0) found.push(subs[i]);
+  }
+  // Newest version first, so a 2026 preset wins over a stale 2024 one.
+  found.sort(function(a, b) { return a.displayName < b.displayName ? 1 : -1; });
+  return found;
+}
+
+function __collectEprFiles(folder, out) {
+  if (!folder || !folder.exists) return out;
+  var entries = folder.getFiles();
+  for (var i = 0; i < entries.length; i++) {
+    var entry = entries[i];
+    if (entry instanceof Folder) __collectEprFiles(entry, out);
+    else if (/\\.epr$/i.test(entry.name)) out.push(entry);
+  }
+  return out;
+}
+
+// All export presets AME ships, plus the user's own saved presets.
+function __collectAllPresets() {
+  var roots = [];
+
+  var ame = __adobeAppFolders("Adobe Media Encoder");
+  for (var i = 0; i < ame.length; i++) {
+    roots.push(new Folder(ame[i].fsName + "/MediaIO/systempresets"));
+  }
+
+  var ppro = __adobeAppFolders("Adobe Premiere Pro");
+  for (var j = 0; j < ppro.length; j++) {
+    roots.push(new Folder(ppro[j].fsName + "/Settings/IngestPresets"));
+  }
+
+  // User-saved presets live under the Documents tree on both platforms.
+  var userRoot = new Folder(Folder.myDocuments.fsName + "/Adobe/Adobe Media Encoder");
+  if (userRoot.exists) {
+    var versions = userRoot.getFiles(function(f) { return f instanceof Folder; });
+    for (var v = 0; v < versions.length; v++) {
+      roots.push(new Folder(versions[v].fsName + "/Presets"));
+    }
+  }
+
+  var presets = [];
+  for (var r = 0; r < roots.length; r++) {
+    var eprs = __collectEprFiles(roots[r], []);
+    for (var e = 0; e < eprs.length; e++) {
+      presets.push({
+        name: decodeURI(eprs[e].displayName).replace(/\\.epr$/i, ""),
+        path: eprs[e].fsName,
+        // The parent folder is the format bucket, e.g. "48323634" (hex "H264").
+        format: eprs[e].parent ? decodeURI(eprs[e].parent.displayName) : ""
+      });
+    }
+  }
+  return presets;
+}
+
+function __findProxyPreset() {
+  var ppro = __adobeAppFolders("Adobe Premiere Pro");
+  for (var i = 0; i < ppro.length; i++) {
+    var proxyDir = new Folder(ppro[i].fsName + "/Settings/IngestPresets/Proxy");
+    var eprs = __collectEprFiles(proxyDir, []);
+    if (eprs.length) {
+      eprs.sort(function(a, b) { return a.displayName < b.displayName ? -1 : 1; });
+      return eprs[0].fsName;
+    }
+  }
+  return "";
+}
+
+function __findStillPreset(outputPath) {
+  var wantJpeg = /\\.jpe?g$/i.test(outputPath);
+  var needles = wantJpeg ? ["jpeg", "jpg"] : ["png"];
+  var presets = __collectAllPresets();
+
+  for (var n = 0; n < needles.length; n++) {
+    for (var i = 0; i < presets.length; i++) {
+      var haystack = (presets[i].name + " " + presets[i].format).toLowerCase();
+      if (haystack.indexOf(needles[n]) !== -1) return presets[i].path;
+    }
+  }
+  return "";
+}
+
+// Returns the path actually written, or "" if nothing was. Media Encoder treats a
+// still export as a one-frame image *sequence* and appends a frame number to the
+// filename, so an exact-path miss is not proof that nothing was written.
+function __firstWrittenFile(outputPath) {
+  var exact = new File(outputPath);
+  if (exact.exists && exact.length > 0) return exact.fsName;
+
+  var dir = exact.parent;
+  if (!dir || !dir.exists) return "";
+
+  var fullName = decodeURI(exact.name);
+  var dot = fullName.lastIndexOf(".");
+  var base = dot === -1 ? fullName : fullName.substring(0, dot);
+  var ext = dot === -1 ? "" : fullName.substring(dot).toLowerCase();
+
+  var matches = dir.getFiles(function(candidate) {
+    if (candidate instanceof Folder) return false;
+    var nm = decodeURI(candidate.name);
+    if (nm.indexOf(base) !== 0) return false;
+    return ext === "" || nm.toLowerCase().substring(nm.length - ext.length) === ext;
+  });
+  if (!matches || !matches.length) return "";
+
+  // Normalize back to the caller's requested path so they get the name they asked for.
+  var produced = matches[0];
+  if (produced.length <= 0) return "";
+  try {
+    if (produced.fsName !== exact.fsName) produced.rename(fullName);
+    return exact.exists ? exact.fsName : produced.fsName;
+  } catch (e) {
+    return produced.fsName;
+  }
+}
+
+// Export a single frame to disk. Returns { ok, method, path, notes } / { ok:false, error, notes }.
+//
+// exportFramePNG/exportFrameJPEG do NOT exist on the public DOM sequence — only on
+// the QE sequence — and even there they return false and write nothing on some
+// builds. So we try QE first, verify against the filesystem rather than the return
+// value, and fall back to a one-frame Media Encoder export.
+function __exportStillFrame(outputPath, ticks) {
+  var seq = app.project.activeSequence;
+  if (!seq) return { ok: false, error: "No active sequence", notes: [] };
+
+  var notes = [];
+  var savedPos = null;
+  try { savedPos = seq.getPlayerPosition().ticks; } catch (e) {}
+
+  if (ticks) {
+    try { seq.setPlayerPosition(String(ticks)); } catch (e) { notes.push("setPlayerPosition: " + e.toString()); }
+  }
+  var atTicks = ticks;
+  if (!atTicks) {
+    try { atTicks = seq.getPlayerPosition().ticks; } catch (e) { atTicks = "0"; }
+  }
+
+  // Clear any stale file so that a file existing afterwards proves we wrote it.
+  var stale = new File(outputPath);
+  if (stale.exists) { try { stale.remove(); } catch (e) {} }
+
+  var wantJpeg = /\\.jpe?g$/i.test(outputPath);
+
+  // --- Path 1: QE DOM. Signature is (path, width, height) with string args. ---
+  try {
+    app.enableQE();
+    var qeSeq = qe.project.getActiveSequence();
+    if (!qeSeq) {
+      notes.push("QE: no active sequence");
+    } else {
+      var fn = wantJpeg ? qeSeq.exportFrameJPEG : qeSeq.exportFramePNG;
+      if (typeof fn !== "function") {
+        notes.push("QE: exportFrame" + (wantJpeg ? "JPEG" : "PNG") + " unavailable on this build");
+      } else {
+        var w = String(seq.frameSizeHorizontal);
+        var h = String(seq.frameSizeVertical);
+        try {
+          notes.push("QE returned " + fn.call(qeSeq, outputPath, w, h));
+        } catch (eArgs) {
+          try { notes.push("QE returned " + fn.call(qeSeq, outputPath, w)); }
+          catch (eArgs2) { notes.push("QE: " + eArgs2.toString()); }
+        }
+      }
+    }
+  } catch (eQE) {
+    notes.push("QE: " + eQE.toString());
+  }
+
+  var written = __firstWrittenFile(outputPath);
+  if (written) {
+    if (savedPos) { try { seq.setPlayerPosition(savedPos); } catch (e) {} }
+    return { ok: true, method: "qe", path: written, notes: notes };
+  }
+  notes.push("QE wrote no file; falling back to Media Encoder");
+
+  // --- Path 2: one-frame export through Media Encoder. ---
+  try {
+    var preset = __findStillPreset(outputPath);
+    if (!preset) {
+      notes.push("AME: no " + (wantJpeg ? "JPEG" : "PNG") + " still preset found on disk");
+    } else {
+      var savedIn = null, savedOut = null;
+      try {
+        savedIn = seq.getInPointAsTime().ticks;
+        savedOut = seq.getOutPointAsTime().ticks;
+      } catch (e) {}
+
+      // seq.timebase is ticks-per-frame, so in..in+timebase is exactly one frame.
+      var frameTicks = parseFloat(seq.timebase);
+      var startTicks = parseFloat(atTicks);
+      seq.setInPoint(String(startTicks));
+      seq.setOutPoint(String(startTicks + frameTicks));
+
+      try {
+        seq.exportAsMediaDirect(outputPath, preset, app.encoder.ENCODE_IN_TO_OUT);
+        notes.push("AME preset: " + preset);
+      } finally {
+        try {
+          if (savedIn !== null) seq.setInPoint(savedIn);
+          if (savedOut !== null) seq.setOutPoint(savedOut);
+        } catch (e) {}
+      }
+    }
+  } catch (eAME) {
+    notes.push("AME: " + eAME.toString());
+  }
+
+  if (savedPos) { try { seq.setPlayerPosition(savedPos); } catch (e) {} }
+
+  written = __firstWrittenFile(outputPath);
+  if (written) return { ok: true, method: "ame", path: written, notes: notes };
+
+  return {
+    ok: false,
+    error: "Frame export produced no file on disk. Neither the QE DOM nor Media Encoder wrote " + outputPath,
+    notes: notes
+  };
+}
+
 function __jsonStringify(obj) {
   // ES3-compatible JSON stringify
   if (typeof JSON !== "undefined" && JSON.stringify) {

--- a/src/tools/effects.ts
+++ b/src/tools/effects.ts
@@ -222,6 +222,38 @@ export function getEffectsTools(bridgeOptions: BridgeOptions) {
         tint?: number;
         saturation?: number;
       }) => {
+        // Lumetri repeats display names across sub-sections (Basic Correction, Creative,
+        // HSL Secondary, ...) and not every match is writable, so each setValue is
+        // guarded and the first writable match per control wins.
+        const controls: Array<{ key: string; label: string; value: number }> = (
+          [
+            { key: "exposure", label: "Exposure", value: args.exposure },
+            { key: "contrast", label: "Contrast", value: args.contrast },
+            { key: "highlights", label: "Highlights", value: args.highlights },
+            { key: "shadows", label: "Shadows", value: args.shadows },
+            { key: "whites", label: "Whites", value: args.whites },
+            { key: "blacks", label: "Blacks", value: args.blacks },
+            { key: "temperature", label: "Temperature", value: args.temperature },
+            { key: "tint", label: "Tint", value: args.tint },
+            { key: "saturation", label: "Saturation", value: args.saturation },
+          ] as Array<{ key: string; label: string; value: number | undefined }>
+        ).filter((c): c is { key: string; label: string; value: number } => c.value !== undefined);
+
+        const setters = controls
+          .map(
+            (c) => `
+              if (!taken.${c.key} && name === "${c.label}") {
+                try {
+                  prop.setValue(${c.value}, true);
+                  taken.${c.key} = true;
+                  changes.${c.key} = ${c.value};
+                } catch(e) {
+                  errors.${c.key} = e.toString();
+                }
+              }`
+          )
+          .join("");
+
         // First apply Lumetri Color effect, then set its properties
         const script = buildToolScript(`
           app.enableQE();
@@ -253,31 +285,23 @@ export function getEffectsTools(bridgeOptions: BridgeOptions) {
             }
           }
           
-          // Set Lumetri properties. Wrap each setValue in try/catch so a single
-          // unsettable property (Lumetri repeats some display names across
-          // sub-sections; not all are writable) does NOT abort the whole script
-          // with "Invalid parameter" and lose every change.
+          // A single unsettable property must not abort the script with "Invalid
+          // parameter" and lose every other change, so each write is guarded.
+          // The taken map is a separate set of flags rather than a truthiness check on
+          // changes: 0 is a legitimate value (saturation 0 is a valid full desaturate),
+          // and a falsy check would re-fire it on every later sub-section that repeats
+          // the same display name.
           var changes = {};
           var errors = {};
-          var trySet = function(name, key, val, taken) {
-            if (taken[key]) return; // first match per logical control wins
-            try { /* lookup target prop has displayName === name */ } catch(e){}
-          };
+          var taken = {};
+
           for (var i = 0; i < clip.components.numItems; i++) {
             var comp = clip.components[i];
             if (comp.displayName !== "Lumetri Color") continue;
             for (var p = 0; p < comp.properties.numItems; p++) {
               var prop = comp.properties[p];
               var name = prop.displayName;
-              ${args.exposure !== undefined ? `if (!changes.exposure && name === "Exposure") { try { prop.setValue(${args.exposure}, true); changes.exposure = ${args.exposure}; } catch(e) { errors.exposure = e.toString(); } }` : ""}
-              ${args.contrast !== undefined ? `if (!changes.contrast && name === "Contrast") { try { prop.setValue(${args.contrast}, true); changes.contrast = ${args.contrast}; } catch(e) { errors.contrast = e.toString(); } }` : ""}
-              ${args.highlights !== undefined ? `if (!changes.highlights && name === "Highlights") { try { prop.setValue(${args.highlights}, true); changes.highlights = ${args.highlights}; } catch(e) { errors.highlights = e.toString(); } }` : ""}
-              ${args.shadows !== undefined ? `if (!changes.shadows && name === "Shadows") { try { prop.setValue(${args.shadows}, true); changes.shadows = ${args.shadows}; } catch(e) { errors.shadows = e.toString(); } }` : ""}
-              ${args.whites !== undefined ? `if (!changes.whites && name === "Whites") { try { prop.setValue(${args.whites}, true); changes.whites = ${args.whites}; } catch(e) { errors.whites = e.toString(); } }` : ""}
-              ${args.blacks !== undefined ? `if (!changes.blacks && name === "Blacks") { try { prop.setValue(${args.blacks}, true); changes.blacks = ${args.blacks}; } catch(e) { errors.blacks = e.toString(); } }` : ""}
-              ${args.temperature !== undefined ? `if (!changes.temperature && name === "Temperature") { try { prop.setValue(${args.temperature}, true); changes.temperature = ${args.temperature}; } catch(e) { errors.temperature = e.toString(); } }` : ""}
-              ${args.tint !== undefined ? `if (!changes.tint && name === "Tint") { try { prop.setValue(${args.tint}, true); changes.tint = ${args.tint}; } catch(e) { errors.tint = e.toString(); } }` : ""}
-              ${args.saturation !== undefined ? `if (!changes.saturation && name === "Saturation") { try { prop.setValue(${args.saturation}, true); changes.saturation = ${args.saturation}; } catch(e) { errors.saturation = e.toString(); } }` : ""}
+              ${setters}
             }
             break;
           }

--- a/src/tools/export.ts
+++ b/src/tools/export.ts
@@ -35,36 +35,7 @@ export function getExportTools(bridgeOptions: BridgeOptions) {
           
           ${args.preset_path
             ? `var presetPath = "${escapeForExtendScript(args.preset_path)}";`
-            : `// Cross-platform default: locate an H.264 "Match Source" preset
-               // by walking the AME systempresets tree. Falls back to first .epr
-               // found in the H.264 dir (4E49434B_48323634 = "NICK_H264").
-               var presetPath = "";
-               var roots = [];
-               if ($.os && $.os.toLowerCase().indexOf("mac") !== -1) {
-                 roots.push("/Applications/Adobe Media Encoder 2026/MediaIO/systempresets");
-                 roots.push("/Applications/Adobe Media Encoder 2025/MediaIO/systempresets");
-                 roots.push("/Applications/Adobe Media Encoder 2024/MediaIO/systempresets");
-               } else {
-                 roots.push("C:\\\\Program Files\\\\Adobe\\\\Adobe Media Encoder 2026\\\\MediaIO\\\\systempresets");
-                 roots.push("C:\\\\Program Files\\\\Adobe\\\\Adobe Media Encoder 2025\\\\MediaIO\\\\systempresets");
-                 roots.push("C:\\\\Program Files\\\\Adobe\\\\Adobe Media Encoder 2024\\\\MediaIO\\\\systempresets");
-               }
-               for (var r = 0; r < roots.length && !presetPath; r++) {
-                 var rootFolder = new Folder(roots[r]);
-                 if (!rootFolder.exists) continue;
-                 var subs = rootFolder.getFiles(function(f){ return f instanceof Folder; });
-                 for (var s = 0; s < subs.length && !presetPath; s++) {
-                   if (subs[s].name.indexOf("48323634") === -1 && subs[s].name.toLowerCase().indexOf("h264") === -1) continue;
-                   var eprs = subs[s].getFiles("*.epr");
-                   var matchFile = null;
-                   for (var k = 0; k < eprs.length; k++) {
-                     var nm = eprs[k].displayName || eprs[k].name;
-                     if (nm.toLowerCase().indexOf("match source - high") !== -1) { matchFile = eprs[k]; break; }
-                   }
-                   if (!matchFile && eprs.length) matchFile = eprs[0];
-                   if (matchFile) presetPath = matchFile.fsName;
-                 }
-               }
+            : `var presetPath = __findH264Preset();
                if (!presetPath) return __error("Could not locate a default H.264 preset. Pass preset_path explicitly.");`
           }
 

--- a/src/tools/export.ts
+++ b/src/tools/export.ts
@@ -98,20 +98,17 @@ export function getExportTools(bridgeOptions: BridgeOptions) {
       },
       handler: async (args: { output_path: string; time_seconds?: number }) => {
         const script = buildToolScript(`
-          var seq = app.project.activeSequence;
-          if (!seq) return __error("No active sequence");
-          
-          ${args.time_seconds !== undefined
-            ? `seq.setPlayerPosition(__secondsToTicks(${args.time_seconds}).toString());`
-            : ""
-          }
-          
           var outputPath = "${escapeForExtendScript(args.output_path)}";
-          seq.exportFramePNG(seq.getPlayerPosition().ticks, outputPath);
-          
-          return __result({ exported: true, outputPath: outputPath });
+          var ticks = ${args.time_seconds !== undefined
+            ? `__secondsToTicks(${args.time_seconds}).toString()`
+            : "null"};
+
+          var res = __exportStillFrame(outputPath, ticks);
+          if (!res.ok) return __error(res.error + " [" + res.notes.join("; ") + "]");
+
+          return __result({ exported: true, outputPath: res.path, method: res.method });
         `);
-        return sendCommand(script, bridgeOptions);
+        return sendCommand(script, { ...bridgeOptions, timeoutMs: 60000 });
       },
     },
 
@@ -319,40 +316,32 @@ export function getExportTools(bridgeOptions: BridgeOptions) {
         const escapedPath = escapeForExtendScript(tempPath);
 
         const script = buildToolScript(`
-          var seq = app.project.activeSequence;
-          if (!seq) return __error("No active sequence");
-          
-          ${args.time_seconds !== undefined
-            ? `seq.setPlayerPosition(__secondsToTicks(${args.time_seconds}).toString());`
-            : ""
-          }
-          
           var outputPath = "${escapedPath}";
-          seq.exportFramePNG(seq.getPlayerPosition().ticks, outputPath);
-          
-          return __result({ exported: true, outputPath: outputPath });
+          var ticks = ${args.time_seconds !== undefined
+            ? `__secondsToTicks(${args.time_seconds}).toString()`
+            : "null"};
+
+          var res = __exportStillFrame(outputPath, ticks);
+          if (!res.ok) return __error(res.error + " [" + res.notes.join("; ") + "]");
+
+          return __result({ exported: true, outputPath: res.path, method: res.method });
         `);
 
-        const result = await sendCommand(script, bridgeOptions);
+        const result = await sendCommand(script, { ...bridgeOptions, timeoutMs: 60000 });
         if (!result.success) return result;
 
-        // Read the exported PNG and return as base64 image content
-        // Wait a moment for the file to be written
-        let attempts = 0;
-        while (!existsSync(tempPath) && attempts < 20) {
-          await new Promise(r => setTimeout(r, 100));
-          attempts++;
-        }
+        // __exportStillFrame already proved the file exists, but it may have landed at a
+        // path other than the one we asked for (Media Encoder appends a frame number to
+        // still exports), so read back the path it reports rather than the one we chose.
+        const framePath = (result.data as { outputPath?: string } | undefined)?.outputPath ?? tempPath;
 
-        if (!existsSync(tempPath)) {
-          return { success: false, error: "Frame export completed but file not found at: " + tempPath };
+        if (!existsSync(framePath)) {
+          return { success: false, error: "Frame export reported success but no file exists at: " + framePath };
         }
 
         try {
-          const imageData = readFileSync(tempPath);
-          const base64 = imageData.toString("base64");
-          // Clean up temp file
-          try { unlinkSync(tempPath); } catch {}
+          const base64 = readFileSync(framePath).toString("base64");
+          try { unlinkSync(framePath); } catch {}
           return {
             success: true,
             data: {
@@ -562,7 +551,12 @@ export function getExportTools(bridgeOptions: BridgeOptions) {
     },
 
     manage_proxies: {
-      description: "Create or attach proxies for a project item",
+      description:
+        "Create, attach, or toggle proxies for a project item. " +
+        "Note: 'create' queues a proxy encode in Adobe Media Encoder and returns immediately — " +
+        "AME renders in the background. Once it finishes, call this tool again with action 'attach' " +
+        "and proxy_path set to the output_path you passed here. There is no single-call create-and-attach " +
+        "in Premiere's ExtendScript API.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -577,32 +571,76 @@ export function getExportTools(bridgeOptions: BridgeOptions) {
           },
           proxy_path: {
             type: "string",
-            description: "Path to proxy file (required for 'attach' action)",
+            description: "Path to an existing proxy file (required for 'attach')",
+          },
+          output_path: {
+            type: "string",
+            description: "Full output path for the proxy to be rendered to (required for 'create')",
+          },
+          preset_path: {
+            type: "string",
+            description:
+              "Path to a proxy ingest preset (.epr) for 'create'. " +
+              "If omitted, the first preset found in Premiere's IngestPresets/Proxy folder is used.",
           },
         },
         required: ["item_id", "action"],
       },
-      handler: async (args: { item_id: string; action: string; proxy_path?: string }) => {
+      handler: async (args: {
+        item_id: string;
+        action: string;
+        proxy_path?: string;
+        output_path?: string;
+        preset_path?: string;
+      }) => {
         const script = buildToolScript(`
           var item = __findProjectItem("${escapeForExtendScript(args.item_id)}");
           if (!item) return __error("Item not found");
-          
+
           var action = "${args.action}";
-          
+
           if (action === "create") {
-            item.createProxy("", 0);
-            return __result({ action: "create", item: item.name, status: "Proxy creation started" });
+            ${!args.output_path
+              ? `return __error("output_path is required for the 'create' action");`
+              : `var outputPath = "${escapeForExtendScript(args.output_path)}";
+                 ${args.preset_path
+                   ? `var presetPath = "${escapeForExtendScript(args.preset_path)}";`
+                   : `var presetPath = __findProxyPreset();
+                      if (!presetPath) {
+                        return __error("Could not locate a proxy ingest preset. Pass preset_path explicitly (an .epr under Premiere's Settings/IngestPresets/Proxy folder).");
+                      }`}
+
+                 // ProjectItem has no createProxy(). Proxy generation must go through
+                 // Adobe Media Encoder; the result is attached in a separate step once
+                 // AME has finished writing the file.
+                 app.encoder.launchEncoder();
+                 app.encoder.encodeProjectItem(item, outputPath, presetPath, app.encoder.ENCODE_ENTIRE, 1);
+                 app.encoder.startBatch();
+
+                 return __result({
+                   action: "create",
+                   item: item.name,
+                   queued: true,
+                   outputPath: outputPath,
+                   presetUsed: presetPath,
+                   nextStep: "Wait for Adobe Media Encoder to finish, then call manage_proxies with action 'attach' and proxy_path set to outputPath."
+                 });`
+            }
           } else if (action === "attach") {
             ${args.proxy_path
-              ? `item.attachProxy("${escapeForExtendScript(args.proxy_path)}", 0);
-                 return __result({ action: "attach", item: item.name, proxyPath: "${escapeForExtendScript(args.proxy_path)}" });`
+              ? `var attachPath = "${escapeForExtendScript(args.proxy_path)}";
+                 if (!new File(attachPath).exists) return __error("Proxy file does not exist: " + attachPath);
+                 var attached = item.attachProxy(attachPath, 0);
+                 if (!attached) return __error("attachProxy() failed for: " + attachPath);
+                 return __result({ action: "attach", item: item.name, proxyPath: attachPath, attached: true });`
               : `return __error("proxy_path is required for attach action");`
             }
           } else if (action === "toggle") {
-            app.project.setProxyEnabled(!app.project.isProxyEnabled());
-            return __result({ action: "toggle", proxiesEnabled: !app.project.isProxyEnabled() });
+            var enabled = !app.project.isProxyEnabled();
+            app.project.setProxyEnabled(enabled);
+            return __result({ action: "toggle", proxiesEnabled: enabled });
           }
-          
+
           return __error("Unknown proxy action: " + action);
         `);
         return sendCommand(script, bridgeOptions);

--- a/src/tools/markers.ts
+++ b/src/tools/markers.ts
@@ -54,13 +54,13 @@ export function getMarkerTools(bridgeOptions: BridgeOptions) {
         const script = buildToolScript(`
           ${markerTarget}
           
-          var timeTicks = __secondsToTicks(${args.time_seconds}).toString();
-          var marker = markers.createMarker(parseFloat(timeTicks));
-          
+          // createMarker() and the marker.end setter both take seconds, not ticks.
+          var marker = markers.createMarker(${args.time_seconds});
+
           ${args.name ? `marker.name = "${escapeForExtendScript(args.name)}";` : ""}
           ${args.comments ? `marker.comments = "${escapeForExtendScript(args.comments)}";` : ""}
           ${args.color !== undefined ? `marker.setColorByIndex(${args.color});` : ""}
-          ${args.duration_seconds ? `marker.end = __secondsToTicks(${args.time_seconds + args.duration_seconds}).toString();` : ""}
+          ${args.duration_seconds ? `marker.end = ${args.time_seconds + args.duration_seconds};` : ""}
           
           return __result({
             added: true,
@@ -194,8 +194,8 @@ export function getMarkerTools(bridgeOptions: BridgeOptions) {
             list.push({
               name: marker.name,
               comments: marker.comments,
-              startSeconds: __ticksToSeconds(marker.start.ticks),
-              endSeconds: __ticksToSeconds(marker.end.ticks),
+              startSeconds: marker.start.seconds,
+              endSeconds: marker.end.seconds,
               type: marker.type
             });
             marker = markers.getNextMarker(marker);

--- a/src/tools/track-targeting.ts
+++ b/src/tools/track-targeting.ts
@@ -931,42 +931,40 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
     },
 
     get_encoder_presets: {
-      description: "List available Adobe Media Encoder export presets for a given format.",
+      description:
+        "List available Adobe Media Encoder export presets, with the .epr path of each so it can be " +
+        "passed to export_sequence or encode_project_item. Presets are discovered by scanning the .epr " +
+        "files Adobe ships on disk (Premiere's ExtendScript API exposes no preset enumeration).",
       parameters: {
         type: "object" as const,
         properties: {
           format: {
             type: "string",
-            description: "Format name to list presets for (e.g., 'H.264', 'QuickTime', 'MPEG2'). Leave empty to list formats.",
+            description:
+              "Filter to presets whose name or format bucket matches this (e.g. 'H.264', 'ProRes', 'Proxy'). Omit to list all.",
           },
         },
       },
       handler: async (args: { format?: string }) => {
         const script = buildToolScript(`
-          var encoder = app.encoder;
-          if (!encoder) return __error("Encoder not available");
-
-          try {
-            var formats = encoder.getFormatList();
-            if (!formats) return __error("Could not get format list");
-
-            var result = [];
-            for (var f = 0; f < formats.length; f++) {
-              var formatName = formats[f];
-              ${args.format ? `if (formatName.toLowerCase().indexOf("${escapeForExtendScript(args.format)}".toLowerCase()) === -1) continue;` : ""}
-              var presets = encoder.getPresetList(formatName);
-              var presetNames = [];
-              if (presets) {
-                for (var p = 0; p < presets.length; p++) {
-                  presetNames.push(presets[p]);
-                }
-              }
-              result.push({ format: formatName, presets: presetNames });
-            }
-            return __result(result);
-          } catch(e) {
-            return __error("Encoder preset listing failed: " + e.message);
+          var presets = __collectAllPresets();
+          if (!presets.length) {
+            return __error("No .epr presets found. Is Adobe Media Encoder installed alongside Premiere Pro?");
           }
+
+          ${args.format
+            ? `var needle = "${escapeForExtendScript(args.format)}".toLowerCase();
+               var filtered = [];
+               for (var i = 0; i < presets.length; i++) {
+                 var p = presets[i];
+                 if (p.name.toLowerCase().indexOf(needle) !== -1 || p.format.toLowerCase().indexOf(needle) !== -1) {
+                   filtered.push(p);
+                 }
+               }
+               presets = filtered;`
+            : ""}
+
+          return __result({ count: presets.length, presets: presets });
         `);
         return sendCommand(script, bridgeOptions);
       },

--- a/src/tools/utility.ts
+++ b/src/tools/utility.ts
@@ -190,15 +190,16 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
             ? `var timeTicks = __secondsToTicks(${args.time_seconds}).toString();`
             : `var timeTicks = seq.getPlayerPosition().ticks;`}
 
-          // Export frame
-          seq.exportFramePNG(timeTicks, "${escapeForExtendScript(args.output_path)}");
+          var res = __exportStillFrame("${escapeForExtendScript(args.output_path)}", timeTicks);
+          if (!res.ok) return __error(res.error + " [" + res.notes.join("; ") + "]");
 
           // Import back
-          app.project.importFiles(["${escapeForExtendScript(args.output_path)}"], false, app.project.rootItem, false);
+          app.project.importFiles([res.path], false, app.project.rootItem, false);
 
           return __result({
             exported: true,
-            path: "${escapeForExtendScript(args.output_path)}",
+            path: res.path,
+            method: res.method,
             atSeconds: __ticksToSeconds(timeTicks),
             note: "Frame exported and imported. Add to timeline with add_to_timeline."
           });

--- a/tests/tools/regressions.test.ts
+++ b/tests/tools/regressions.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { BridgeOptions } from "../../src/bridge/file-bridge.js";
+
+vi.mock("../../src/bridge/file-bridge.js", () => ({
+  sendCommand: vi.fn().mockResolvedValue({ success: true, data: {} }),
+  sendRawCommand: vi.fn().mockResolvedValue({ success: true, data: {} }),
+  getTempDir: vi.fn().mockReturnValue("/tmp/test"),
+  cleanupTempDir: vi.fn(),
+}));
+
+import { sendCommand } from "../../src/bridge/file-bridge.js";
+import { getMarkerTools } from "../../src/tools/markers.js";
+import { getExportTools } from "../../src/tools/export.js";
+import { getUtilityTools } from "../../src/tools/utility.js";
+import { getTrackTargetingTools } from "../../src/tools/track-targeting.js";
+
+const mockedSendCommand = vi.mocked(sendCommand);
+const bridgeOptions: BridgeOptions = { tempDir: "/tmp/test-bridge", timeoutMs: 5000 };
+
+/** Run a tool handler and return the ExtendScript it generated. */
+async function scriptFor(tool: { handler: (args: never) => Promise<unknown> }, args: unknown) {
+  mockedSendCommand.mockClear();
+  await tool.handler(args as never);
+  expect(mockedSendCommand).toHaveBeenCalled();
+  return mockedSendCommand.mock.calls[0][0] as string;
+}
+
+/**
+ * Same, with comments removed. The helpers name the broken APIs in prose to explain
+ * why they're avoided ("ProjectItem has no createProxy()"), so an assertion that a
+ * method is never *called* has to look at code only.
+ */
+async function codeFor(tool: { handler: (args: never) => Promise<unknown> }, args: unknown) {
+  const script = await scriptFor(tool, args);
+  return script.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^[ \t]*\/\/.*$/gm, "");
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+// https://github.com/leancoderkavy/premiere-pro-mcp/issues/6
+describe("issue #6 — markers must use seconds, not ticks", () => {
+  const markers = getMarkerTools(bridgeOptions);
+
+  it("add_marker passes seconds straight to createMarker", async () => {
+    const script = await scriptFor(markers.add_marker, { time_seconds: 2.0 });
+
+    expect(script).toContain("createMarker(2)");
+    // The old bug: __secondsToTicks(2) -> 508032000000 handed to createMarker(),
+    // placing the marker ~508 billion seconds down the timeline.
+    expect(script).not.toContain("__secondsToTicks(2).toString()");
+    expect(script).not.toMatch(/createMarker\(parseFloat/);
+  });
+
+  it("add_marker sets marker.end in seconds when given a duration", async () => {
+    const script = await scriptFor(markers.add_marker, { time_seconds: 2.0, duration_seconds: 3.0 });
+
+    expect(script).toContain("marker.end = 5");
+    expect(script).not.toMatch(/marker\.end = __secondsToTicks/);
+  });
+
+  it("list_markers reads Time.seconds rather than re-converting ticks", async () => {
+    const script = await scriptFor(markers.list_markers, {});
+
+    expect(script).toContain("startSeconds: marker.start.seconds");
+    expect(script).toContain("endSeconds: marker.end.seconds");
+    expect(script).not.toContain("__ticksToSeconds(marker.start.ticks)");
+  });
+
+  it("delete_marker still compares ticks against ticks", async () => {
+    // This path was always correct — both sides are ticks. Guard it so the #6
+    // fix doesn't get over-applied here.
+    const script = await scriptFor(markers.delete_marker, { time_seconds: 2.0 });
+
+    expect(script).toContain("__secondsToTicks(2)");
+    expect(script).toContain("marker.start.ticks");
+  });
+});
+
+// https://github.com/leancoderkavy/premiere-pro-mcp/issues/7
+describe("issue #7 — no calls to nonexistent ExtendScript methods", () => {
+  const exportTools = getExportTools(bridgeOptions);
+  const trackTargeting = getTrackTargetingTools(bridgeOptions);
+
+  it("manage_proxies never calls ProjectItem.createProxy()", async () => {
+    const code = await codeFor(exportTools.manage_proxies, {
+      item_id: "clip1",
+      action: "create",
+      output_path: "/tmp/proxy.mov",
+    });
+
+    // ProjectItem has no createProxy(); proxies must go through Media Encoder.
+    expect(code).not.toContain("createProxy");
+    expect(code).toContain("encodeProjectItem");
+  });
+
+  it("manage_proxies 'create' refuses to report false success without an output path", async () => {
+    const script = await scriptFor(exportTools.manage_proxies, { item_id: "clip1", action: "create" });
+
+    expect(script).toContain("output_path is required");
+    expect(script).not.toContain("Proxy creation started");
+  });
+
+  it("manage_proxies 'toggle' reports the state it actually set", async () => {
+    const script = await scriptFor(exportTools.manage_proxies, { item_id: "clip1", action: "toggle" });
+
+    // The old code reported !isProxyEnabled() *after* flipping it — i.e. the inverse
+    // of the truth, every single time.
+    expect(script).toContain("proxiesEnabled: enabled");
+    expect(script).not.toContain("proxiesEnabled: !app.project.isProxyEnabled()");
+  });
+
+  it("get_encoder_presets never calls encoder.getFormatList()", async () => {
+    const code = await codeFor(trackTargeting.get_encoder_presets, { format: "H.264" });
+
+    // EncoderManager has no getFormatList(); presets are found by scanning .epr files.
+    expect(code).not.toContain("getFormatList");
+    expect(code).toContain("__collectAllPresets()");
+  });
+});
+
+// https://github.com/leancoderkavy/premiere-pro-mcp/issues/9
+describe("issue #9 — frame export uses the QE DOM and verifies the file landed", () => {
+  const exportTools = getExportTools(bridgeOptions);
+  const utility = getUtilityTools(bridgeOptions);
+
+  const frameTools: Array<[string, { handler: (args: never) => Promise<unknown> }, unknown]> = [
+    ["export_frame", exportTools.export_frame, { output_path: "/tmp/f.png" }],
+    ["capture_frame", exportTools.capture_frame, {}],
+    ["freeze_frame", utility.freeze_frame, { output_path: "/tmp/f.png" }],
+  ];
+
+  for (const [name, tool, args] of frameTools) {
+    it(`${name} does not call exportFramePNG on the public DOM sequence`, async () => {
+      const script = await scriptFor(tool, args);
+
+      // exportFramePNG exists only on the QE sequence. Calling it on
+      // app.project.activeSequence throws "seq.exportFramePNG is not a function".
+      expect(script).not.toMatch(/seq\.exportFramePNG/);
+      expect(script).toContain("__exportStillFrame(");
+    });
+
+    it(`${name} surfaces an error instead of claiming success when no file is written`, async () => {
+      const script = await scriptFor(tool, args);
+
+      expect(script).toContain("if (!res.ok) return __error(");
+    });
+  }
+});
+
+describe("script-builder helpers used by the fixes are actually defined", () => {
+  const exportTools = getExportTools(bridgeOptions);
+
+  it("prepends every helper the generated scripts call", async () => {
+    const script = await scriptFor(exportTools.export_frame, { output_path: "/tmp/f.png" });
+
+    for (const helper of [
+      "function __exportStillFrame(",
+      "function __firstWrittenFile(",
+      "function __findStillPreset(",
+      "function __collectAllPresets(",
+      "function __findProxyPreset(",
+      "function __adobeAppFolders(",
+      "function __collectEprFiles(",
+    ]) {
+      expect(script).toContain(helper);
+    }
+  });
+});

--- a/tests/tools/regressions.test.ts
+++ b/tests/tools/regressions.test.ts
@@ -13,6 +13,7 @@ import { getMarkerTools } from "../../src/tools/markers.js";
 import { getExportTools } from "../../src/tools/export.js";
 import { getUtilityTools } from "../../src/tools/utility.js";
 import { getTrackTargetingTools } from "../../src/tools/track-targeting.js";
+import { getEffectsTools } from "../../src/tools/effects.js";
 
 const mockedSendCommand = vi.mocked(sendCommand);
 const bridgeOptions: BridgeOptions = { tempDir: "/tmp/test-bridge", timeoutMs: 5000 };
@@ -147,6 +148,44 @@ describe("issue #9 — frame export uses the QE DOM and verifies the file landed
   }
 });
 
+// Defects found while reviewing PR #3 (repair 6 broken tools on Premiere Pro 2026).
+describe("PR #3 follow-ups — color_correct and export_sequence", () => {
+  const effects = getEffectsTools(bridgeOptions);
+  const exportTools = getExportTools(bridgeOptions);
+
+  it("color_correct applies a value of 0 exactly once", async () => {
+    const code = await codeFor(effects.color_correct, { node_id: "clip1", saturation: 0 });
+
+    // saturation: 0 is a valid full desaturate. Guarding on `!changes.saturation`
+    // leaves the guard permanently open for 0, re-firing setValue on every later
+    // Lumetri sub-section that repeats the "Saturation" display name.
+    expect(code).toContain("!taken.saturation");
+    expect(code).toContain("taken.saturation = true");
+    expect(code).not.toContain("!changes.saturation");
+  });
+
+  it("color_correct carries no dead helper", async () => {
+    const code = await codeFor(effects.color_correct, { node_id: "clip1", exposure: 1 });
+    expect(code).not.toContain("trySet");
+  });
+
+  it("color_correct only emits setters for the controls it was given", async () => {
+    const code = await codeFor(effects.color_correct, { node_id: "clip1", exposure: 1.5 });
+
+    expect(code).toContain('name === "Exposure"');
+    expect(code).not.toContain('name === "Saturation"');
+  });
+
+  it("export_sequence finds its default preset without hardcoding a version year", async () => {
+    const code = await codeFor(exportTools.export_sequence, { output_path: "/tmp/out.mp4" });
+
+    expect(code).toContain("__findH264Preset()");
+    // Hardcoded install paths rot the moment Adobe ships the next version.
+    expect(code).not.toContain("Adobe Media Encoder 2025");
+    expect(code).not.toContain("Adobe Media Encoder 2026");
+  });
+});
+
 describe("script-builder helpers used by the fixes are actually defined", () => {
   const exportTools = getExportTools(bridgeOptions);
 
@@ -159,6 +198,7 @@ describe("script-builder helpers used by the fixes are actually defined", () => 
       "function __findStillPreset(",
       "function __collectAllPresets(",
       "function __findProxyPreset(",
+      "function __findH264Preset(",
       "function __adobeAppFolders(",
       "function __collectEprFiles(",
     ]) {


### PR DESCRIPTION
Closes #2, closes #5, closes #6, closes #7, closes #8, closes #9.

## The important part

The CEP 12 bridge fix from #1 has been sitting on `main` since March but was **never published to npm**. Everyone installing with `npm install -g premiere-pro-mcp` still got the pre-fix `CSInterface.js`, so every tool call returned `{"success":true,"data":null}`. That's #2, #5, and #8 — one bug, reported three times, already fixed, just never shipped.

This bumps to **1.1.2**. I verified the tarball rather than assuming: `npm pack` now contains the `CSInterface.js` that forwards the `evalScript` callback, and a manifest with `--enable-nodejs`.

## Bugs fixed on top

**#6 — markers placed at wildly wrong times.** `createMarker()` takes seconds; it was handed ticks, so a marker at 2.0s landed ~508 billion seconds down the timeline. `marker.end` had the same bug.

One correction to the issue: the absurd `list_markers` readings weren't an independent conversion bug. They were *downstream* of the first bug — the marker really was at an insane position, so its tick value saturated near int64 max (`36310201 × 254016000000 ≈ 2^63`). Switching to `Time.seconds` is still the right call, and `delete_marker`/`update_marker` were left alone because they compare ticks to ticks and were always correct.

**#7 — two tools called methods that don't exist.** `ProjectItem` has no `createProxy()`; `EncoderManager` has no `getFormatList()`. `manage_proxies` "create" now queues a real proxy encode through Media Encoder (and says so) instead of reporting `"Proxy creation started"` for work that never happened. `get_encoder_presets` now finds presets by scanning the `.epr` files on disk and returns each one's path, so the result can be fed straight into `export_sequence`.

Also found while in there: `manage_proxies` with `action: "toggle"` reported `!isProxyEnabled()` *after* flipping it — the inverse of the truth, every time.

**#9 — `capture_frame` / `export_frame` / `freeze_frame`.** `exportFramePNG` exists only on the QE DOM sequence, not the public one, so every call threw. Now routed through QE with the right signature.

The second half of that issue is the more important one: @victorhendersonf-del found that even on the correct QE object the call returns `false` and writes nothing. So success is no longer inferred from the return value at all — these tools now check that a file **actually exists on disk**, with a one-frame Media Encoder export as a fallback, and return an error with diagnostics otherwise. They can no longer report success having written nothing.

## PR #3 follow-ups

Merged #3 (thanks @surftheglitch — six real tools repaired, live-tested on 2026), then fixed two defects in it:

- `color_correct` carried a dead `trySet` helper that was declared, never called, and had an empty body.
- Its "first writable match wins" guard tested `!changes.<control>`, which stays true when the value is `0`. `saturation: 0` is a valid full desaturate, so the guard never closed and `setValue` re-fired across every Lumetri sub-section repeating that display name.
- `export_sequence`'s new preset lookup hardcoded Media Encoder 2024/2025/2026 paths, which rot the moment Adobe ships 2027. Reused the version-agnostic `.epr` scanner added for #7.

## Also

Removed a `> **Note:** This is a temporary fork for a bug fix PR.` banner from the top of the README. It was @bdenney99's fork notice and rode in with the #1 merge, so the canonical repo had been describing itself as a temporary fork of itself, linking to itself.

## Testing

`tsc` clean. **307 tests pass** (288 + 19 new). New `tests/tools/regressions.test.ts` pins each bug above so they can't come back.

⚠️ **Not live-verified**: I don't have Premiere running, so the frame-export and proxy-create paths are fixed against the documented API and covered by tests, but not yet exercised against a real host. @victorhendersonf-del and @rishabhk571 both offered to test — that'd be very welcome before anyone leans on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)