### PR TITLE
Harden CEP panel Node loading; stop reporting empty evalScript results as OK

### DIFF
--- a/cep-plugin/main.js
+++ b/cep-plugin/main.js
@@ -30,9 +30,24 @@ function setStatus(state, text) {
 }
 
 // ---- File I/O via Node.js (CEP has access to Node) ----
-var fs = require("fs");
-var path = require("path");
-var os = require("os");
+// --enable-nodejs puts `require` in the global scope on most hosts, but on some it
+// lands on cep_node instead. Try both, and fail loudly rather than letting fs come
+// back undefined and surface later as "Cannot read properties of undefined".
+function nodeRequire(moduleName) {
+  if (typeof require !== "undefined") return require(moduleName);
+
+  var cepNode = typeof cep_node !== "undefined" ? cep_node : typeof window !== "undefined" ? window.cep_node : null;
+  if (cepNode && typeof cepNode.require === "function") return cepNode.require(moduleName);
+
+  throw new Error(
+    'Node.js is not available in this CEP panel, so "' + moduleName + '" could not be loaded. ' +
+      "Check that CSXS/manifest.xml has <Parameter>--enable-nodejs</Parameter>, then fully quit and reopen Premiere Pro."
+  );
+}
+
+var fs = nodeRequire("fs");
+var path = nodeRequire("path");
+var os = nodeRequire("os");
 tempDir = path.join(os.tmpdir(), "premiere-mcp-bridge");
 
 function ensureDir(dir) {
@@ -127,10 +142,21 @@ function processOneCommand(cmdFileName) {
         // Check if it's already valid JSON
         var parsed = JSON.parse(result);
         response = JSON.stringify(parsed);
+        log("Result: OK", "ok");
       } else {
-        response = JSON.stringify({ success: true, data: result || null });
+        // An empty result means evalScript gave us nothing back. That is a bridge
+        // failure, not a successful command with no data — reporting it as "OK" is
+        // what made this so hard to diagnose. Say so.
+        response = JSON.stringify({
+          success: false,
+          error:
+            "The bridge received an empty result from evalScript (got " +
+            (typeof result) +
+            "). The script may not have run. If every command does this, the CEP panel is stale — " +
+            "close and reopen it (a reload is not enough), or reinstall the extension.",
+        });
+        log("Result: EMPTY — evalScript returned nothing (see response file)", "err");
       }
-      log("Result: OK", "ok");
     } catch (e) {
       // If result isn't JSON, wrap it
       if (result && result.indexOf("Error") === 0) {


### PR DESCRIPTION
Follow-up to #4 and #8.

## Takes the good half of #4

@Abdullah-Salams's `require` / `cep_node.require` compatibility loader is a genuine robustness win, so it's in (rewritten slightly). `require` is global on most CEP hosts but lives on `cep_node` on others; trying both — and throwing a clear error when neither exists — beats letting `fs` come back `undefined` and resurface later as the baffling `Cannot read properties of undefined (reading 'existsSync')` that several people hit.

## Stops the panel from lying about empty results

This is the one I care about. The panel did:

```js
} else {
  response = JSON.stringify({ success: true, data: result || null });
}
log("Result: OK", "ok");
```

An empty result from `evalScript` is a **bridge failure**, not a successful command that happened to return no data. Reporting it as `success: true` and logging `Result: OK` is a big part of why #5 and #8 took three separate reporters to pin down — the panel was actively telling everyone it was fine. It now returns an error that names the likely cause, including the stale-panel trap @kota4d flagged (a DevTools reload isn't enough; the old poller survives and keeps eating command files with the broken shim).

## What I did not take from #4, and why

- **`--mixed-context`** — added to fix the null-result bug, but that bug was the dropped `evalScript` callback, fixed in #1. @kota4d verified on PPro 26.2.2 that `--mixed-context` is not needed, and @JacobACrocker tested with and without it on 26.3 and got `data: null` either way. With the `cep_node` fallback above we don't need it, and it changes context semantics for everyone to buy nothing.

- **The `__mcpBridgeResult` script wrapper** — same story: aimed at a bug that's already fixed at the root. It would rewrite every generated script, and this is precisely the area @TheTiEr warned about on #8 after breaking their own install trying to "fix" the trailing IIFE. The bare IIFE's completion value propagates correctly once the callback is forwarded. Not worth the churn or the risk.

@Abdullah-Salams — thank you, the diagnosis in #4 was sound and the `cep_node` fallback was the right instinct. It was mostly overtaken by #1 landing first.

307 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)