### PR TITLE
Premiere Pro 2026 compatibility + CEP bridge auto-start reliability

### DIFF
--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.0.0" ExtensionBundleName="MCP Bridge">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.0.1" ExtensionBundleName="MCP Bridge">
   <ExtensionList>
-    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.0.0"/>
+    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.0.1"/>
+    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.0.1"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>
@@ -40,6 +41,35 @@
               <Height>200</Height>
               <Width>300</Width>
             </MinSize>
+          </Geometry>
+          <Icons/>
+        </UI>
+      </DispatchInfo>
+    </Extension>
+    <Extension Id="com.mcp.premiere.bridge.headless">
+      <DispatchInfo>
+        <Resources>
+          <MainPath>./index.html</MainPath>
+          <ScriptPath>./host.jsx</ScriptPath>
+          <CEFCommandLine>
+            <Parameter>--allow-file-access-from-files</Parameter>
+            <Parameter>--enable-nodejs</Parameter>
+          </CEFCommandLine>
+        </Resources>
+        <Lifecycle>
+          <AutoVisible>false</AutoVisible>
+          <StartOn>
+            <Event>com.adobe.csxs.events.ApplicationActivate</Event>
+            <Event>applicationActivate</Event>
+          </StartOn>
+        </Lifecycle>
+        <UI>
+          <Type>Custom</Type>
+          <Geometry>
+            <Size>
+              <Height>1</Height>
+              <Width>1</Width>
+            </Size>
           </Geometry>
           <Icons/>
         </UI>

--- a/cep-plugin/main.js
+++ b/cep-plugin/main.js
@@ -260,9 +260,10 @@ function saveTempDir() {
   log("MCP Bridge CEP plugin loaded");
   setStatus("waiting", "Ready — click Start Bridge");
 
-  // Auto-start if temp dir exists
-  if (fs.existsSync(tempDir)) {
-    log("Temp directory exists, auto-starting...");
-    setTimeout(startBridge, 500);
-  }
+  // Always auto-start. The headless instance (StartOn ApplicationActivate) has no
+  // one to click Start, and macOS periodically purges the temp dir — so create it
+  // rather than gating auto-start on its existence.
+  ensureDir(tempDir);
+  log("Auto-starting bridge...");
+  setTimeout(startBridge, 500);
 })();

--- a/cep-plugin/main.js
+++ b/cep-plugin/main.js
@@ -65,7 +65,7 @@ function listCommandFiles() {
     if (!fs.existsSync(tempDir)) return [];
     var files = fs.readdirSync(tempDir);
     return files
-      .filter(function (f) { return f.indexOf("cmd_") === 0 && f.indexOf(".jsx") > 0; })
+      .filter(function (f) { return f.indexOf("cmd_") === 0 && f.slice(-4) === ".jsx"; })
       .sort(); // process in order
   } catch (e) {
     return [];
@@ -113,12 +113,24 @@ function processCommands() {
   }
 }
 
+// Both the visible panel and the headless auto-start instance run this file.
+// A rename is atomic on the same volume, so whichever engine renames first owns
+// the command; the loser's rename throws and it skips the file.
+var ENGINE_ID = Math.random().toString(36).slice(2, 8);
+
 function processOneCommand(cmdFileName) {
   var cmdFilePath = path.join(tempDir, cmdFileName);
-  var script = readFile(cmdFilePath);
+  var claimPath = cmdFilePath + "." + ENGINE_ID + ".claimed";
+  try {
+    fs.renameSync(cmdFilePath, claimPath);
+  } catch (e) {
+    return; // another engine claimed this command
+  }
+
+  var script = readFile(claimPath);
+  deleteFile(claimPath);
   if (!script) {
     log("Failed to read: " + cmdFileName, "err");
-    deleteFile(cmdFilePath);
     return;
   }
 
@@ -128,10 +140,18 @@ function processOneCommand(cmdFileName) {
 
   log("Executing: " + cmdFileName + " (" + script.length + " chars)", "cmd");
 
-  // Delete the command file immediately to avoid re-processing
-  deleteFile(cmdFilePath);
+  // While evalScript is in flight, heartbeat a busy file so the MCP server can
+  // tell "script still running (modal dialog?)" apart from "plugin not running".
+  // Only starts after 2s, so fast commands never touch the extra file.
+  var busyFilePath = path.join(tempDir, "busy_" + id + ".json");
+  var startedAt = new Date().getTime();
+  var busyTimer = setInterval(function () {
+    writeFile(busyFilePath, '{"id":"' + id + '","elapsedMs":' + (new Date().getTime() - startedAt) + "}");
+  }, 2000);
 
   executeScript(script, function (result) {
+    clearInterval(busyTimer);
+    deleteFile(busyFilePath);
     commandCount++;
     document.getElementById("cmdCount").textContent = commandCount;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -239,9 +239,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -259,9 +256,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -279,9 +273,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -299,9 +290,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -319,9 +307,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -339,9 +324,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1440,9 +1422,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1464,9 +1443,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1488,9 +1464,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1512,9 +1485,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/bridge/file-bridge.ts
+++ b/src/bridge/file-bridge.ts
@@ -82,6 +82,7 @@ export async function sendCommand(
   const id = `${Date.now()}_${++commandCounter}`;
   const cmdFile = join(tempDir, `cmd_${id}.jsx`);
   const resFile = join(tempDir, `res_${id}.json`);
+  const busyFile = join(tempDir, `busy_${id}.json`);
 
   // Validate script
   validateScript(script);
@@ -90,11 +91,12 @@ export async function sendCommand(
   writeFileSync(cmdFile, script, "utf-8");
 
   // Poll for response
-  const result = await pollForResponse(resFile, timeoutMs);
+  const result = await pollForResponse(resFile, busyFile, timeoutMs);
 
   // Cleanup
   safeUnlink(cmdFile);
   safeUnlink(resFile);
+  safeUnlink(busyFile);
 
   return result;
 }
@@ -137,23 +139,43 @@ export async function sendRawCommand(
   const id = `${Date.now()}_${++commandCounter}`;
   const cmdFile = join(tempDir, `cmd_${id}.jsx`);
   const resFile = join(tempDir, `res_${id}.json`);
+  const busyFile = join(tempDir, `busy_${id}.json`);
 
   validateScript(script, true);
   writeFileSync(cmdFile, script, "utf-8");
-  const result = await pollForResponse(resFile, timeoutMs);
+  const result = await pollForResponse(resFile, busyFile, timeoutMs);
   safeUnlink(cmdFile);
   safeUnlink(resFile);
+  safeUnlink(busyFile);
 
   return result;
 }
 
 async function pollForResponse(
   resFile: string,
+  busyFile: string,
   timeoutMs: number
 ): Promise<CommandResult> {
   const start = Date.now();
+  // The CEP plugin writes busy_<id>.json every ~2s while evalScript is in flight.
+  // A fresh busy file past the deadline means Premiere accepted the script but hasn't
+  // returned — nearly always a modal dialog blocking the scripting engine, or a
+  // genuinely long operation — so we keep waiting up to a hard cap instead of
+  // misreporting "is the plugin running?".
+  const hardCapMs = Math.max(timeoutMs * 4, 120_000);
+  let sawBusy = false;
 
-  return new Promise((resolve, reject) => {
+  const busyIsFresh = (): boolean => {
+    try {
+      if (!existsSync(busyFile)) return false;
+      sawBusy = true;
+      return Date.now() - statSync(busyFile).mtimeMs < 6_000;
+    } catch {
+      return false;
+    }
+  };
+
+  return new Promise((resolve) => {
     const check = () => {
       if (existsSync(resFile)) {
         try {
@@ -169,10 +191,21 @@ async function pollForResponse(
         return;
       }
 
-      if (Date.now() - start > timeoutMs) {
+      const elapsed = Date.now() - start;
+      if (elapsed > timeoutMs) {
+        const stillBusy = busyIsFresh();
+        if (stillBusy && elapsed <= hardCapMs) {
+          setTimeout(check, POLL_INTERVAL_MS);
+          return;
+        }
         resolve({
           success: false,
-          error: `Command timed out after ${timeoutMs}ms. Is the CEP plugin running in Premiere Pro?`,
+          error: sawBusy
+            ? `Premiere accepted the script but did not finish within ${elapsed}ms. ` +
+              `A modal dialog inside Premiere Pro is likely blocking the scripting engine — ` +
+              `check the Premiere window and dismiss any open dialog. ` +
+              `(The result, if any, will be discarded.)`
+            : `Command timed out after ${timeoutMs}ms. Is the CEP plugin running in Premiere Pro?`,
         });
         return;
       }
@@ -204,7 +237,7 @@ export function cleanupTempDir(options?: BridgeOptions): void {
   try {
     const files = readdirSync(tempDir);
     for (const file of files) {
-      if (file.startsWith("cmd_") || file.startsWith("res_")) {
+      if (file.startsWith("cmd_") || file.startsWith("res_") || file.startsWith("busy_")) {
         safeUnlink(join(tempDir, file));
       }
     }

--- a/src/bridge/file-bridge.ts
+++ b/src/bridge/file-bridge.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, writeFileSync, readFileSync, unlinkSync, existsSync, readdirSync, statSync, chmodSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { getHelpersSource, helpersFileName, buildBootstrap } from "./script-builder.js";
 
 const DEFAULT_TEMP_DIR = join(tmpdir(), "premiere-mcp-bridge");
 const POLL_INTERVAL_MS = 100;
@@ -64,6 +65,18 @@ export function getTempDir(options?: BridgeOptions): string {
 }
 
 /**
+ * Make sure this server version's helpers file exists in the temp dir, and return
+ * the bootstrap line each command must carry so the CEP-side engine loads it once.
+ */
+function ensureHelpers(tempDir: string): string {
+  const helpersPath = join(tempDir, helpersFileName());
+  if (!existsSync(helpersPath)) {
+    writeFileSync(helpersPath, getHelpersSource(), "utf-8");
+  }
+  return buildBootstrap(helpersPath);
+}
+
+/**
  * Send a command (ExtendScript) to the CEP plugin and wait for a response.
  * 
  * Protocol:
@@ -87,8 +100,9 @@ export async function sendCommand(
   // Validate script
   validateScript(script);
 
-  // Write command file
-  writeFileSync(cmdFile, script, "utf-8");
+  // Write command file (bootstrap loads the helpers into the engine if needed)
+  writeFileSync(cmdFile, `${ensureHelpers(tempDir)}
+${script}`, "utf-8");
 
   // Poll for response
   const result = await pollForResponse(resFile, busyFile, timeoutMs);
@@ -142,7 +156,8 @@ export async function sendRawCommand(
   const busyFile = join(tempDir, `busy_${id}.json`);
 
   validateScript(script, true);
-  writeFileSync(cmdFile, script, "utf-8");
+  writeFileSync(cmdFile, `${ensureHelpers(tempDir)}
+${script}`, "utf-8");
   const result = await pollForResponse(resFile, busyFile, timeoutMs);
   safeUnlink(cmdFile);
   safeUnlink(resFile);

--- a/src/bridge/script-builder.ts
+++ b/src/bridge/script-builder.ts
@@ -2,6 +2,7 @@
  * Builds ExtendScript strings with helper functions prepended.
  * All generated code must be ES3-compatible (var, no arrow functions, no let/const).
  */
+import { createHash } from "node:crypto";
 
 const HELPERS = `
 // === MCP Bridge Helpers (auto-prepended) ===
@@ -454,11 +455,43 @@ function __error(msg) {
 `;
 
 /**
- * Build a complete ExtendScript by wrapping user code in an IIFE with helpers.
+ * The helpers are NOT inlined into every command. Re-sending ~14KB of helper code
+ * with each evalScript both wastes the 200ms-polling pipe and — observed on
+ * Premiere 26.2.2 — can hit "InternalError: Stack overrun" once the long-lived
+ * ExtendScript engine has degraded, at which point every tool call dies with an
+ * opaque "EvalScript error.". Instead the file bridge writes the helpers to
+ * <tempDir>/helpers_<version>.jsx once, and each command carries only a tiny
+ * bootstrap that $.evalFile's them into the engine if this exact version isn't
+ * loaded yet. Self-healing across engine restarts, and each version of the server
+ * loads its own helpers file, so upgrades can't execute stale helpers.
+ */
+export const HELPERS_VERSION = createHash("md5").update(HELPERS).digest("hex").slice(0, 12);
+
+export function getHelpersSource(): string {
+  return `${HELPERS}
+var __HELPERS_V = "${HELPERS_VERSION}";
+`;
+}
+
+export function helpersFileName(): string {
+  return `helpers_${HELPERS_VERSION}.jsx`;
+}
+
+/**
+ * Build the bootstrap + user-code command script. The helpers file path is only
+ * known to the file bridge, which injects it via buildBootstrap().
+ */
+export function buildBootstrap(helpersPath: string): string {
+  const escaped = helpersPath.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `if (typeof __HELPERS_V === "undefined" || __HELPERS_V !== "${HELPERS_VERSION}") { $.evalFile("${escaped}"); }`;
+}
+
+/**
+ * Build a complete ExtendScript by wrapping user code in an IIFE.
+ * Helper functions are loaded by the bootstrap the file bridge prepends.
  */
 export function buildScript(code: string): string {
-  return `${HELPERS}
-(function() {
+  return `(function() {
   try {
     ${code}
   } catch(e) {

--- a/src/bridge/script-builder.ts
+++ b/src/bridge/script-builder.ts
@@ -6,6 +6,32 @@
 const HELPERS = `
 // === MCP Bridge Helpers (auto-prepended) ===
 
+// ExtendScript (ES3) has no native JSON object. Tool scripts use __jsonStringify
+// directly, but LLM-authored code via execute_extendscript reaches for
+// JSON.stringify reflexively — give it a global. Parse is intentionally omitted:
+// implementing it needs eval, which the command validator blocks.
+if (typeof JSON === "undefined") {
+  JSON = {};
+}
+if (typeof JSON.stringify === "undefined") {
+  JSON.stringify = function (obj) { return __jsonStringify(obj); };
+}
+
+// Premiere's createNewSequence(name, id) expects a UUID-shaped id; anything else
+// can fall back to interactive UI (a modal New Sequence dialog) and wedge the bridge.
+function __uuid() {
+  var hex = "0123456789abcdef";
+  var s = "";
+  for (var i = 0; i < 36; i++) {
+    if (i === 8 || i === 13 || i === 18 || i === 23) { s += "-"; continue; }
+    if (i === 14) { s += "4"; continue; }
+    var r = Math.floor(Math.random() * 16);
+    if (i === 19) { r = (r & 3) | 8; }
+    s += hex.charAt(r);
+  }
+  return s;
+}
+
 var TICKS_PER_SECOND = 254016000000;
 
 function __ticksToSeconds(ticks) {

--- a/src/bridge/script-builder.ts
+++ b/src/bridge/script-builder.ts
@@ -11,10 +11,15 @@ const HELPERS = `
 // directly, but LLM-authored code via execute_extendscript reaches for
 // JSON.stringify reflexively — give it a global. Parse is intentionally omitted:
 // implementing it needs eval, which the command validator blocks.
+// The engine is shared and long-lived, so also REPLACE our own earlier wrapper if
+// one is already installed (detected via the __mcpPolyfill flag or its source) —
+// a stale wrapper closing over an older __jsonStringify caused recursion bugs.
+// A real json2-style implementation loaded by another extension is left alone.
 if (typeof JSON === "undefined") {
   JSON = {};
 }
-if (typeof JSON.stringify === "undefined") {
+if (!JSON.stringify || JSON.__mcpPolyfill === true || String(JSON.stringify).indexOf("__jsonStringify") !== -1) {
+  JSON.__mcpPolyfill = true;
   JSON.stringify = function (obj) { return __jsonStringify(obj); };
 }
 
@@ -415,11 +420,10 @@ function __exportStillFrame(outputPath, ticks) {
 }
 
 function __jsonStringify(obj) {
-  // ES3-compatible JSON stringify
-  if (typeof JSON !== "undefined" && JSON.stringify) {
-    return JSON.stringify(obj);
-  }
-  // Fallback for very old ExtendScript
+  // ES3-compatible JSON stringify. Never delegate to JSON.stringify here: the
+  // global JSON polyfill above is a wrapper around THIS function, so delegating
+  // creates infinite mutual recursion ("InternalError: Stack overrun") that took
+  // down every __result call in the shared engine.
   if (obj === null) return "null";
   if (obj === undefined) return "undefined";
   if (typeof obj === "string") return '"' + obj.replace(/\\\\/g, "\\\\\\\\").replace(/"/g, '\\\\"').replace(/\\n/g, "\\\\n") + '"';

--- a/src/tools/sequence.ts
+++ b/src/tools/sequence.ts
@@ -1,5 +1,70 @@
 import { buildToolScript, escapeForExtendScript } from "../bridge/script-builder.js";
 import { sendCommand, BridgeOptions } from "../bridge/file-bridge.js";
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Find a default .sqpreset on this machine for create_sequence without preset_path.
+ *
+ * Every sequence-creation route that lets Premiere pick settings interactively is
+ * unusable from scripting: app.project.createNewSequence(name, id) opens the modal
+ * New Sequence dialog in Premiere 26 (verified on 26.2.2 — even with a UUID id),
+ * which freezes the shared ExtendScript engine until a human dismisses it. So the
+ * no-preset path must still resolve to a concrete preset file.
+ */
+let cachedDefaultPreset: string | null | undefined;
+export function findDefaultSequencePreset(): string | null {
+  if (cachedDefaultPreset !== undefined) return cachedDefaultPreset;
+
+  if (process.env.PREMIERE_DEFAULT_SEQUENCE_PRESET && existsSync(process.env.PREMIERE_DEFAULT_SEQUENCE_PRESET)) {
+    return (cachedDefaultPreset = process.env.PREMIERE_DEFAULT_SEQUENCE_PRESET);
+  }
+
+  const roots: string[] = [];
+  const appDirs =
+    process.platform === "darwin"
+      ? { base: "/Applications", match: /^Adobe Premiere Pro/ }
+      : { base: "C:\\Program Files\\Adobe", match: /^Adobe Premiere Pro/ };
+  try {
+    for (const dir of readdirSync(appDirs.base)) {
+      if (!appDirs.match.test(dir)) continue;
+      const appRoot = join(appDirs.base, dir);
+      if (process.platform === "darwin") {
+        for (const inner of readdirSync(appRoot)) {
+          if (inner.endsWith(".app")) roots.push(join(appRoot, inner, "Contents", "Settings", "SequencePresets"));
+        }
+      } else {
+        roots.push(join(appRoot, "Settings", "SequencePresets"));
+      }
+    }
+  } catch {
+    /* fall through */
+  }
+
+  const found: string[] = [];
+  const walk = (dir: string, depth: number) => {
+    if (depth > 3 || !existsSync(dir)) return;
+    for (const entry of readdirSync(dir)) {
+      const p = join(dir, entry);
+      try {
+        if (statSync(p).isDirectory()) walk(p, depth + 1);
+        else if (entry.endsWith(".sqpreset")) found.push(p);
+      } catch {
+        /* skip unreadable */
+      }
+    }
+  };
+  for (const root of roots.sort().reverse()) walk(root, 0); // newest app version first
+
+  // Prefer a plain HD/UHD progressive preset; otherwise take anything.
+  const preferred =
+    found.find((p) => /UHD \(4K\) 2160p 25 fps\.sqpreset$/.test(p)) ||
+    found.find((p) => /2160p 25|1080p 25/.test(p)) ||
+    found.find((p) => /2160p|1080p/.test(p)) ||
+    found[0] ||
+    null;
+  return (cachedDefaultPreset = preferred);
+}
 
 export function getSequenceTools(bridgeOptions: BridgeOptions) {
   return {
@@ -14,33 +79,35 @@ export function getSequenceTools(bridgeOptions: BridgeOptions) {
           },
           preset_path: {
             type: "string",
-            description: "Optional path to a sequence preset file (.sqpreset). Uses default if omitted.",
+            description:
+              "Optional path to a sequence preset file (.sqpreset). If omitted, a default preset is discovered from the Premiere installation (override with PREMIERE_DEFAULT_SEQUENCE_PRESET).",
           },
         },
         required: ["name"],
       },
       handler: async (args: { name: string; preset_path?: string }) => {
         // app.project.createNewSequenceFromPreset does not exist in Premiere Pro
-        // (verified missing in 26.x) — preset-based creation goes through the QE DOM.
-        // The no-preset form MUST pass a UUID second argument: the one-arg call throws
-        // "Not Enough Parameters", and a non-UUID id can pop the modal New Sequence
-        // dialog, which blocks the entire scripting engine until dismissed by hand.
-        const presetCode = args.preset_path
-          ? `
-          app.enableQE();
-          qe.project.newSequence("${escapeForExtendScript(args.name)}", "${escapeForExtendScript(args.preset_path)}");
-          var seq = app.project.activeSequence;
-          if (!seq || seq.name !== "${escapeForExtendScript(args.name)}") {
-            return __error("Failed to create sequence from preset: ${escapeForExtendScript(args.preset_path)}");
-          }`
-          : `
-          var seq = app.project.createNewSequence("${escapeForExtendScript(args.name)}", __uuid());
-          if (!seq) seq = app.project.activeSequence;
-          if (!seq) return __error("Failed to create sequence");`;
+        // (verified missing in 26.x), and createNewSequence(name, id) opens the
+        // modal New Sequence dialog there — every creation goes through the QE DOM
+        // with an explicit preset. See findDefaultSequencePreset().
+        const presetPath = args.preset_path || findDefaultSequencePreset();
+        if (!presetPath) {
+          return {
+            success: false,
+            error:
+              "No sequence preset found. Pass preset_path (an .sqpreset file) or set PREMIERE_DEFAULT_SEQUENCE_PRESET — " +
+              "creating a sequence without a preset opens a modal dialog in Premiere 26+, which would freeze scripting.",
+          };
+        }
 
         const script = buildToolScript(`
-          ${presetCode}
-          return __result({ created: true, name: seq.name, id: seq.sequenceID });
+          app.enableQE();
+          qe.project.newSequence("${escapeForExtendScript(args.name)}", "${escapeForExtendScript(presetPath)}");
+          var seq = app.project.activeSequence;
+          if (!seq || seq.name !== "${escapeForExtendScript(args.name)}") {
+            return __error("Failed to create sequence from preset: ${escapeForExtendScript(presetPath)}");
+          }
+          return __result({ created: true, name: seq.name, id: seq.sequenceID, presetUsed: "${escapeForExtendScript(presetPath)}" });
         `);
         return sendCommand(script, bridgeOptions);
       },

--- a/src/tools/sequence.ts
+++ b/src/tools/sequence.ts
@@ -20,14 +20,26 @@ export function getSequenceTools(bridgeOptions: BridgeOptions) {
         required: ["name"],
       },
       handler: async (args: { name: string; preset_path?: string }) => {
+        // app.project.createNewSequenceFromPreset does not exist in Premiere Pro
+        // (verified missing in 26.x) — preset-based creation goes through the QE DOM.
+        // The no-preset form MUST pass a UUID second argument: the one-arg call throws
+        // "Not Enough Parameters", and a non-UUID id can pop the modal New Sequence
+        // dialog, which blocks the entire scripting engine until dismissed by hand.
         const presetCode = args.preset_path
-          ? `app.project.createNewSequenceFromPreset("${escapeForExtendScript(args.name)}", "${escapeForExtendScript(args.preset_path)}");`
-          : `app.project.createNewSequence("${escapeForExtendScript(args.name)}");`;
+          ? `
+          app.enableQE();
+          qe.project.newSequence("${escapeForExtendScript(args.name)}", "${escapeForExtendScript(args.preset_path)}");
+          var seq = app.project.activeSequence;
+          if (!seq || seq.name !== "${escapeForExtendScript(args.name)}") {
+            return __error("Failed to create sequence from preset: ${escapeForExtendScript(args.preset_path)}");
+          }`
+          : `
+          var seq = app.project.createNewSequence("${escapeForExtendScript(args.name)}", __uuid());
+          if (!seq) seq = app.project.activeSequence;
+          if (!seq) return __error("Failed to create sequence");`;
 
         const script = buildToolScript(`
           ${presetCode}
-          var seq = app.project.activeSequence;
-          if (!seq) return __error("Failed to create sequence");
           return __result({ created: true, name: seq.name, id: seq.sequenceID });
         `);
         return sendCommand(script, bridgeOptions);
@@ -285,10 +297,14 @@ export function getSequenceTools(bridgeOptions: BridgeOptions) {
         required: ["name", "preset_path"],
       },
       handler: async (args: { name: string; preset_path: string }) => {
+        // createNewSequenceFromPreset is not a real API (missing in 26.x) — use QE.
         const script = buildToolScript(`
-          app.project.createNewSequenceFromPreset("${escapeForExtendScript(args.name)}", "${escapeForExtendScript(args.preset_path)}");
+          app.enableQE();
+          qe.project.newSequence("${escapeForExtendScript(args.name)}", "${escapeForExtendScript(args.preset_path)}");
           var seq = app.project.activeSequence;
-          if (!seq) return __error("Failed to create sequence from preset");
+          if (!seq || seq.name !== "${escapeForExtendScript(args.name)}") {
+            return __error("Failed to create sequence from preset: ${escapeForExtendScript(args.preset_path)}");
+          }
           return __result({ created: true, name: seq.name, id: seq.sequenceID });
         `);
         return sendCommand(script, bridgeOptions);

--- a/tests/bridge/file-bridge.test.ts
+++ b/tests/bridge/file-bridge.test.ts
@@ -161,7 +161,10 @@ describe("sendCommand", () => {
 
     const writeCall = mockedWriteFileSync.mock.calls[0];
     expect(String(writeCall[0])).toMatch(/cmd_.*\.jsx$/);
-    expect(writeCall[1]).toBe("var x = 1;");
+    // command = one-line helpers bootstrap, then the script itself
+    const content = String(writeCall[1]);
+    expect(content.endsWith("\nvar x = 1;")).toBe(true);
+    expect(content).toContain('$.evalFile("/tmp/test-bridge/helpers_');
     expect(writeCall[2]).toBe("utf-8");
   });
 

--- a/tests/bridge/script-builder.test.ts
+++ b/tests/bridge/script-builder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildScript, escapeForExtendScript, buildToolScript } from "../../src/bridge/script-builder.js";
+import { buildScript, escapeForExtendScript, buildToolScript, getHelpersSource, buildBootstrap, helpersFileName, HELPERS_VERSION } from "../../src/bridge/script-builder.js";
 
 describe("buildScript", () => {
   it("wraps code in an IIFE with try/catch", () => {
@@ -11,8 +11,8 @@ describe("buildScript", () => {
     expect(result).toContain("})();");
   });
 
-  it("prepends helper functions", () => {
-    const result = buildScript("return __result({});");
+  it("defines helper functions in the helpers source", () => {
+    const result = getHelpersSource();
     expect(result).toContain("var TICKS_PER_SECOND = 254016000000;");
     expect(result).toContain("function __ticksToSeconds(ticks)");
     expect(result).toContain("function __secondsToTicks(seconds)");
@@ -104,23 +104,26 @@ describe("escapeForExtendScript", () => {
 });
 
 describe("generated script structure", () => {
-  it("helpers appear before the IIFE", () => {
-    const result = buildScript("return __result({});");
-    const helpersEnd = result.indexOf("// === End MCP Bridge Helpers ===");
-    const iifeStart = result.indexOf("(function() {");
-    expect(helpersEnd).toBeLessThan(iifeStart);
-    expect(helpersEnd).toBeGreaterThan(-1);
-    expect(iifeStart).toBeGreaterThan(-1);
+  it("bootstrap loads this exact helpers version via $.evalFile", () => {
+    const bootstrap = buildBootstrap("/tmp/x/" + helpersFileName());
+    expect(bootstrap).toContain(`__HELPERS_V !== "${HELPERS_VERSION}"`);
+    expect(bootstrap).toContain(`$.evalFile("/tmp/x/helpers_${HELPERS_VERSION}.jsx")`);
+    expect(getHelpersSource()).toContain(`var __HELPERS_V = "${HELPERS_VERSION}";`);
+  });
+
+  it("bootstrap escapes quotes and backslashes in the helpers path", () => {
+    const bootstrap = buildBootstrap('C:\\temp\\he"rs.jsx');
+    expect(bootstrap).toContain('$.evalFile("C:\\\\temp\\\\he\\"rs.jsx")');
   });
 
   it("__findProjectItem recursively searches bins", () => {
-    const result = buildScript("");
+    const result = getHelpersSource();
     expect(result).toContain("if (item.type === 2)");
     expect(result).toContain("var found = __findProjectItem(nodeIdOrName, item);");
   });
 
   it("__findClip searches both video and audio tracks", () => {
-    const result = buildScript("");
+    const result = getHelpersSource();
     expect(result).toContain("seq.videoTracks.numTracks");
     expect(result).toContain("seq.audioTracks.numTracks");
     expect(result).toContain('trackType: "video"');
@@ -128,7 +131,7 @@ describe("generated script structure", () => {
   });
 
   it("__jsonStringify handles all types", () => {
-    const result = buildScript("");
+    const result = getHelpersSource();
     expect(result).toContain('if (obj === null) return "null"');
     expect(result).toContain('if (typeof obj === "string")');
     expect(result).toContain('if (typeof obj === "number"');

--- a/tests/bridge/script-builder.test.ts
+++ b/tests/bridge/script-builder.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { buildScript, escapeForExtendScript, buildToolScript, getHelpersSource, buildBootstrap, helpersFileName, HELPERS_VERSION } from "../../src/bridge/script-builder.js";
+import { runInNewContext } from "node:vm";
 
 describe("buildScript", () => {
   it("wraps code in an IIFE with try/catch", () => {
@@ -137,5 +138,29 @@ describe("generated script structure", () => {
     expect(result).toContain('if (typeof obj === "number"');
     expect(result).toContain("if (obj instanceof Array)");
     expect(result).toContain('if (typeof obj === "object")');
+  });
+});
+
+describe("helpers execute correctly in an ES3-like engine", () => {
+  it("__result works when JSON is undefined (polyfill must not recurse into itself)", () => {
+    // Regression: __jsonStringify once delegated to JSON.stringify while the JSON
+    // polyfill delegated back to __jsonStringify — infinite mutual recursion that
+    // stack-overran the shared ExtendScript engine on every tool response.
+    const sandbox: Record<string, unknown> = { JSON: undefined };
+    const out = runInNewContext(
+      getHelpersSource() + '\n__result({ connected: true, nested: { n: 1, arr: [1, "a", false, null] } });',
+      sandbox
+    );
+    expect(out).toBe('{"success":true,"data":{"connected":true,"nested":{"n":1,"arr":[1,"a",false,null]}}}');
+  });
+
+  it("a stale wrapper from an older helpers version gets replaced", () => {
+    // Simulate a polluted long-lived engine: JSON.stringify is our old-style wrapper.
+    const stale = { stringify: function badWrapper(o: unknown) { return "__jsonStringify" + String(o); } };
+    const sandbox: Record<string, unknown> = { JSON: stale };
+    runInNewContext(getHelpersSource(), sandbox);
+    const json = sandbox.JSON as { stringify: (o: unknown) => string; __mcpPolyfill?: boolean };
+    expect(json.__mcpPolyfill).toBe(true);
+    expect(json.stringify({ ok: 1 })).toBe('{"ok":1}');
   });
 });

--- a/tests/tools/regressions.test.ts
+++ b/tests/tools/regressions.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getHelpersSource } from "../../src/bridge/script-builder.js";
 import { BridgeOptions } from "../../src/bridge/file-bridge.js";
 
 vi.mock("../../src/bridge/file-bridge.js", () => ({
@@ -189,8 +190,8 @@ describe("PR #3 follow-ups — color_correct and export_sequence", () => {
 describe("script-builder helpers used by the fixes are actually defined", () => {
   const exportTools = getExportTools(bridgeOptions);
 
-  it("prepends every helper the generated scripts call", async () => {
-    const script = await scriptFor(exportTools.export_frame, { output_path: "/tmp/f.png" });
+  it("defines every helper the generated scripts call", async () => {
+    const script = getHelpersSource();
 
     for (const helper of [
       "function __exportStillFrame(",

--- a/tests/tools/tool-modules.test.ts
+++ b/tests/tools/tool-modules.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getHelpersSource } from "../../src/bridge/script-builder.js";
 import { BridgeOptions } from "../../src/bridge/file-bridge.js";
 
 // Mock sendCommand and sendRawCommand so tool handlers don't do real I/O
@@ -340,9 +341,8 @@ describe("Tool Handler Behavior", () => {
       const tools = getDiscoveryTools(bridgeOptions);
       await (tools.list_sequence_tracks.handler as any)({});
 
-      const script = mockedSendCommand.mock.calls[0][0];
-      // The user code portion (after helpers) should use activeSequence directly
-      const userCode = script.split("// === End MCP Bridge Helpers ===")[1];
+      // Helpers are no longer inlined — the whole script is user code.
+      const userCode = mockedSendCommand.mock.calls[0][0];
       expect(userCode).toContain("app.project.activeSequence");
       // Should NOT call __findSequence in user code when no sequence_id is provided
       expect(userCode).not.toContain('__findSequence("');
@@ -480,13 +480,17 @@ describe("Script Generation Patterns", () => {
     expect(script).toContain("})();");
   });
 
-  it("scripts include helper functions", async () => {
+  it("scripts do not inline helpers; helpers source defines them", async () => {
     const tools = getDiscoveryTools(bridgeOptions);
     await (tools.get_project_info.handler as any)({});
 
     const script = mockedSendCommand.mock.calls[0][0];
-    expect(script).toContain("function __result(data)");
-    expect(script).toContain("function __error(msg)");
-    expect(script).toContain("TICKS_PER_SECOND");
+    // Inlining ~14KB of helpers per command overflowed the ExtendScript stack
+    // on long-lived engines; commands must stay lean.
+    expect(script).not.toContain("function __jsonStringify(obj)");
+    const helpers = getHelpersSource();
+    expect(helpers).toContain("function __result(data)");
+    expect(helpers).toContain("function __error(msg)");
+    expect(helpers).toContain("TICKS_PER_SECOND");
   });
 });


### PR DESCRIPTION
Five fixes from cutting the shu uemura Holiday '26 campaign against Premiere Pro 26.2.2, where the bridge and tools ran thousands of live commands (storyboard matching + assembling 8 sequences / 72 trimmed clips via MCP).

## Sequence creation without the modal trap
`app.project.createNewSequence()` in 26.x opens the New Sequence dialog and wedges the shared ExtendScript engine until dismissed — from a headless bridge that's a deadlock. `create_sequence` now uses `qe.project.newSequence` with an explicit `.sqpreset`, and discovers a default preset from the Premiere installation when none is given (`PREMIERE_DEFAULT_SEQUENCE_PRESET` overrides).

## Helpers loaded once per engine
Command payloads dropped from ~14KB to ~200B by loading the ExtendScript helper library once via `$.evalFile` (per engine, content-hashed filename) instead of inlining it into every command.

## JSON polyfill recursion fix
ExtendScript has no native JSON; the polyfill and `__jsonStringify` could recurse into each other infinitely. Fixed, with VM regression tests.

## Modal-hang diagnostics (busy heartbeat)
While `evalScript` is in flight the bridge heartbeats a `busy_<id>.json` file (after 2s), so the MCP server can tell "script still running / modal dialog blocking" apart from "plugin not running" — previously both looked like a silent timeout. Command files are also claimed via atomic rename so the panel and headless instances never double-execute.

## CEP bridge: unconditional auto-start
Auto-start was gated on the bridge temp dir already existing. macOS periodically purges `/var/folders`, so Premiere would boot with a silent, idle headless bridge and every command timed out with no heartbeat (hit live on 2026-07-20). The panel now `ensureDir`s the temp dir and always starts the poll loop.

## Testing
- 312 tests pass (`npm test`), including new VM regression tests for the JSON polyfill and helpers bootstrap.
- Everything above exercised live against Premiere Pro 26.2.2 across multi-hour editing sessions (sequence creation from preset, trimmed overwriteClip inserts, markers, Lumetri, adjustment layers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)