### PR TITLE
Fix frame-export fallback and Windows CEP discovery setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ premiere-pro-mcp --install-cep
 npm run install-cep
 ```
 
-This symlinks the plugin into Premiere Pro's extensions folder and enables debug mode.
+This installs the plugin into Premiere Pro's per-user extensions folder and enables debug mode.
 
 <details>
 <summary>Manual installation (macOS)</summary>
@@ -83,7 +83,7 @@ done
 <summary>Manual installation (Windows)</summary>
 
 1. Copy the `cep-plugin` folder to `%APPDATA%\Adobe\CEP\extensions\MCPBridgeCEP`
-2. Open Registry Editor and set these DWORD values to `1`:
+2. Open Registry Editor and set these **String (`REG_SZ`)** values to `1` (not DWORD):
    - `HKEY_CURRENT_USER\Software\Adobe\CSXS.12\PlayerDebugMode`
    - (repeat for CSXS.9 through CSXS.14)
 
@@ -510,8 +510,12 @@ Many tools use the undocumented QE DOM (enabled via `app.enableQE()`). These too
 <details>
 <summary><strong>CEP plugin doesn't appear in Premiere Pro</strong></summary>
 
-1. Verify debug mode: `defaults read com.adobe.CSXS.12 PlayerDebugMode` should return `1`
-2. Check the plugin exists: `ls ~/Library/Application\ Support/Adobe/CEP/extensions/MCPBridgeCEP`
+1. Verify debug mode:
+   - macOS: `defaults read com.adobe.CSXS.12 PlayerDebugMode` should return `1`
+   - Windows: `reg query "HKCU\SOFTWARE\Adobe\CSXS.12" /v PlayerDebugMode` should report `REG_SZ    1` (a `REG_DWORD` value is not valid for unsigned CEP discovery)
+2. Check the plugin exists:
+   - macOS: `ls ~/Library/Application\ Support/Adobe/CEP/extensions/MCPBridgeCEP`
+   - Windows: `dir "%APPDATA%\Adobe\CEP\extensions\MCPBridgeCEP"`
 3. Completely restart Premiere Pro (not just close/reopen the project)
 4. Check the CSXS version matches your Premiere Pro version
 

--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.0.1" ExtensionBundleName="MCP Bridge">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.1.5" ExtensionBundleName="MCP Bridge">
   <ExtensionList>
-    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.0.1"/>
-    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.0.1"/>
+    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.1.5"/>
+    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.1.5"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "install-cep": "bash scripts/install-cep.sh"
+    "install-cep": "node dist/index.js --install-cep"
   },
   "repository": {
     "type": "git",

--- a/scripts/install-cep.ps1
+++ b/scripts/install-cep.ps1
@@ -1,0 +1,68 @@
+param(
+  [switch]$Diagnose
+)
+
+$ErrorActionPreference = "Stop"
+
+$projectDir = Split-Path -Parent $PSScriptRoot
+$pluginSource = Join-Path $projectDir "cep-plugin"
+$cepRoot = Join-Path $env:APPDATA "Adobe\CEP\extensions"
+$pluginDestination = Join-Path $cepRoot "MCPBridgeCEP"
+$resolvedCepRoot = [System.IO.Path]::GetFullPath($cepRoot).TrimEnd([System.IO.Path]::DirectorySeparatorChar)
+$resolvedDestination = [System.IO.Path]::GetFullPath($pluginDestination)
+
+if (-not $resolvedDestination.StartsWith($resolvedCepRoot + [System.IO.Path]::DirectorySeparatorChar, [System.StringComparison]::OrdinalIgnoreCase)) {
+  throw "Refusing to install outside the CEP extensions directory: $resolvedDestination"
+}
+
+Write-Host "=== MCP Bridge CEP Plugin Installer ==="
+Write-Host "Source:      $pluginSource"
+Write-Host "Destination: $pluginDestination"
+
+if (-not (Test-Path -LiteralPath (Join-Path $pluginSource "CSXS\manifest.xml"))) {
+  throw "CEP plugin manifest not found at $pluginSource"
+}
+
+if (-not $Diagnose) {
+  New-Item -ItemType Directory -Force -Path $cepRoot | Out-Null
+
+  if (Test-Path -LiteralPath $pluginDestination) {
+    Remove-Item -LiteralPath $resolvedDestination -Recurse -Force
+  }
+  Copy-Item -LiteralPath $pluginSource -Destination $pluginDestination -Recurse
+
+  # Adobe requires PlayerDebugMode to be a String value. A DWORD that happens
+  # to contain 1 is ignored by CEP and the unsigned extension is not discovered.
+  foreach ($version in 9..14) {
+    $key = "HKCU:\SOFTWARE\Adobe\CSXS.$version"
+    New-Item -Path $key -Force | Out-Null
+    New-ItemProperty -Path $key -Name "PlayerDebugMode" -PropertyType String -Value "1" -Force | Out-Null
+  }
+}
+
+$problems = @()
+if (-not (Test-Path -LiteralPath (Join-Path $pluginDestination "CSXS\manifest.xml"))) {
+  $problems += "Plugin manifest is missing from $pluginDestination"
+}
+
+foreach ($version in 9..14) {
+  $key = "HKCU:\SOFTWARE\Adobe\CSXS.$version"
+  $value = Get-ItemProperty -Path $key -Name "PlayerDebugMode" -ErrorAction SilentlyContinue
+  if ($null -eq $value -or [string]$value.PlayerDebugMode -ne "1") {
+    $problems += "CSXS.$version PlayerDebugMode is missing or not set to 1"
+    continue
+  }
+
+  $kind = (Get-Item -Path $key).GetValueKind("PlayerDebugMode")
+  if ($kind -ne [Microsoft.Win32.RegistryValueKind]::String) {
+    $problems += "CSXS.$version PlayerDebugMode is $kind; Adobe requires REG_SZ"
+  }
+}
+
+if ($problems.Count -gt 0) {
+  Write-Error ($problems -join [Environment]::NewLine)
+  exit 1
+}
+
+Write-Host ""
+Write-Host "Installation verified. Restart Premiere Pro, then open Window > Extensions > MCP Bridge."

--- a/src/bridge/script-builder.ts
+++ b/src/bridge/script-builder.ts
@@ -387,19 +387,22 @@ function __exportStillFrame(outputPath, ticks) {
         savedOut = seq.getOutPointAsTime().ticks;
       } catch (e) {}
 
-      // seq.timebase is ticks-per-frame, so in..in+timebase is exactly one frame.
+      // seq.timebase is ticks-per-frame, but Sequence.setInPoint/setOutPoint take
+      // seconds (unlike setPlayerPosition, which takes ticks). Convert before
+      // setting the one-frame range or Premiere targets an astronomically large
+      // interval and the still export produces no file.
       var frameTicks = parseFloat(seq.timebase);
       var startTicks = parseFloat(atTicks);
-      seq.setInPoint(String(startTicks));
-      seq.setOutPoint(String(startTicks + frameTicks));
+      seq.setInPoint(__ticksToSeconds(startTicks));
+      seq.setOutPoint(__ticksToSeconds(startTicks + frameTicks));
 
       try {
         seq.exportAsMediaDirect(outputPath, preset, app.encoder.ENCODE_IN_TO_OUT);
         notes.push("AME preset: " + preset);
       } finally {
         try {
-          if (savedIn !== null) seq.setInPoint(savedIn);
-          if (savedOut !== null) seq.setOutPoint(savedOut);
+          if (savedIn !== null) seq.setInPoint(__ticksToSeconds(savedIn));
+          if (savedOut !== null) seq.setOutPoint(__ticksToSeconds(savedOut));
         } catch (e) {}
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createServer } from "./server.js";
 import { cleanupTempDir, getTempDir } from "./bridge/file-bridge.js";
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 import { fileURLToPath } from "url";
 import path from "path";
 
@@ -42,13 +42,24 @@ if (args.includes("--version") || args.includes("-v")) {
 }
 
 if (args.includes("--install-cep")) {
-  const scriptPath = path.join(projectRoot, "scripts", "install-cep.sh");
   console.log("Installing CEP plugin...\n");
+  const isWindows = process.platform === "win32";
+  const scriptPath = path.join(projectRoot, "scripts", isWindows ? "install-cep.ps1" : "install-cep.sh");
   try {
-    execSync(`bash "${scriptPath}"`, { stdio: "inherit", cwd: projectRoot });
+    if (isWindows) {
+      execFileSync(
+        "powershell.exe",
+        ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", scriptPath],
+        { stdio: "inherit", cwd: projectRoot }
+      );
+    } else {
+      execFileSync("bash", [scriptPath], { stdio: "inherit", cwd: projectRoot });
+    }
   } catch {
     console.error("CEP installation failed. Try running manually:");
-    console.error(`  bash "${scriptPath}"`);
+    console.error(isWindows
+      ? `  powershell -ExecutionPolicy Bypass -File "${scriptPath}"`
+      : `  bash "${scriptPath}"`);
     process.exit(1);
   }
   process.exit(0);

--- a/tests/bridge/file-bridge.test.ts
+++ b/tests/bridge/file-bridge.test.ts
@@ -164,7 +164,7 @@ describe("sendCommand", () => {
     // command = one-line helpers bootstrap, then the script itself
     const content = String(writeCall[1]);
     expect(content.endsWith("\nvar x = 1;")).toBe(true);
-    expect(content).toContain('$.evalFile("/tmp/test-bridge/helpers_');
+    expect(content.replaceAll("\\\\", "/")).toContain('$.evalFile("/tmp/test-bridge/helpers_');
     expect(writeCall[2]).toBe("utf-8");
   });
 

--- a/tests/cep-install.test.ts
+++ b/tests/cep-install.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = process.cwd();
+
+describe("CEP installation metadata", () => {
+  it("keeps the CEP bundle and extension versions aligned with package.json", () => {
+    const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+    const manifest = readFileSync(join(root, "cep-plugin", "CSXS", "manifest.xml"), "utf8");
+
+    expect(manifest).toContain(`ExtensionBundleVersion="${pkg.version}"`);
+    expect(manifest.match(new RegExp(`Version="${pkg.version.replaceAll(".", "\\.")}"`, "g"))).toHaveLength(3);
+  });
+
+  it("documents the Windows unsigned-extension value as REG_SZ", () => {
+    const readme = readFileSync(join(root, "README.md"), "utf8");
+    const installer = readFileSync(join(root, "scripts", "install-cep.ps1"), "utf8");
+
+    expect(readme).toContain("String (`REG_SZ`)");
+    expect(readme).not.toContain("set these DWORD values");
+    expect(installer).toContain('-PropertyType String -Value "1"');
+  });
+});

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { execSync } from "child_process";
+import { readFileSync } from "node:fs";
 import { join } from "path";
 
 const BIN = join(process.cwd(), "dist", "index.js");
@@ -31,9 +32,7 @@ describe("CLI flags", () => {
 
   it("--version matches package.json version", () => {
     const version = execSync(`node ${BIN} --version`, { encoding: "utf-8" }).trim();
-    const pkg = JSON.parse(
-      execSync(`cat ${join(process.cwd(), "package.json")}`, { encoding: "utf-8" })
-    );
+    const pkg = JSON.parse(readFileSync(join(process.cwd(), "package.json"), "utf-8"));
     expect(version).toBe(pkg.version);
   });
 });

--- a/tests/tools/regressions.test.ts
+++ b/tests/tools/regressions.test.ts
@@ -147,6 +147,18 @@ describe("issue #9 — frame export uses the QE DOM and verifies the file landed
       expect(script).toContain("if (!res.ok) return __error(");
     });
   }
+
+  it("sets and restores the AME one-frame range in seconds", () => {
+    const helpers = getHelpersSource();
+
+    // Sequence.setInPoint/setOutPoint accept seconds. Passing ticks here made
+    // the fallback target an enormous range and prevented a still from landing.
+    expect(helpers).toContain("seq.setInPoint(__ticksToSeconds(startTicks))");
+    expect(helpers).toContain("seq.setOutPoint(__ticksToSeconds(startTicks + frameTicks))");
+    expect(helpers).toContain("seq.setInPoint(__ticksToSeconds(savedIn))");
+    expect(helpers).toContain("seq.setOutPoint(__ticksToSeconds(savedOut))");
+    expect(helpers).not.toContain("seq.setInPoint(String(startTicks))");
+  });
 });
 
 // Defects found while reviewing PR #3 (repair 6 broken tools on Premiere Pro 2026).


### PR DESCRIPTION
## What changed

- Fix the issue #9 Media Encoder still-frame fallback to set and restore sequence in/out points in seconds, as required by Premiere's Sequence API, while retaining ticks for the playhead.
- Add a native PowerShell CEP installer for Windows and route `--install-cep` to it.
- Write `PlayerDebugMode` as `REG_SZ` for CSXS 9-14; the previous README instructed Windows users to create a DWORD, which Adobe's CEP setup does not accept for unsigned-extension discovery.
- Align the CEP manifest bundle/extension versions with package version 1.1.5 and add a regression test to keep them synchronized.
- Make two existing tests platform-neutral so the suite passes on Windows.

## Root cause

For issue #9, the QE path correctly fell back when no file was written, but the fallback passed tick values to `Sequence.setInPoint()` and `setOutPoint()`. Those methods take seconds, so the requested one-frame range became enormous and no still landed.

For issue #14, the package's Windows setup path was internally inconsistent: the CLI invoked a Bash script that only enabled debug mode on macOS, while the manual Windows instructions specified DWORD values. Adobe's CEP documentation and sample require `PlayerDebugMode` to be a String value.

## Validation

- `npm run build`
- `npm test` - 315 passing
- CEP manifest validated against Adobe's ExtensionManifest v7 XSD
- PowerShell installer syntax parsed successfully
- `npm pack --dry-run --json` includes `scripts/install-cep.ps1`

## Runtime evidence boundary

This checkout does not have Premiere Pro installed, so the corrected frame export and CEP discovery paths are not claimed as live-verified. The PR removes two concrete API/setup defects and keeps filesystem verification/error diagnostics in place.

Addresses #9 and #14.
