### PR TITLE
Release 1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.1.6] - 2026-07-20
+
+### Fixed
+
+- **Frame capture's Media Encoder fallback now exports exactly one frame.** The fallback passed
+  tick values to sequence in/out methods that require seconds, producing an invalid export range
+  when the undocumented QE frame-export method wrote no file. The range and its saved state are
+  now converted to seconds. ([#9](https://github.com/leancoderkavy/premiere-pro-mcp/issues/9))
+
+- **Windows CEP installation now enables unsigned-extension discovery correctly.** The CLI uses a
+  native PowerShell installer on Windows and creates `PlayerDebugMode` as the `REG_SZ` value Adobe
+  requires. Previous instructions incorrectly specified a DWORD, and the Bash installer never
+  enabled Windows debug mode. ([#14](https://github.com/leancoderkavy/premiere-pro-mcp/issues/14))
+
+- CEP bundle and extension versions now match the npm package version, with regression coverage to
+  prevent future drift.
+
+### Validation
+
+- TypeScript build and 315 automated tests pass. The corrected Premiere runtime paths still require
+  live confirmation on a machine with Premiere Pro installed.
+
 ## [1.1.2] - 2026-07-11
 
 The headline of this release is that the CEP 12 bridge fix from

--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.1.5" ExtensionBundleName="MCP Bridge">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.1.6" ExtensionBundleName="MCP Bridge">
   <ExtensionList>
-    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.1.5"/>
-    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.1.5"/>
+    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.1.6"/>
+    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.1.6"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "premiere-pro-mcp",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "MCP server for controlling Adobe Premiere Pro via CEP/ExtendScript — 269 tools for AI-driven video editing",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Publishes the issue #9 frame-export fallback fix and issue #14 Windows CEP installer fix as npm version 1.1.6. Build and all 315 tests pass; npm publish dry-run succeeds.