### PR TITLE
Improve MCP and bridge performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Performance
+
+- Prefer event-driven bridge response notification with a conservative polling fallback, reducing
+  idle filesystem checks while preserving compatibility with filesystems where watching is
+  unavailable or unreliable.
+- Cache immutable tool catalogs and converted Zod schemas across stateless HTTP server instances.
+  A local 100-iteration benchmark reduced average repeated server construction from 5.87 ms to
+  2.21 ms (62.4%).
+
 ## [1.2.0] - 2026-07-20
 
 ### Added

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,0 +1,34 @@
+# Performance notes
+
+## July 2026 audit
+
+The bridge used synchronous existence checks every 100 ms for every in-flight command. Node's
+filesystem documentation recommends `fs.watch()` over stat polling when possible, while warning
+that watching can be unreliable on some network and virtualized filesystems. The bridge therefore
+uses event notification as the low-latency path and retains a 100 ms initial / 250 ms subsequent
+polling fallback for correctness.
+
+The Streamable HTTP endpoint intentionally remains stateless. The MCP transport specification
+permits servers without session management, but this means each request constructs a new
+`McpServer`. Tool definitions and converted Zod schemas are immutable for a given bridge and
+capability configuration, so they are cached while each request still receives an independent MCP
+server and transport.
+
+Research sources:
+
+- [Node.js filesystem API](https://nodejs.org/api/fs.html#fswatchfilename-options-listener)
+- [MCP Streamable HTTP transport](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports)
+- [Adobe Premiere UXP ESLint and transaction guidance](https://developer.adobe.com/premiere-pro/uxp/resources/fundamentals/eslint-support/)
+
+## Local benchmark
+
+Windows, Node.js 22, 100 `createServer()` calls:
+
+| Path | Average |
+|---|---:|
+| Cache bypassed with unique bridge configurations | 5.873 ms |
+| Reused bridge configuration | 2.208 ms |
+
+This is a 62.4% reduction in repeated server-construction time. It does not measure Premiere host
+execution time or claim equivalent end-to-end editing latency. Bridge watcher behavior is covered
+by unit tests; live CEP latency remains dependent on Premiere and the host filesystem.

--- a/src/bridge/file-bridge.ts
+++ b/src/bridge/file-bridge.ts
@@ -1,10 +1,10 @@
-import { mkdirSync, writeFileSync, readFileSync, unlinkSync, existsSync, readdirSync, statSync, chmodSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, writeFileSync, readFileSync, unlinkSync, existsSync, readdirSync, statSync, chmodSync, watch, FSWatcher } from "node:fs";
+import { basename, dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { getHelpersSource, helpersFileName, buildBootstrap } from "./script-builder.js";
 
 const DEFAULT_TEMP_DIR = join(tmpdir(), "premiere-mcp-bridge");
-const POLL_INTERVAL_MS = 100;
+const POLL_FALLBACK_MS = 250;
 const DEFAULT_TIMEOUT_MS = 30000;
 
 export interface BridgeOptions {
@@ -191,14 +191,35 @@ async function pollForResponse(
   };
 
   return new Promise((resolve) => {
+    let settled = false;
+    let timer: NodeJS.Timeout | undefined;
+    let watcher: FSWatcher | undefined;
+    let fallbackDelay = 100;
+
+    const finish = (result: CommandResult) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      watcher?.close();
+      resolve(result);
+    };
+
+    const scheduleFallback = () => {
+      if (!settled) {
+        timer = setTimeout(check, fallbackDelay);
+        fallbackDelay = POLL_FALLBACK_MS;
+      }
+    };
+
     const check = () => {
+      if (settled) return;
       if (existsSync(resFile)) {
         try {
           const raw = readFileSync(resFile, "utf-8");
           const result = JSON.parse(raw) as CommandResult;
-          resolve(result);
+          finish(result);
         } catch (e) {
-          resolve({
+          finish({
             success: false,
             error: `Failed to parse response: ${e instanceof Error ? e.message : String(e)}`,
           });
@@ -207,13 +228,13 @@ async function pollForResponse(
       }
 
       const elapsed = Date.now() - start;
-      if (elapsed > timeoutMs) {
+      if (elapsed >= timeoutMs) {
         const stillBusy = busyIsFresh();
         if (stillBusy && elapsed <= hardCapMs) {
-          setTimeout(check, POLL_INTERVAL_MS);
+          scheduleFallback();
           return;
         }
-        resolve({
+        finish({
           success: false,
           error: sawBusy
             ? `Premiere accepted the script but did not finish within ${elapsed}ms. ` +
@@ -225,8 +246,24 @@ async function pollForResponse(
         return;
       }
 
-      setTimeout(check, POLL_INTERVAL_MS);
+      scheduleFallback();
     };
+
+    // Prefer event-driven notification for low response latency without constant stat calls.
+    // fs.watch is not reliable on every network/virtual filesystem, so the slower timer above
+    // remains the correctness fallback and also protects against missed/coalesced events.
+    try {
+      const responseName = basename(resFile);
+      watcher = watch(dirname(resFile), { persistent: false }, (_event, filename) => {
+        if (!filename || filename.toString() === responseName) check();
+      });
+      watcher.on("error", () => {
+        watcher?.close();
+        watcher = undefined;
+      });
+    } catch {
+      watcher = undefined;
+    }
 
     check();
   });

--- a/src/server.ts
+++ b/src/server.ts
@@ -103,10 +103,15 @@ interface ToolDef {
   handler: (args: any) => Promise<{ success: boolean; data?: unknown; error?: string }>;
 }
 
+const toolCatalogCache = new Map<string, Record<string, ToolDef>>();
+const schemaCache = new WeakMap<Record<string, unknown>, Record<string, z.ZodTypeAny>>();
+
 /**
  * Convert a JSON Schema-style parameters object to a Zod shape for MCP SDK registration.
  */
 function jsonSchemaToZodShape(params: Record<string, unknown>): Record<string, z.ZodTypeAny> {
+  const cached = schemaCache.get(params);
+  if (cached) return cached;
   const shape: Record<string, z.ZodTypeAny> = {};
   const properties = (params.properties ?? {}) as Record<string, Record<string, unknown>>;
   const required = (params.required ?? []) as string[];
@@ -151,19 +156,23 @@ function jsonSchemaToZodShape(params: Record<string, unknown>): Record<string, z
     shape[key] = zodType;
   }
 
+  schemaCache.set(params, shape);
   return shape;
 }
 
-export function createServer(bridgeOptions: BridgeOptions): McpServer {
-  const server = new McpServer({
-    name: "premiere-pro-mcp",
-    version: "1.2.0",
+function collectTools(
+  bridgeOptions: BridgeOptions,
+  capabilities: ReturnType<typeof resolveCapabilities>,
+): Record<string, ToolDef> {
+  const cacheKey = JSON.stringify({
+    tempDir: bridgeOptions.tempDir ?? process.env.PREMIERE_TEMP_DIR ?? null,
+    timeoutMs: bridgeOptions.timeoutMs ?? process.env.PREMIERE_TIMEOUT_MS ?? null,
+    capabilities: [...capabilities.capabilities].sort(),
   });
+  const cached = toolCatalogCache.get(cacheKey);
+  if (cached) return cached;
 
-  const capabilities = resolveCapabilities();
-
-  // Collect all tools from each module
-  const toolModules: Record<string, ToolDef> = {
+  const tools: Record<string, ToolDef> = {
     ...getDiscoveryTools(bridgeOptions),
     ...getProjectTools(bridgeOptions),
     ...getMediaTools(bridgeOptions),
@@ -194,6 +203,20 @@ export function createServer(bridgeOptions: BridgeOptions): McpServer {
     ...getProjectManagerTools(bridgeOptions),
     ...getEditPlanTools(bridgeOptions, { capabilities }),
   };
+  toolCatalogCache.set(cacheKey, tools);
+  return tools;
+}
+
+export function createServer(bridgeOptions: BridgeOptions): McpServer {
+  const server = new McpServer({
+    name: "premiere-pro-mcp",
+    version: "1.2.0",
+  });
+
+  const capabilities = resolveCapabilities();
+
+  // Collect all tools from each module
+  const toolModules = collectTools(bridgeOptions, capabilities);
 
   // Register each tool with the MCP server
   for (const [name, tool] of Object.entries(toolModules)) {

--- a/tests/bridge/file-bridge.test.ts
+++ b/tests/bridge/file-bridge.test.ts
@@ -8,8 +8,9 @@ import {
   readdirSync,
   statSync,
   chmodSync,
+  watch,
 } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   getTempDir,
@@ -28,6 +29,9 @@ vi.mock("node:fs", () => ({
   readdirSync: vi.fn(),
   statSync: vi.fn(),
   chmodSync: vi.fn(),
+  watch: vi.fn(() => {
+    throw new Error("watch unavailable in unit-test fallback");
+  }),
 }));
 
 const mockedExistsSync = vi.mocked(existsSync);
@@ -38,6 +42,7 @@ const mockedUnlinkSync = vi.mocked(unlinkSync);
 const mockedReaddirSync = vi.mocked(readdirSync);
 const mockedStatSync = vi.mocked(statSync);
 const mockedChmodSync = vi.mocked(chmodSync);
+const mockedWatch = vi.mocked(watch);
 
 // ensureDir on an existing dir stat-checks ownership; default to a dir owned by us
 // with safe perms so the existing tests exercise the happy path.
@@ -180,6 +185,46 @@ describe("sendCommand", () => {
     const result = await promise;
 
     expect(result).toEqual({ success: true, data: { version: "24.0" } });
+  });
+
+  it("attempts event-driven response watching before using the polling fallback", async () => {
+    mockedExistsSync.mockImplementation((path) => String(path).includes("res_"));
+    mockedReadFileSync.mockReturnValue('{"success":true,"data":{}}');
+
+    const promise = sendCommand("test", { tempDir: "/tmp/test-bridge" });
+    await vi.advanceTimersByTimeAsync(100);
+    await promise;
+
+    expect(mockedWatch).toHaveBeenCalledWith(
+      dirname(join("/tmp/test-bridge", "response.json")),
+      { persistent: false },
+      expect.any(Function),
+    );
+  });
+
+  it("resolves immediately when the watcher reports the response file", async () => {
+    let responseExists = false;
+    let onChange: ((event: string, filename: string) => void) | undefined;
+    const fakeWatcher = { on: vi.fn().mockReturnThis(), close: vi.fn() };
+    mockedWatch.mockImplementationOnce(((_path, _options, listener) => {
+      onChange = listener as (event: string, filename: string) => void;
+      return fakeWatcher;
+    }) as typeof watch);
+    mockedExistsSync.mockImplementation((path) =>
+      String(path).includes("res_") ? responseExists : true,
+    );
+    mockedReadFileSync.mockReturnValue('{"success":true,"data":{"eventDriven":true}}');
+
+    const promise = sendCommand("test", { tempDir: "/tmp/test-bridge" });
+    const responsePath = mockedWatch.mock.calls[0]?.[0];
+    expect(responsePath).toBeDefined();
+    responseExists = true;
+    const commandWrite = mockedWriteFileSync.mock.calls.find(([path]) => String(path).includes("cmd_"));
+    const responseName = String(commandWrite?.[0]).replace(/.*[\\/]+cmd_/, "res_").replace(/\.jsx$/, ".json");
+    onChange?.("rename", responseName);
+
+    await expect(promise).resolves.toEqual({ success: true, data: { eventDriven: true } });
+    expect(fakeWatcher.close).toHaveBeenCalled();
   });
 
   it("returns error on JSON parse failure", async () => {


### PR DESCRIPTION
## What changed

- replaces constant 100 ms bridge response polling with event-driven `fs.watch()` notification plus a conservative polling fallback
- caches immutable tool catalogs and converted Zod schemas across stateless HTTP server instances
- adds watcher/fallback regression coverage and documents research and benchmark boundaries

## Why

The CEP bridge repeatedly performed synchronous filesystem checks while commands were in flight, and stateless HTTP requests rebuilt identical tool definitions and schemas. Node recommends filesystem watching over stat polling where supported; the fallback preserves correctness on filesystems where watching is unavailable or unreliable.

## Performance evidence

100 local `createServer()` iterations on Windows / Node.js 22:

- cache bypassed: 5.873 ms average
- reused configuration: 2.208 ms average
- improvement: 62.4%

This benchmark covers server construction only, not Premiere execution latency.

## Validation

- `npm run build`
- `npm test -- --reporter=dot` — 335/335 passed
- `npm pack --dry-run`
- `git diff --check`