### PR TITLE
Verify Premiere mutations and fix audio level writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-07-21
+
 ### Added
 
 - Added `get_capabilities` for machine-readable Windows/macOS runtime, CEP/UXP backend,
@@ -14,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Audio-level writes now convert dB to Premiere's amplitude value and verify the applied value.
+- Audio keyframes now use Premiere `Time` objects and verify each written value.
+- Ripple delete, razor, and native transition tools now verify host state and return actionable
+  errors instead of false success on affected Premiere Pro 26.3 installations. ([#21](https://github.com/leancoderkavy/premiere-pro-mcp/issues/21))
 - Capability profiles now enforce `inspect` and `edit` across the complete tool surface and treat
   expression evaluation as unsafe scripting instead of allowing unclassified tools through.
 - The npm CLI now copies the CEP plugin on macOS, verifies installation metadata, rejects unsupported

--- a/README.md
+++ b/README.md
@@ -27,7 +27,12 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 
 The AI handles the entire workflow through 269 tools spanning the supported ExtendScript, QE DOM, and safe edit-planning surfaces.
 
-### What's new in 1.2.0
+### What's new in 1.2.1
+
+- Mutation tools now verify Premiere state, audio dB is converted to amplitude correctly, and
+  affected Premiere Pro 26.3 hosts return actionable errors instead of false success.
+
+### Added in 1.2.0
 
 - **Safe edit plans:** preview compound insert/remove operations, bind approval to a SHA-256 plan token, then apply the validated plan in one bridge command.
 - **Capability profiles:** unsafe scripting is disabled by default and requires explicit `unsafe-script` authority.
@@ -251,6 +256,14 @@ The file-based IPC bridge is simple, reliable, and works across macOS and Window
 | `split_clip` / `trim_clip` / `move_clip` | Basic edits |
 | `set_clip_properties` | Opacity, scale, rotation, position |
 | `link_selection` / `unlink_selection` | Link/unlink A/V |
+
+> **Premiere Pro 26.3 compatibility:** some installations silently ignore QE structural edits
+> (`ripple_delete`, razor/split) and existing effect-parameter writes. These tools now verify
+> the resulting sequence state and return an error instead of a false success. For structural
+> edits, rebuild the wanted source ranges into a new sequence with `create_sequence` and
+> `add_to_timeline`. Native transitions are unavailable when the host does not expose
+> `qeTrack.addTransition`; overlay clips remain a workaround for transitions that do not need
+> to blend adjacent source frames. See [issue #21](https://github.com/leancoderkavy/premiere-pro-mcp/issues/21).
 
 ### Effects & Color (8)
 

--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.2.0" ExtensionBundleName="MCP Bridge">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.2.1" ExtensionBundleName="MCP Bridge">
   <ExtensionList>
-    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.2.0"/>
-    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.2.0"/>
+    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.2.1"/>
+    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.2.1"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "premiere-pro-mcp",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "MCP server for controlling Adobe Premiere Pro via CEP and UXP — safe, structured AI-driven video editing",
   "main": "dist/index.js",
   "type": "module",

--- a/src/tools/advanced.ts
+++ b/src/tools/advanced.ts
@@ -31,9 +31,14 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
           
           var qeClip = qeTrack.getItemAt(result.clipIndex);
           if (!qeClip) return __error("QE clip not found");
-          
+
+          var deletedNodeId = result.clip.nodeId;
+          var deletedName = result.clip.name;
           qeClip.rippleDelete();
-          return __result({ rippleDeleted: true, clipName: result.clip.name });
+          if (__findClip(deletedNodeId)) {
+            return __error("Premiere reported rippleDelete but the clip is still present. Structural QE edits are known to no-op on some Premiere Pro 26.3 installations; rebuild the keep-segments into a new sequence as a workaround.");
+          }
+          return __result({ rippleDeleted: true, verified: true, clipName: deletedName });
         `);
         return sendCommand(script, bridgeOptions);
       },

--- a/src/tools/audio.ts
+++ b/src/tools/audio.ts
@@ -20,6 +20,7 @@ export function getAudioTools(bridgeOptions: BridgeOptions) {
         required: ["node_id", "level_db"],
       },
       handler: async (args: { node_id: string; level_db: number }) => {
+        const amplitude = Math.pow(10, args.level_db / 20);
         const script = buildToolScript(`
           var result = __findClip("${escapeForExtendScript(args.node_id)}");
           if (!result) return __error("Clip not found");
@@ -31,8 +32,14 @@ export function getAudioTools(bridgeOptions: BridgeOptions) {
             if (comp.displayName === "Volume" || comp.matchName === "audioVolume") {
               for (var p = 0; p < comp.properties.numItems; p++) {
                 if (comp.properties[p].displayName === "Level") {
-                  comp.properties[p].setValue(${args.level_db}, true);
-                  return __result({ adjusted: true, clipName: clip.name, levelDb: ${args.level_db} });
+                  var levelProp = comp.properties[p];
+                  var requestedAmplitude = ${amplitude};
+                  var writeResult = levelProp.setValue(requestedAmplitude, true);
+                  var appliedAmplitude = Number(levelProp.getValue());
+                  if (isNaN(appliedAmplitude) || Math.abs(appliedAmplitude - requestedAmplitude) > 0.0001) {
+                    return __error("Premiere did not apply the requested audio level (requested " + requestedAmplitude + ", read back " + appliedAmplitude + "). Effect-property writes are known to no-op on some Premiere Pro 26.3 installations.");
+                  }
+                  return __result({ adjusted: true, verified: true, clipName: clip.name, levelDb: ${args.level_db}, amplitude: appliedAmplitude, writeResult: writeResult });
                 }
               }
             }
@@ -77,12 +84,17 @@ export function getAudioTools(bridgeOptions: BridgeOptions) {
             const amp = Math.max(Math.pow(10, kf.level_db / 20), 0.0000001);
             return `
             (function() {
-              var kfTime = __secondsToTicks(${kf.time_seconds});
-              var t = kfTime;
-              if (typeof kfTime === "object" && kfTime.toString) t = kfTime.toString();
+              var t = new Time();
+              t.ticks = __secondsToTicks(${kf.time_seconds}).toString();
+              var wrote = false;
               try { levelProp.addKey(t); } catch(e1) {}
-              try { levelProp.setValueAtKey(t, ${amp}, 1); }
-              catch(e2) { try { levelProp.setValueAtTime(t, ${amp}); } catch(e3) {} }
+              try { levelProp.setValueAtKey(t, ${amp}, 1); wrote = true; }
+              catch(e2) { try { levelProp.setValueAtTime(t, ${amp}, 1); wrote = true; } catch(e3) {} }
+              var readBack = NaN;
+              try { readBack = Number(levelProp.getValueAtTime(t)); } catch(e4) {}
+              if (!wrote || isNaN(readBack) || Math.abs(readBack - ${amp}) > 0.0001) {
+                verificationErrors.push("${kf.time_seconds}s requested ${amp}, read back " + readBack);
+              }
             })();`;
           })
           .join("\n");
@@ -108,10 +120,14 @@ export function getAudioTools(bridgeOptions: BridgeOptions) {
 
           if (!levelProp) return __error("Could not find audio Level property");
 
+          var verificationErrors = [];
           try { levelProp.setTimeVarying(true); } catch(e) {}
           ${keyframeCode}
 
-          return __result({ keyframesAdded: ${args.keyframes.length}, clipName: clip.name });
+          if (verificationErrors.length) {
+            return __error("Premiere did not apply one or more audio keyframes: " + verificationErrors.join("; ") + ". Effect-property writes are known to no-op on some Premiere Pro 26.3 installations.");
+          }
+          return __result({ keyframesAdded: ${args.keyframes.length}, verified: true, clipName: clip.name });
         `);
         return sendCommand(script, bridgeOptions);
       },

--- a/src/tools/timeline.ts
+++ b/src/tools/timeline.ts
@@ -202,11 +202,17 @@ export function getTimelineTools(bridgeOptions: BridgeOptions) {
           
           var track = ${trackType === "video" ? `seq.getVideoTrackAt(${trackIndex})` : `seq.getAudioTrackAt(${trackIndex})`};
           if (!track) return __error("Track not found");
-          
+
+          var domTrack = ${trackType === "video" ? `app.project.activeSequence.videoTracks[${trackIndex}]` : `app.project.activeSequence.audioTracks[${trackIndex}]`};
+          var clipCountBefore = domTrack.clips.numItems;
           var timeTicks = __secondsToTicks(${args.time_seconds}).toString();
           track.razor(timeTicks);
-          
-          return __result({ split: true, atSeconds: ${args.time_seconds}, trackIndex: ${trackIndex}, trackType: "${trackType}" });
+
+          var clipCountAfter = domTrack.clips.numItems;
+          if (clipCountAfter <= clipCountBefore) {
+            return __error("Premiere reported razor but the track clip count did not change. Structural QE edits are known to no-op on some Premiere Pro 26.3 installations.");
+          }
+          return __result({ split: true, verified: true, atSeconds: ${args.time_seconds}, trackIndex: ${trackIndex}, trackType: "${trackType}" });
         `);
         return sendCommand(script, bridgeOptions);
       },

--- a/src/tools/transitions.ts
+++ b/src/tools/transitions.ts
@@ -71,10 +71,20 @@ export function getTransitionsTools(bridgeOptions: BridgeOptions) {
           var cutTicks = __secondsToTicks(${args.cut_point_seconds}).toString();
           var durationTicks = __secondsToTicks(${duration}).toString();
 
+          if (typeof qeTrack.addTransition !== "function") {
+            return __error("This Premiere build does not expose qeTrack.addTransition; native transition writes are unavailable (confirmed on Premiere Pro 26.3). Use an overlay clip where possible.");
+          }
+          var domTrack = app.project.activeSequence.videoTracks[${args.track_index}];
+          var transitionCountBefore = domTrack.transitions.numItems;
           qeTrack.addTransition(transitionQE, true, cutTicks, durationTicks, "0", false);
+
+          if (domTrack.transitions.numItems <= transitionCountBefore) {
+            return __error("Premiere accepted addTransition but no transition appeared on the track.");
+          }
 
           return __result({
             added: true,
+            verified: true,
             transition: transitionName,
             trackIndex: ${args.track_index},
             atSeconds: ${args.cut_point_seconds},
@@ -141,6 +151,11 @@ export function getTransitionsTools(bridgeOptions: BridgeOptions) {
           if (!transitionQE) return __error("Transition not found: " + transitionName);
 
           var qeTrack = qeSeq.getVideoTrackAt(result.trackIndex);
+          if (!qeTrack || typeof qeTrack.addTransition !== "function") {
+            return __error("This Premiere build does not expose qeTrack.addTransition; native transition writes are unavailable (confirmed on Premiere Pro 26.3). Use an overlay clip where possible.");
+          }
+          var domTrack = app.project.activeSequence.videoTracks[result.trackIndex];
+          var transitionCountBefore = domTrack.transitions.numItems;
           var durationTicks = __secondsToTicks(${duration}).toString();
           var clip = result.clip;
           var position = "${position}";
@@ -153,9 +168,14 @@ export function getTransitionsTools(bridgeOptions: BridgeOptions) {
             var endTicks = clip.end.ticks;
             qeTrack.addTransition(transitionQE, true, endTicks, durationTicks, "0", false);
           }
+
+          if (domTrack.transitions.numItems <= transitionCountBefore) {
+            return __error("Premiere accepted addTransition but no transition appeared on the track.");
+          }
           
           return __result({
             added: true,
+            verified: true,
             transition: transitionName,
             clipName: clip.name,
             position: position,
@@ -217,7 +237,11 @@ export function getTransitionsTools(bridgeOptions: BridgeOptions) {
 
           var track = seq.videoTracks[${trackIndex}];
           var qeTrack = qeSeq.getVideoTrackAt(${trackIndex});
+          if (!qeTrack || typeof qeTrack.addTransition !== "function") {
+            return __error("This Premiere build does not expose qeTrack.addTransition; native transition writes are unavailable (confirmed on Premiere Pro 26.3). Use overlay clips where possible.");
+          }
           var durationTicks = __secondsToTicks(${duration}).toString();
+          var transitionCountBefore = track.transitions.numItems;
           var count = 0;
           
           // Add transition at each cut point (between consecutive clips)
@@ -228,9 +252,16 @@ export function getTransitionsTools(bridgeOptions: BridgeOptions) {
               count++;
             } catch(e) {}
           }
+
+          var transitionCountAfter = track.transitions.numItems;
+          var verifiedCount = transitionCountAfter - transitionCountBefore;
+          if (verifiedCount !== count) {
+            return __error("Premiere reported " + count + " transition writes but only " + verifiedCount + " appeared on the track.");
+          }
           
           return __result({
-            added: count,
+            added: verifiedCount,
+            verified: true,
             transition: transitionName,
             trackIndex: ${trackIndex},
             durationSeconds: ${duration}

--- a/tests/tools/tool-modules.test.ts
+++ b/tests/tools/tool-modules.test.ts
@@ -277,6 +277,54 @@ describe("Tool Handler Behavior", () => {
     });
   });
 
+  describe("verified Premiere mutations", () => {
+    it("converts audio dB to amplitude and verifies the readback", async () => {
+      const tools = getAudioTools(bridgeOptions);
+      await (tools.adjust_audio_levels.handler as any)({ node_id: "clip-1", level_db: -6 });
+      const script = mockedSendCommand.mock.calls[0][0];
+      expect(script).toContain("requestedAmplitude");
+      expect(script).toContain("levelProp.getValue()");
+      expect(script).toContain("Premiere did not apply the requested audio level");
+      expect(script).toContain("0.501187");
+    });
+
+    it("uses Time objects and verifies audio keyframe values", async () => {
+      const tools = getAudioTools(bridgeOptions);
+      await (tools.add_audio_keyframes.handler as any)({
+        node_id: "clip-1",
+        keyframes: [{ time_seconds: 1.5, level_db: -12 }],
+      });
+      const script = mockedSendCommand.mock.calls[0][0];
+      expect(script).toContain("new Time()");
+      expect(script).toContain("getValueAtTime(t)");
+      expect(script).toContain("verificationErrors");
+    });
+
+    it("verifies ripple delete and razor postconditions", async () => {
+      await (getAdvancedTools(bridgeOptions).ripple_delete.handler as any)({ node_id: "clip-1" });
+      let script = mockedSendCommand.mock.calls[0][0];
+      expect(script).toContain("if (__findClip(deletedNodeId))");
+
+      vi.clearAllMocks();
+      await (getTimelineTools(bridgeOptions).split_clip.handler as any)({ time_seconds: 2 });
+      script = mockedSendCommand.mock.calls[0][0];
+      expect(script).toContain("clipCountAfter <= clipCountBefore");
+    });
+
+    it("checks transition API availability and verifies track state", async () => {
+      const tools = getTransitionsTools(bridgeOptions);
+      await (tools.add_transition.handler as any)({
+        transition_name: "Cross Dissolve",
+        track_index: 0,
+        cut_point_seconds: 2,
+      });
+      const script = mockedSendCommand.mock.calls[0][0];
+      expect(script).toContain('typeof qeTrack.addTransition !== "function"');
+      expect(script).toContain("transitionCountBefore");
+      expect(script).toContain("domTrack.transitions.numItems <= transitionCountBefore");
+    });
+  });
+
   describe("discovery tools", () => {
     it("get_project_info generates correct script", async () => {
       const tools = getDiscoveryTools(bridgeOptions);

--- a/uxp-plugin/manifest.json
+++ b/uxp-plugin/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.ppmcp.premiere.uxp",
   "name": "Premiere Pro MCP Bridge",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "main": "index.html",
   "host": { "app": "premierepro", "minVersion": "25.6.0" },
   "entrypoints": [


### PR DESCRIPTION
## What changed
- convert requested audio dB values to Premiere amplitude values and verify readback
- write audio keyframes with Premiere `Time` objects and verify every keyframe
- verify ripple-delete, razor, and transition postconditions instead of returning false success
- return actionable Premiere Pro 26.3 compatibility errors and document workarounds
- prepare aligned npm, CEP, and UXP version 1.2.1

## Root cause
`adjust_audio_levels` passed dB directly to a parameter that expects amplitude. Separately, Premiere Pro 26.3 can accept QE/effect writes without mutating sequence state, while `qeTrack.addTransition` may be absent entirely. The affected tools trusted method return/absence-of-throw instead of independently reading host state.

## Validation
- `npm run build`
- `npm test` (346 passed)
- `npm pack --dry-run` (104 packaged files)
- `git diff --check`

Closes #21