### PR TITLE
Upgrade toolchain to TS7/Vitest4/Zod4 and align schema/docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded toolchain dependencies to TypeScript 7, Vitest 4, Zod 4, `@types/node` 26, and
+  `@modelcontextprotocol/sdk` 1.29 in `package.json` and synchronized `package-lock.json`.
+
+### Fixed
+
+- Added `"types": ["node"]` to `tsconfig.json` so TypeScript 7 resolves Node built-in module
+  imports and globals during compilation.
+- Updated JSON-schema conversion in `src/server.ts` for Zod 4's `z.record(keyType, valueType)`
+  signature when handling open object maps.
+
+### Validation
+
+- `npm run build` passes with TypeScript 7.
+- `npm test` passes with Vitest 4 (12 files, 346 tests).
+
 ## [1.2.1] - 2026-07-21
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,16 +8,16 @@ Thanks for your interest in contributing! This guide covers how to get set up an
 
 - Node.js 18+
 - Adobe Premiere Pro 2020+ (for testing)
-- An MCP-compatible client (Claude Desktop, Windsurf, Cursor, etc.)
+- An MCP-compatible client (Claude Desktop, Windsurf, Cursor, GitHub Copilot, etc.)
 
 ### Getting started
 
 ```bash
-git clone https://github.com/ppmcp/premiere-pro-mcp.git
+git clone https://github.com/leancoderkavy/premiere-pro-mcp.git
 cd premiere-pro-mcp
 npm install
 npm run dev          # Watch mode — recompiles on changes
-npm run install-cep  # Symlink CEP plugin into Premiere Pro
+npm run install-cep  # Install CEP plugin into Premiere Pro
 ```
 
 After making changes, restart your MCP client to pick up the new tools.
@@ -31,7 +31,7 @@ src/
 ├── bridge/
 │   ├── file-bridge.ts    # File-based IPC (.jsx → .json)
 │   └── script-builder.ts # Generates ES3 ExtendScript with helpers
-└── tools/                # 28 tool modules
+└── tools/                # 29 tool modules
 ```
 
 ### How tools work
@@ -134,7 +134,7 @@ When filing an issue, please include:
 
 - Premiere Pro version
 - OS (macOS/Windows)
-- MCP client (Claude Desktop, Windsurf, Cursor, etc.)
+- MCP client (Claude Desktop, Windsurf, Cursor, GitHub Copilot, etc.)
 - The tool name and parameters you used
 - The error message or unexpected behavior
 - Whether the CEP panel shows "Running"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Node.js](https://img.shields.io/badge/Node.js-18%2B-green.svg)](https://nodejs.org)
-[![MCP](https://img.shields.io/badge/MCP-1.27-purple.svg)](https://modelcontextprotocol.io)
+[![MCP](https://img.shields.io/badge/MCP-1.29-purple.svg)](https://modelcontextprotocol.io)
 [![npm](https://img.shields.io/npm/v/premiere-pro-mcp.svg)](https://www.npmjs.com/package/premiere-pro-mcp)
 [![Fly.io](https://img.shields.io/badge/Fly.io-deployed-7C3AED.svg)](https://premiere-pro-mcp.fly.dev)
 [![Premiere Pro](https://img.shields.io/badge/Premiere%20Pro-2020--2026-9999FF.svg)](https://www.adobe.com/products/premiere.html)
@@ -19,9 +19,9 @@
 
 ## What is this?
 
-An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that lets AI assistants like **Claude**, **Windsurf**, **Cursor**, or any MCP-compatible client directly control Adobe Premiere Pro — importing media, editing timelines, applying effects, managing keyframes, exporting, and more.
+An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that lets AI assistants like **Claude**, **Windsurf**, **Cursor**, **GitHub Copilot**, or any MCP-compatible client directly control Adobe Premiere Pro — importing media, editing timelines, applying effects, managing keyframes, exporting, and more.
 
-```
+```text
 "Add the B-roll clips to V2, apply a cross dissolve between each, color correct them to match the A-roll, and export a 1080p ProRes."
 ```
 
@@ -54,7 +54,7 @@ npm install -g premiere-pro-mcp
 **Option B — Clone from source:**
 
 ```bash
-git clone https://github.com/ppmcp/premiere-pro-mcp.git
+git clone https://github.com/leancoderkavy/premiere-pro-mcp.git
 cd premiere-pro-mcp
 npm install
 npm run build
@@ -155,6 +155,24 @@ Add to `.cursor/mcp.json` in your project or global config:
 
 </details>
 
+<details>
+<summary><strong>GitHub Copilot (VS Code)</strong></summary>
+
+Add to your VS Code MCP server configuration:
+
+```json
+{
+  "mcpServers": {
+    "premiere-pro": {
+      "command": "node",
+      "args": ["/absolute/path/to/premiere-pro-mcp/dist/index.js"]
+    }
+  }
+}
+```
+
+</details>
+
 ### 4. Verify the bridge in Premiere Pro
 
 1. Open (or restart) Premiere Pro
@@ -167,7 +185,7 @@ The default bridge directory is derived from the operating system on both sides,
 ### Windows and macOS capability coverage
 
 | Surface | Windows | macOS | Verification boundary |
-|---|---|---|---|
+| :------ | :------ | :---- | :-------------------- |
 | CEP production bridge | Premiere Pro 2020–2026 | Premiere Pro 2020–2026 | Run `get_capabilities`, then `ping` with Premiere open |
 | UXP preview bridge | Premiere Pro 25.6+ | Premiere Pro 25.6+ | Live loopback WebSocket and host API verification required |
 | npm CEP installer | Copies plugin and verifies `REG_SZ` debug keys | Copies plugin and verifies the installed manifest/debug settings | Restart Premiere after installation |
@@ -180,28 +198,31 @@ The default bridge directory is derived from the operating system on both sides,
 ## Architecture
 
 **Local (stdio):**
-```
-┌───────────────┐   stdio (MCP)   ┌──────────────┐   File-based IPC   ┌──────────────┐
-│  AI Client    │ ◄──────────────► │  MCP Server  │ ◄────────────────► │  CEP Plugin  │
+
+```text
+┌───────────────┐   stdio (MCP)    ┌──────────────┐   File-based IPC   ┌───────────────┐
+│  AI Client    │ ◄──────────────► │  MCP Server  │ ◄────────────────► │  CEP Plugin   │
 │  (Claude,     │                  │  (Node.js /  │   .jsx commands    │  (runs inside │
-│   Windsurf,   │                  │   TypeScript) │   .json responses  │   Premiere)   │
-│   Cursor)     │                  └──────────────┘                    └──────┬────────┘
+│   Windsurf,   │                  │  TypeScript) │   .json responses  │  Premiere)    │
+│   Cursor,     │                  └──────────────┘                    └──────┬────────┘
+│   Copilot)    │                                                             │
 └───────────────┘                                                             │ evalScript()
                                                                               ▼
-                                                                       ┌──────────────┐
+                                                                       ┌───────────────┐
                                                                        │  Premiere Pro │
                                                                        │  ExtendScript │
                                                                        │  + QE DOM     │
-                                                                       └──────────────┘
+                                                                       └───────────────┘
 ```
 
 **Remote (HTTP/SSE — Fly.io):**
-```
+
+```text
 ┌───────────────┐  HTTP+SSE (MCP)  ┌─────────────────────┐   File-based IPC   ┌──────────────┐
-│  AI Client    │ ◄───────────────► │  MCP Server         │ ◄────────────────► │  CEP Plugin  │
-│  (any MCP     │                   │  premiere-pro-mcp   │   .jsx / .json     │  (Premiere)  │
-│   client)     │                   │  .fly.dev           │   shared volume    └──────────────┘
-└───────────────┘                   └─────────────────────┘
+│  AI Client    │ ◄──────────────► │  MCP Server         │ ◄────────────────► │  CEP Plugin  │
+│  (any MCP     │                  │  premiere-pro-mcp   │   .jsx / .json     │  (Premiere)  │
+│   client)     │                  │  .fly.dev           │   shared volume    └──────────────┘
+└───────────────┘                  └─────────────────────┘
 ```
 
 1. AI client invokes an MCP tool (e.g., `add_to_timeline`)
@@ -214,12 +235,12 @@ The file-based IPC bridge is simple, reliable, and works across macOS and Window
 
 ---
 
-## Tools (268)
+## Tools (269)
 
 ### Discovery & Inspection (10 + 10)
 
 | Tool | Description |
-|------|-------------|
+| :--- | :---------- |
 | `get_project_info` | Current project name, path, sequences, items |
 | `get_active_sequence` | Detailed active sequence with all clips |
 | `list_project_items` | All items in the project panel |
@@ -234,7 +255,7 @@ The file-based IPC bridge is simple, reliable, and works across macOS and Window
 ### Project Management (26)
 
 | Tool | Description |
-|------|-------------|
+| :--- | :---------- |
 | `save_project` / `save_project_as` / `open_project` | File operations |
 | `create_project` / `close_project` | Project lifecycle |
 | `import_media` / `import_folder` / `import_ae_comps` | Import media and AE comps |
@@ -247,7 +268,7 @@ The file-based IPC bridge is simple, reliable, and works across macOS and Window
 ### Timeline & Editing (10 + 27 advanced)
 
 | Tool | Description |
-|------|-------------|
+| :--- | :---------- |
 | `add_to_timeline` / `overwrite_clip` | Insert and overwrite edits |
 | `ripple_delete` | Remove clip and close gap (QE) |
 | `roll_edit` / `slide_edit` / `slip_edit` | Professional trim modes (QE) |
@@ -268,7 +289,7 @@ The file-based IPC bridge is simple, reliable, and works across macOS and Window
 ### Effects & Color (8)
 
 | Tool | Description |
-|------|-------------|
+| :--- | :---------- |
 | `apply_effect` / `apply_audio_effect` | Apply by name (QE) |
 | `remove_effect` / `remove_all_effects` | Remove effects |
 | `color_correct` | Lumetri: exposure, contrast, temperature, etc. |
@@ -278,7 +299,7 @@ The file-based IPC bridge is simple, reliable, and works across macOS and Window
 ### Keyframes (8)
 
 | Tool | Description |
-|------|-------------|
+| :--- | :---------- |
 | `add_keyframe` / `get_keyframes` | Create and read keyframes |
 | `remove_keyframe` / `remove_keyframe_range` | Delete keyframes |
 | `set_keyframe_interpolation` | Linear / Hold / Bezier |
@@ -288,7 +309,7 @@ The file-based IPC bridge is simple, reliable, and works across macOS and Window
 ### Export & Encoding (14)
 
 | Tool | Description |
-|------|-------------|
+| :--- | :---------- |
 | `export_sequence` | Export via Adobe Media Encoder |
 | `capture_frame` | Export frame as PNG, return as base64 image |
 | `export_as_fcp_xml` / `export_aaf` / `export_omf` | Interchange formats |
@@ -298,7 +319,7 @@ The file-based IPC bridge is simple, reliable, and works across macOS and Window
 ### Source Monitor & Playback (7 + 4)
 
 | Tool | Description |
-|------|-------------|
+| :--- | :---------- |
 | `open_in_source` / `close_source_monitor` | Source monitor control |
 | `insert_from_source` / `overwrite_from_source` | 3-point editing |
 | `play_timeline` / `stop_playback` | Playback control (QE) |
@@ -307,7 +328,7 @@ The file-based IPC bridge is simple, reliable, and works across macOS and Window
 ### Selection & Clipboard (7 + 6)
 
 | Tool | Description |
-|------|-------------|
+| :--- | :---------- |
 | `select_clips_by_name` / `select_clips_in_range` | Smart selection |
 | `copy_effects_between_clips` | Copy effects via QE |
 | `batch_apply_effect` | Apply effect to multiple clips |
@@ -316,7 +337,7 @@ The file-based IPC bridge is simple, reliable, and works across macOS and Window
 ### Media Properties (16)
 
 | Tool | Description |
-|------|-------------|
+| :--- | :---------- |
 | `set_offline` / `has_proxy` / `detach_proxy` | Offline/proxy management |
 | `set_override_frame_rate` | Override FPS |
 | `set_scale_to_frame_size` | Auto-scale to sequence frame |
@@ -326,7 +347,7 @@ The file-based IPC bridge is simple, reliable, and works across macOS and Window
 ### Sequence Management (11)
 
 | Tool | Description |
-|------|-------------|
+| :--- | :---------- |
 | `create_sequence` / `create_sequence_from_preset` | Create sequences from `.sqpreset` files without opening Premiere's modal dialog |
 | `duplicate_sequence` / `delete_sequence` | Manage sequences |
 | `auto_reframe_sequence` | Auto-reframe for social media |
@@ -336,14 +357,14 @@ The file-based IPC bridge is simple, reliable, and works across macOS and Window
 ### Workspace & Captions (2 + 1)
 
 | Tool | Description |
-|------|-------------|
+| :--- | :---------- |
 | `get_workspaces` / `set_workspace` | Switch workspace layouts |
 | `create_caption_track` | Create caption/subtitle tracks |
 
 ### Scripting (6)
 
 | Tool | Description |
-|------|-------------|
+| :--- | :----------- |
 | `execute_extendscript` | Run arbitrary ExtendScript (ES3) |
 | `evaluate_expression` | Quick one-line eval |
 | `send_raw_script` | Bypass security validation (advanced) |
@@ -359,7 +380,7 @@ Track targeting, batch operations, markers, audio levels, motion/transform, meta
 The server exposes three LLM context resources and four workflow prompts:
 
 | Resource URI | Description |
-|-------------|-------------|
+| :----------- | :---------- |
 | `config://premiere-instructions` | Best practices: workflow order, timeline rules, effect tips, error handling |
 | `config://extendscript-reference` | Complete ExtendScript API reference for writing custom scripts |
 | `config://premiere-workflows` | Machine-readable catalog for rough cuts, dialogue cleanup, captions, and delivery |
@@ -391,7 +412,7 @@ A live instance is running at **https://premiere-pro-mcp.fly.dev**.
 
 ```bash
 # Clone and deploy your own instance
-git clone https://github.com/ppmcp/premiere-pro-mcp.git
+git clone https://github.com/leancoderkavy/premiere-pro-mcp.git
 cd premiere-pro-mcp
 fly apps create your-app-name
 # Required: add bearer token auth
@@ -400,6 +421,7 @@ fly deploy --remote-only
 ```
 
 Then connect with:
+
 ```json
 {
   "mcpServers": {
@@ -419,11 +441,12 @@ Then connect with:
 ## Environment Variables
 
 | Variable | Description | Default |
-|----------|-------------|--------|
+| :------- | :---------- | :------ |
 | `PREMIERE_TEMP_DIR` | Shared temp directory for MCP ↔ CEP communication | OS temp dir + `/premiere-mcp-bridge` |
 | `PREMIERE_TIMEOUT_MS` | Command timeout in milliseconds | `30000` |
 | `PREMIERE_DEFAULT_SEQUENCE_PRESET` | Override the auto-discovered `.sqpreset` used by `create_sequence` | auto-discovered |
 | `PREMIERE_MCP_CAPABILITIES` | Comma-separated authority profile; add `unsafe-script` only when raw scripting is required | `inspect,edit,export,filesystem` |
+| `PREMIERE_MCP_DEBUG` | Set to `1` (or `true`) to emit verbose server diagnostics to stderr | unset |
 | `PORT` | HTTP port (HTTP/SSE transport only) | `3000` |
 | `MCP_AUTH_TOKEN` | Bearer token required by the HTTP transport | unset |
 | `ALLOW_UNAUTHENTICATED` | Set to `1` to run HTTP without auth (unsafe; throwaway instances only) | unset |
@@ -432,16 +455,16 @@ Then connect with:
 
 ## Project Structure
 
-```
+```text
 premiere-pro-mcp/
 ├── src/
 │   ├── index.ts                 # Entry point — stdio transport setup
 │   ├── http-server.ts           # Entry point — HTTP/SSE transport (Fly.io / remote)
-│   ├── server.ts                # MCP server — registers 268 tools + 3 resources + 4 prompts
+│   ├── server.ts                # MCP server — registers 269 tools + 3 resources + 4 prompts
 │   ├── bridge/
 │   │   ├── file-bridge.ts       # File-based IPC (write .jsx, poll .json)
 │   │   └── script-builder.ts    # ExtendScript generator with ES3 helpers
-│   ├── tools/                   # 28 tool modules
+│   ├── tools/                   # 29 tool modules
 │   │   ├── discovery.ts         # Project discovery and queries
 │   │   ├── project.ts           # Project management and import
 │   │   ├── media.ts             # Media and proxy management

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,435 +9,53 @@
       "version": "1.2.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.12.1",
-        "zod": "^3.23.0"
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.4.3"
       },
       "bin": {
         "premiere-pro-mcp": "dist/index.js"
       },
       "devDependencies": {
-        "@types/node": "^22.10.0",
-        "typescript": "^5.7.0",
-        "vitest": "^3.2.7"
+        "@types/node": "^26.1.1",
+        "typescript": "^7.0.2",
+        "vitest": "^4.1.10"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
-      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
-      "cpu": [
-        "ppc64"
-      ],
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
-      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
-      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
-      "cpu": [
-        "arm64"
-      ],
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
-      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
-      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
-      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
-      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
-      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
-      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
-      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
-      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
-      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
-      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
-      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
-      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
-      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
-      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
-      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
-      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
-      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
-      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
-      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@hono/node-server": {
@@ -456,12 +74,13 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.1",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
-      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -498,336 +117,341 @@
         }
       }
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
-      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ]
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
     },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
-      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
-      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
-      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
-      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
-      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
-      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
-      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
-      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
-      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
-      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
-      "cpu": [
-        "loong64"
+      "libc": [
+        "musl"
       ],
-      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
-      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
-      "cpu": [
-        "loong64"
       ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
-      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
-      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
-      "cpu": [
-        "ppc64"
+      "libc": [
+        "glibc"
       ],
-      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
-      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
-      "cpu": [
-        "riscv64"
       ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
-      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
-      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
-      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
-      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
-      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
-      "cpu": [
-        "x64"
       ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
-      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
-      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
-      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
-      "cpu": [
-        "ia32"
       ],
-      "dev": true,
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
-      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
-      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
-      "cpu": [
-        "x64"
       ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
       "optional": true,
-      "os": [
-        "win32"
-      ]
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
@@ -837,56 +461,401 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.13",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
-      "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
-      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.7",
-        "@vitest/utils": "3.2.7",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
-      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.7",
+        "@vitest/spy": "4.1.10",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
+        "magic-string": "^0.30.21"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -898,39 +867,42 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
-      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^2.0.0"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
-      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.7",
-        "pathe": "^2.0.3",
-        "strip-literal": "^3.0.0"
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
-      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.7",
-        "magic-string": "^0.30.17",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -938,26 +910,25 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
-      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
       "dev": true,
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
+      "license": "MIT",
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
-      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.7",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -1014,6 +985,7 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
@@ -1051,15 +1023,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1090,28 +1053,13 @@
       }
     },
     "node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
+      "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 16"
       }
     },
     "node_modules/content-disposition": {
@@ -1135,6 +1083,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cookie": {
       "version": "0.7.2",
@@ -1202,15 +1157,6 @@
         }
       }
     },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -1218,6 +1164,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -1268,10 +1224,11 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-      "dev": true
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -1285,47 +1242,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/esbuild": {
-      "version": "0.28.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
-      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.1",
-        "@esbuild/android-arm": "0.28.1",
-        "@esbuild/android-arm64": "0.28.1",
-        "@esbuild/android-x64": "0.28.1",
-        "@esbuild/darwin-arm64": "0.28.1",
-        "@esbuild/darwin-x64": "0.28.1",
-        "@esbuild/freebsd-arm64": "0.28.1",
-        "@esbuild/freebsd-x64": "0.28.1",
-        "@esbuild/linux-arm": "0.28.1",
-        "@esbuild/linux-arm64": "0.28.1",
-        "@esbuild/linux-ia32": "0.28.1",
-        "@esbuild/linux-loong64": "0.28.1",
-        "@esbuild/linux-mips64el": "0.28.1",
-        "@esbuild/linux-ppc64": "0.28.1",
-        "@esbuild/linux-riscv64": "0.28.1",
-        "@esbuild/linux-s390x": "0.28.1",
-        "@esbuild/linux-x64": "0.28.1",
-        "@esbuild/netbsd-arm64": "0.28.1",
-        "@esbuild/netbsd-x64": "0.28.1",
-        "@esbuild/openbsd-arm64": "0.28.1",
-        "@esbuild/openbsd-x64": "0.28.1",
-        "@esbuild/openharmony-arm64": "0.28.1",
-        "@esbuild/sunos-x64": "0.28.1",
-        "@esbuild/win32-arm64": "0.28.1",
-        "@esbuild/win32-ia32": "0.28.1",
-        "@esbuild/win32-x64": "0.28.1"
-      }
-    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1337,6 +1253,7 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
@@ -1469,6 +1386,7 @@
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
       },
@@ -1526,6 +1444,7 @@
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1706,12 +1625,6 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true
-    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -1724,17 +1637,285 @@
       "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
       "license": "BSD-2-Clause"
     },
-    "node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
@@ -1811,6 +1992,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -1846,6 +2028,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/on-finished": {
@@ -1901,28 +2097,22 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true
-    },
-    "node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "dev": true,
-      "engines": {
-        "node": ">= 14.16"
-      }
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -1940,9 +2130,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
       "dev": true,
       "funding": [
         {
@@ -1958,6 +2148,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
@@ -2029,48 +2220,38 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.62.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
-      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.9"
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.62.2",
-        "@rollup/rollup-android-arm64": "4.62.2",
-        "@rollup/rollup-darwin-arm64": "4.62.2",
-        "@rollup/rollup-darwin-x64": "4.62.2",
-        "@rollup/rollup-freebsd-arm64": "4.62.2",
-        "@rollup/rollup-freebsd-x64": "4.62.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
-        "@rollup/rollup-linux-arm64-musl": "4.62.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
-        "@rollup/rollup-linux-loong64-musl": "4.62.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
-        "@rollup/rollup-linux-x64-gnu": "4.62.2",
-        "@rollup/rollup-linux-x64-musl": "4.62.2",
-        "@rollup/rollup-openbsd-x64": "4.62.2",
-        "@rollup/rollup-openharmony-arm64": "4.62.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
-        "@rollup/rollup-win32-x64-gnu": "4.62.2",
-        "@rollup/rollup-win32-x64-msvc": "4.62.2",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
       }
     },
     "node_modules/router": {
@@ -2251,6 +2432,7 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2272,22 +2454,11 @@
       }
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-      "dev": true
-    },
-    "node_modules/strip-literal": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -2297,16 +2468,21 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-      "dev": true
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
       "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.4"
@@ -2318,29 +2494,12 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-      "dev": true,
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
     "node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tinyspy": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
-      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -2353,6 +2512,14 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/type-is": {
       "version": "2.0.1",
@@ -2369,23 +2536,44 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+        "tsc": "bin/tsc"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2408,17 +2596,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.6",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
-      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.27.0 || ^0.28.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -2434,9 +2622,10 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -2449,13 +2638,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -2481,87 +2673,80 @@
         }
       }
     },
-    "node_modules/vite-node": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-      "dev": true,
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.4.1",
-        "es-module-lexer": "^1.7.0",
-        "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/vitest": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
-      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.7",
-        "@vitest/mocker": "3.2.7",
-        "@vitest/pretty-format": "^3.2.7",
-        "@vitest/runner": "3.2.7",
-        "@vitest/snapshot": "3.2.7",
-        "@vitest/spy": "3.2.7",
-        "@vitest/utils": "3.2.7",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.1",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.4",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.7",
-        "@vitest/ui": "3.2.7",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@types/debug": {
+        "@opentelemetry/api": {
           "optional": true
         },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser": {
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {
@@ -2572,6 +2757,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },
@@ -2614,9 +2802,9 @@
       "license": "ISC"
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -58,12 +58,12 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.1",
-    "zod": "^3.23.0"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
-    "@types/node": "^22.10.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.2.7"
+    "@types/node": "^26.1.1",
+    "typescript": "^7.0.2",
+    "vitest": "^4.1.10"
   }
 }

--- a/scripts/build-chat-dmg.sh
+++ b/scripts/build-chat-dmg.sh
@@ -138,8 +138,8 @@ REQUIREMENTS
 SUPPORT
 =======
 
-GitHub: https://github.com/ppmcp/premiere-pro-mcp
-Issues: https://github.com/ppmcp/premiere-pro-mcp/issues
+GitHub: https://github.com/leancoderkavy/premiere-pro-mcp
+Issues: https://github.com/leancoderkavy/premiere-pro-mcp/issues
 README_EOF
 
 echo "✓ README created"

--- a/scripts/build-chat-zip.sh
+++ b/scripts/build-chat-zip.sh
@@ -260,8 +260,8 @@ REQUIREMENTS
 SUPPORT
 =======
 
-GitHub: https://github.com/ppmcp/premiere-pro-mcp
-Issues: https://github.com/ppmcp/premiere-pro-mcp/issues
+GitHub: https://github.com/leancoderkavy/premiere-pro-mcp
+Issues: https://github.com/leancoderkavy/premiere-pro-mcp/issues
 README_EOF
 
 echo "✓ README created"

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,15 @@ import path from "path";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const projectRoot = path.resolve(__dirname, "..");
+const debugEnabled = /^(1|true|yes|on|debug)$/i.test(
+  process.env.PREMIERE_MCP_DEBUG ?? "",
+);
+
+function debugLog(message: string): void {
+  if (debugEnabled) {
+    console.error(`[premiere-pro-mcp] ${message}`);
+  }
+}
 
 // Handle CLI flags
 const args = process.argv.slice(2);
@@ -28,15 +37,16 @@ Environment variables:
   PREMIERE_TEMP_DIR     Shared temp directory (default: OS temp + /premiere-mcp-bridge)
   PREMIERE_TIMEOUT_MS   Command timeout in ms (default: 30000)
   PREMIERE_MCP_CAPABILITIES  Comma-separated authority profile
+  PREMIERE_MCP_DEBUG    Set to 1/true to enable verbose stderr diagnostics
 
-More info: https://github.com/ppmcp/premiere-pro-mcp
+More info: https://github.com/leancoderkavy/premiere-pro-mcp
 `);
   process.exit(0);
 }
 
 if (args.includes("--version") || args.includes("-v")) {
   const pkg = await import("../package.json", { with: { type: "json" } }).catch(
-    () => ({ default: { version: "unknown" } })
+    () => ({ default: { version: "unknown" } }),
   );
   console.log(pkg.default.version);
   process.exit(0);
@@ -47,25 +57,36 @@ if (args.includes("--install-cep")) {
   const isWindows = process.platform === "win32";
   const isMacOS = process.platform === "darwin";
   if (!isWindows && !isMacOS) {
-    console.error(`CEP installation is supported only on Windows and macOS (current platform: ${process.platform}).`);
+    console.error(
+      `CEP installation is supported only on Windows and macOS (current platform: ${process.platform}).`,
+    );
     process.exit(1);
   }
-  const scriptPath = path.join(projectRoot, "scripts", isWindows ? "install-cep.ps1" : "install-cep.sh");
+  const scriptPath = path.join(
+    projectRoot,
+    "scripts",
+    isWindows ? "install-cep.ps1" : "install-cep.sh",
+  );
   try {
     if (isWindows) {
       execFileSync(
         "powershell.exe",
         ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", scriptPath],
-        { stdio: "inherit", cwd: projectRoot }
+        { stdio: "inherit", cwd: projectRoot },
       );
     } else {
-      execFileSync("bash", [scriptPath, "--copy"], { stdio: "inherit", cwd: projectRoot });
+      execFileSync("bash", [scriptPath, "--copy"], {
+        stdio: "inherit",
+        cwd: projectRoot,
+      });
     }
   } catch {
     console.error("CEP installation failed. Try running manually:");
-    console.error(isWindows
-      ? `  powershell -ExecutionPolicy Bypass -File "${scriptPath}"`
-      : `  bash "${scriptPath}"`);
+    console.error(
+      isWindows
+        ? `  powershell -ExecutionPolicy Bypass -File "${scriptPath}"`
+        : `  bash "${scriptPath}"`,
+    );
     process.exit(1);
   }
   process.exit(0);
@@ -80,8 +101,8 @@ async function main() {
   };
 
   const tempDir = getTempDir(bridgeOptions);
-  console.error(`[premiere-pro-mcp] Starting MCP server...`);
-  console.error(`[premiere-pro-mcp] Temp directory: ${tempDir}`);
+  debugLog("Starting MCP server...");
+  debugLog(`Temp directory: ${tempDir}`);
 
   // Clean up any stale files from previous sessions
   cleanupTempDir(bridgeOptions);
@@ -90,7 +111,7 @@ async function main() {
   const transport = new StdioServerTransport();
 
   await server.connect(transport);
-  console.error(`[premiere-pro-mcp] Server connected and ready`);
+  debugLog("Server connected and ready");
 }
 
 main().catch((err) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,7 +32,10 @@ import { getEditPlanTools } from "./tools/edit-plans.js";
 import { guardToolHandler, resolveCapabilities } from "./security/index.js";
 import { EXTENDSCRIPT_REFERENCE } from "./resources/extendscript-reference.js";
 import { WORKFLOW_PROMPTS, WORKFLOW_RESOURCE } from "./workflows/catalog.js";
-import { annotationsForTool, structuredToolResult } from "./workflows/tool-metadata.js";
+import {
+  annotationsForTool,
+  structuredToolResult,
+} from "./workflows/tool-metadata.js";
 import { z } from "zod";
 
 const PREMIERE_INSTRUCTIONS = `You are controlling Adobe Premiere Pro through MCP tools. Follow these best practices:
@@ -100,50 +103,101 @@ CUSTOM SCRIPTING:
 interface ToolDef {
   description: string;
   parameters: Record<string, unknown>;
-  handler: (args: any) => Promise<{ success: boolean; data?: unknown; error?: string }>;
+  handler: (
+    args: any,
+  ) => Promise<{ success: boolean; data?: unknown; error?: string }>;
 }
 
 const toolCatalogCache = new Map<string, Record<string, ToolDef>>();
-const schemaCache = new WeakMap<Record<string, unknown>, Record<string, z.ZodTypeAny>>();
+const schemaCache = new WeakMap<
+  Record<string, unknown>,
+  Record<string, z.ZodTypeAny>
+>();
+const debugEnabled = /^(1|true|yes|on|debug)$/i.test(
+  process.env.PREMIERE_MCP_DEBUG ?? "",
+);
+
+function debugLog(message: string): void {
+  if (debugEnabled) {
+    console.error(`[premiere-pro-mcp] ${message}`);
+  }
+}
+
+function jsonSchemaPropToZod(prop: Record<string, unknown>): z.ZodTypeAny {
+  const propType = prop.type as string | undefined;
+
+  if (propType === "string") {
+    if (prop.enum && Array.isArray(prop.enum) && prop.enum.length > 0) {
+      const enumValues = prop.enum as [string, ...string[]];
+      return z.enum(enumValues);
+    }
+    return z.string();
+  }
+
+  if (propType === "number") {
+    return z.number();
+  }
+
+  if (propType === "boolean") {
+    return z.boolean();
+  }
+
+  if (propType === "array") {
+    const itemSchema = (prop.items ?? {}) as Record<string, unknown>;
+    // Use unknown as a safe fallback while still emitting a concrete items schema.
+    const itemZod =
+      Object.keys(itemSchema).length > 0
+        ? jsonSchemaPropToZod(itemSchema)
+        : z.unknown();
+    return z.array(itemZod);
+  }
+
+  if (propType === "object") {
+    const nestedProperties = (prop.properties ?? {}) as Record<
+      string,
+      Record<string, unknown>
+    >;
+    const nestedRequired = new Set((prop.required ?? []) as string[]);
+
+    if (Object.keys(nestedProperties).length === 0) {
+      return z.record(z.string(), z.unknown());
+    }
+
+    const nestedShape: Record<string, z.ZodTypeAny> = {};
+    for (const [nestedKey, nestedProp] of Object.entries(nestedProperties)) {
+      let nestedZod = jsonSchemaPropToZod(nestedProp);
+      if (nestedProp.description) {
+        nestedZod = nestedZod.describe(nestedProp.description as string);
+      }
+      if (!nestedRequired.has(nestedKey)) {
+        nestedZod = nestedZod.optional();
+      }
+      nestedShape[nestedKey] = nestedZod;
+    }
+
+    return z.object(nestedShape).passthrough();
+  }
+
+  return z.unknown();
+}
 
 /**
  * Convert a JSON Schema-style parameters object to a Zod shape for MCP SDK registration.
  */
-function jsonSchemaToZodShape(params: Record<string, unknown>): Record<string, z.ZodTypeAny> {
+function jsonSchemaToZodShape(
+  params: Record<string, unknown>,
+): Record<string, z.ZodTypeAny> {
   const cached = schemaCache.get(params);
   if (cached) return cached;
   const shape: Record<string, z.ZodTypeAny> = {};
-  const properties = (params.properties ?? {}) as Record<string, Record<string, unknown>>;
+  const properties = (params.properties ?? {}) as Record<
+    string,
+    Record<string, unknown>
+  >;
   const required = (params.required ?? []) as string[];
 
   for (const [key, prop] of Object.entries(properties)) {
-    let zodType: z.ZodTypeAny;
-    const propType = prop.type as string;
-
-    switch (propType) {
-      case "string":
-        if (prop.enum) {
-          const enumValues = prop.enum as [string, ...string[]];
-          zodType = z.enum(enumValues);
-        } else {
-          zodType = z.string();
-        }
-        break;
-      case "number":
-        zodType = z.number();
-        break;
-      case "boolean":
-        zodType = z.boolean();
-        break;
-      case "array":
-        zodType = z.array(z.any());
-        break;
-      case "object":
-        zodType = z.record(z.any());
-        break;
-      default:
-        zodType = z.any();
-    }
+    let zodType = jsonSchemaPropToZod(prop);
 
     if (prop.description) {
       zodType = zodType.describe(prop.description as string);
@@ -166,7 +220,8 @@ function collectTools(
 ): Record<string, ToolDef> {
   const cacheKey = JSON.stringify({
     tempDir: bridgeOptions.tempDir ?? process.env.PREMIERE_TEMP_DIR ?? null,
-    timeoutMs: bridgeOptions.timeoutMs ?? process.env.PREMIERE_TIMEOUT_MS ?? null,
+    timeoutMs:
+      bridgeOptions.timeoutMs ?? process.env.PREMIERE_TIMEOUT_MS ?? null,
     capabilities: [...capabilities.capabilities].sort(),
   });
   const cached = toolCatalogCache.get(cacheKey);
@@ -234,9 +289,15 @@ export function createServer(bridgeOptions: BridgeOptions): McpServer {
           if (result.success) {
             // Special handling for capture_frame: return image content block
             const data = result.data as Record<string, unknown> | undefined;
-            if (data && data.mimeType === "image/png" && typeof data.base64 === "string") {
+            if (
+              data &&
+              data.mimeType === "image/png" &&
+              typeof data.base64 === "string"
+            ) {
               return {
-                structuredContent: structuredToolResult(name, true, { mimeType: data.mimeType }),
+                structuredContent: structuredToolResult(name, true, {
+                  mimeType: data.mimeType,
+                }),
                 content: [
                   {
                     type: "image" as const,
@@ -261,7 +322,12 @@ export function createServer(bridgeOptions: BridgeOptions): McpServer {
             };
           } else {
             return {
-              structuredContent: structuredToolResult(name, false, undefined, result.error),
+              structuredContent: structuredToolResult(
+                name,
+                false,
+                undefined,
+                result.error,
+              ),
               content: [
                 {
                   type: "text" as const,
@@ -273,7 +339,12 @@ export function createServer(bridgeOptions: BridgeOptions): McpServer {
           }
         } catch (err) {
           return {
-            structuredContent: structuredToolResult(name, false, undefined, err instanceof Error ? err.message : String(err)),
+            structuredContent: structuredToolResult(
+              name,
+              false,
+              undefined,
+              err instanceof Error ? err.message : String(err),
+            ),
             content: [
               {
                 type: "text" as const,
@@ -283,7 +354,7 @@ export function createServer(bridgeOptions: BridgeOptions): McpServer {
             isError: true,
           };
         }
-      }
+      },
     );
   }
 
@@ -292,7 +363,8 @@ export function createServer(bridgeOptions: BridgeOptions): McpServer {
     "premiere-instructions",
     "config://premiere-instructions",
     {
-      description: "Instructions and best practices for using Premiere Pro via MCP tools",
+      description:
+        "Instructions and best practices for using Premiere Pro via MCP tools",
       mimeType: "text/plain",
     },
     async (uri) => ({
@@ -302,7 +374,7 @@ export function createServer(bridgeOptions: BridgeOptions): McpServer {
           text: PREMIERE_INSTRUCTIONS,
         },
       ],
-    })
+    }),
   );
 
   server.resource(
@@ -313,14 +385,24 @@ export function createServer(bridgeOptions: BridgeOptions): McpServer {
       mimeType: "application/json",
     },
     async (uri) => ({
-      contents: [{ uri: uri.href, mimeType: "application/json", text: WORKFLOW_RESOURCE }],
-    })
+      contents: [
+        {
+          uri: uri.href,
+          mimeType: "application/json",
+          text: WORKFLOW_RESOURCE,
+        },
+      ],
+    }),
   );
 
   for (const prompt of WORKFLOW_PROMPTS) {
     server.registerPrompt(
       prompt.name,
-      { title: prompt.title, description: prompt.description, argsSchema: prompt.argsSchema },
+      {
+        title: prompt.title,
+        description: prompt.description,
+        argsSchema: prompt.argsSchema,
+      },
       prompt.render,
     );
   }
@@ -330,7 +412,8 @@ export function createServer(bridgeOptions: BridgeOptions): McpServer {
     "extendscript-reference",
     "config://extendscript-reference",
     {
-      description: "Complete Premiere Pro ExtendScript API reference for writing custom scripts via execute_extendscript",
+      description:
+        "Complete Premiere Pro ExtendScript API reference for writing custom scripts via execute_extendscript",
       mimeType: "text/plain",
     },
     async (uri) => ({
@@ -340,11 +423,13 @@ export function createServer(bridgeOptions: BridgeOptions): McpServer {
           text: EXTENDSCRIPT_REFERENCE,
         },
       ],
-    })
+    }),
   );
 
   const toolCount = Object.keys(toolModules).length;
-  console.error(`[premiere-pro-mcp] Registered ${toolCount} tools + 3 resources + ${WORKFLOW_PROMPTS.length} prompts`);
+  debugLog(
+    `Registered ${toolCount} tools + 3 resources + ${WORKFLOW_PROMPTS.length} prompts`,
+  );
 
   return server;
 }

--- a/src/tools/advanced.ts
+++ b/src/tools/advanced.ts
@@ -1,10 +1,14 @@
-import { buildToolScript, escapeForExtendScript } from "../bridge/script-builder.js";
+import {
+  buildToolScript,
+  escapeForExtendScript,
+} from "../bridge/script-builder.js";
 import { sendCommand, BridgeOptions } from "../bridge/file-bridge.js";
 
 export function getAdvancedTools(bridgeOptions: BridgeOptions) {
   return {
     ripple_delete: {
-      description: "Ripple delete a clip (removes clip and closes the gap). Uses QE DOM.",
+      description:
+        "Ripple delete a clip (removes clip and closes the gap). Uses QE DOM.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -45,7 +49,8 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
     },
 
     roll_edit: {
-      description: "Perform a roll edit on a clip (adjusts the edit point between two adjacent clips). Uses QE DOM.",
+      description:
+        "Perform a roll edit on a clip (adjusts the edit point between two adjacent clips). Uses QE DOM.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -55,7 +60,8 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
           },
           offset_seconds: {
             type: "number",
-            description: "Offset in seconds (positive = roll right, negative = roll left)",
+            description:
+              "Offset in seconds (positive = roll right, negative = roll left)",
           },
         },
         required: ["node_id", "offset_seconds"],
@@ -84,7 +90,8 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
     },
 
     slide_edit: {
-      description: "Perform a slide edit on a clip (moves clip without changing its duration, adjusting adjacent clips). Uses QE DOM.",
+      description:
+        "Perform a slide edit on a clip (moves clip without changing its duration, adjusting adjacent clips). Uses QE DOM.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -94,7 +101,8 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
           },
           offset_seconds: {
             type: "number",
-            description: "Offset in seconds (positive = slide right, negative = slide left)",
+            description:
+              "Offset in seconds (positive = slide right, negative = slide left)",
           },
         },
         required: ["node_id", "offset_seconds"],
@@ -123,7 +131,8 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
     },
 
     slip_edit: {
-      description: "Perform a slip edit on a clip (changes source in/out points without moving clip on timeline). Uses QE DOM.",
+      description:
+        "Perform a slip edit on a clip (changes source in/out points without moving clip on timeline). Uses QE DOM.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -133,7 +142,8 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
           },
           offset_seconds: {
             type: "number",
-            description: "Offset in seconds (positive = slip forward in source, negative = slip backward)",
+            description:
+              "Offset in seconds (positive = slip forward in source, negative = slip backward)",
           },
         },
         required: ["node_id", "offset_seconds"],
@@ -177,7 +187,10 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
         },
         required: ["node_id", "target_track_index"],
       },
-      handler: async (args: { node_id: string; target_track_index: number }) => {
+      handler: async (args: {
+        node_id: string;
+        target_track_index: number;
+      }) => {
         const script = buildToolScript(`
           app.enableQE();
           var qeSeq = qe.project.getActiveSequence();
@@ -234,7 +247,8 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
     },
 
     set_clip_speed_qe: {
-      description: "Set clip playback speed using QE DOM (more reliable than ExtendScript). Supports reverse.",
+      description:
+        "Set clip playback speed using QE DOM (more reliable than ExtendScript). Supports reverse.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -244,7 +258,8 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
           },
           speed_percent: {
             type: "number",
-            description: "Speed as percentage (100 = normal, 200 = 2x, 50 = half speed)",
+            description:
+              "Speed as percentage (100 = normal, 200 = 2x, 50 = half speed)",
           },
           reverse: {
             type: "boolean",
@@ -253,7 +268,11 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
         },
         required: ["node_id", "speed_percent"],
       },
-      handler: async (args: { node_id: string; speed_percent: number; reverse?: boolean }) => {
+      handler: async (args: {
+        node_id: string;
+        speed_percent: number;
+        reverse?: boolean;
+      }) => {
         const script = buildToolScript(`
           app.enableQE();
           var qeSeq = qe.project.getActiveSequence();
@@ -360,7 +379,8 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
     },
 
     set_time_interpolation: {
-      description: "Set time interpolation type for a clip (Frame Sampling, Frame Blending, Optical Flow). Uses QE DOM.",
+      description:
+        "Set time interpolation type for a clip (Frame Sampling, Frame Blending, Optical Flow). Uses QE DOM.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -370,12 +390,16 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
           },
           interpolation_type: {
             type: "number",
-            description: "0 = Frame Sampling, 1 = Frame Blending, 2 = Optical Flow",
+            description:
+              "0 = Frame Sampling, 1 = Frame Blending, 2 = Optical Flow",
           },
         },
         required: ["node_id", "interpolation_type"],
       },
-      handler: async (args: { node_id: string; interpolation_type: number }) => {
+      handler: async (args: {
+        node_id: string;
+        interpolation_type: number;
+      }) => {
         const script = buildToolScript(`
           app.enableQE();
           var qeSeq = qe.project.getActiveSequence();
@@ -503,7 +527,8 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
     },
 
     link_selection: {
-      description: "Link the currently selected video and audio clips in the active sequence",
+      description:
+        "Link the currently selected video and audio clips in the active sequence",
       parameters: {},
       handler: async () => {
         const script = buildToolScript(`
@@ -517,7 +542,8 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
     },
 
     unlink_selection: {
-      description: "Unlink the currently selected video and audio clips in the active sequence",
+      description:
+        "Unlink the currently selected video and audio clips in the active sequence",
       parameters: {},
       handler: async () => {
         const script = buildToolScript(`
@@ -531,7 +557,8 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
     },
 
     overwrite_clip: {
-      description: "Overwrite a project item onto the timeline (replaces existing clips at the insertion point)",
+      description:
+        "Overwrite a project item onto the timeline (replaces existing clips at the insertion point)",
       parameters: {
         type: "object" as const,
         properties: {
@@ -554,7 +581,12 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
         },
         required: ["item_id"],
       },
-      handler: async (args: { item_id: string; start_seconds?: number; track_index?: number; audio_track_index?: number }) => {
+      handler: async (args: {
+        item_id: string;
+        start_seconds?: number;
+        track_index?: number;
+        audio_track_index?: number;
+      }) => {
         const startSeconds = args.start_seconds ?? 0;
         const trackIndex = args.track_index ?? 0;
         const audioTrackIndex = args.audio_track_index ?? 0;
@@ -581,7 +613,8 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
     },
 
     create_sequence_from_clips: {
-      description: "Create a new sequence by automatically placing project items in order",
+      description:
+        "Create a new sequence by automatically placing project items in order",
       parameters: {
         type: "object" as const,
         properties: {
@@ -591,14 +624,19 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
           },
           item_ids: {
             type: "array",
-            description: "Array of project item names or node IDs to include in order",
+            items: { type: "string" },
+            description:
+              "Array of project item names or node IDs to include in order",
           },
         },
         required: ["name", "item_ids"],
       },
       handler: async (args: { name: string; item_ids: string[] }) => {
         const itemLookups = args.item_ids
-          .map((id, i) => `var item${i} = __findProjectItem("${escapeForExtendScript(id)}"); if (!item${i}) return __error("Item not found: ${escapeForExtendScript(id)}"); items.push(item${i});`)
+          .map(
+            (id, i) =>
+              `var item${i} = __findProjectItem("${escapeForExtendScript(id)}"); if (!item${i}) return __error("Item not found: ${escapeForExtendScript(id)}"); items.push(item${i});`,
+          )
           .join("\n          ");
 
         const script = buildToolScript(`
@@ -620,7 +658,8 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
         properties: {
           sequence_id: {
             type: "string",
-            description: "Sequence name or ID. Uses active sequence if omitted.",
+            description:
+              "Sequence name or ID. Uses active sequence if omitted.",
           },
         },
       },
@@ -640,13 +679,15 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
     },
 
     export_as_project: {
-      description: "Export a sequence as a standalone Premiere Pro project file",
+      description:
+        "Export a sequence as a standalone Premiere Pro project file",
       parameters: {
         type: "object" as const,
         properties: {
           sequence_id: {
             type: "string",
-            description: "Sequence name or ID. Uses active sequence if omitted.",
+            description:
+              "Sequence name or ID. Uses active sequence if omitted.",
           },
           output_path: {
             type: "string",
@@ -676,7 +717,8 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
         properties: {
           sequence_id: {
             type: "string",
-            description: "Sequence name or ID. Uses active sequence if omitted.",
+            description:
+              "Sequence name or ID. Uses active sequence if omitted.",
           },
           start_seconds: {
             type: "number",
@@ -685,7 +727,10 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
         },
         required: ["start_seconds"],
       },
-      handler: async (args: { sequence_id?: string; start_seconds: number }) => {
+      handler: async (args: {
+        sequence_id?: string;
+        start_seconds: number;
+      }) => {
         const seqLookup = args.sequence_id
           ? `var seq = __findSequence("${escapeForExtendScript(args.sequence_id)}"); if (!seq) return __error("Sequence not found");`
           : `var seq = app.project.activeSequence; if (!seq) return __error("No active sequence");`;
@@ -701,7 +746,8 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
     },
 
     scene_edit_detection: {
-      description: "Perform scene edit detection on the selected clips in the active sequence",
+      description:
+        "Perform scene edit detection on the selected clips in the active sequence",
       parameters: {},
       handler: async () => {
         const script = buildToolScript(`
@@ -715,13 +761,15 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
     },
 
     delete_preview_files: {
-      description: "Delete all preview/render cache files for the project. Uses QE DOM.",
+      description:
+        "Delete all preview/render cache files for the project. Uses QE DOM.",
       parameters: {
         type: "object" as const,
         properties: {
           media_type: {
             type: "string",
-            description: "Type of preview files to delete: 'video', 'audio', or 'all' (default: 'all')",
+            description:
+              "Type of preview files to delete: 'video', 'audio', or 'all' (default: 'all')",
           },
         },
       },
@@ -743,7 +791,8 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
     },
 
     add_tracks: {
-      description: "Add video and/or audio tracks to the active sequence. Uses QE DOM.",
+      description:
+        "Add video and/or audio tracks to the active sequence. Uses QE DOM.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -753,7 +802,8 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
           },
           audio_tracks: {
             type: "number",
-            description: "Number of standard stereo audio tracks to add (default: 0)",
+            description:
+              "Number of standard stereo audio tracks to add (default: 0)",
           },
           audio_mono_tracks: {
             type: "number",
@@ -795,7 +845,8 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
     },
 
     set_color_value: {
-      description: "Set a color value on an effect property (e.g., tint color, fill color)",
+      description:
+        "Set a color value on an effect property (e.g., tint color, fill color)",
       parameters: {
         type: "object" as const,
         properties: {
@@ -828,7 +879,15 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
             description: "Blue (0-255)",
           },
         },
-        required: ["node_id", "component_name", "property_name", "alpha", "red", "green", "blue"],
+        required: [
+          "node_id",
+          "component_name",
+          "property_name",
+          "alpha",
+          "red",
+          "green",
+          "blue",
+        ],
       },
       handler: async (args: {
         node_id: string;
@@ -901,7 +960,8 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
     },
 
     get_linked_items: {
-      description: "Get all clips in the sequence that are linked to the same source as a given clip",
+      description:
+        "Get all clips in the sequence that are linked to the same source as a given clip",
       parameters: {
         type: "object" as const,
         properties: {
@@ -936,7 +996,8 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
     },
 
     get_mogrt_component: {
-      description: "Get MOGRT (Motion Graphics Template) component parameters from a clip",
+      description:
+        "Get MOGRT (Motion Graphics Template) component parameters from a clip",
       parameters: {
         type: "object" as const,
         properties: {

--- a/src/tools/project.ts
+++ b/src/tools/project.ts
@@ -1,4 +1,7 @@
-import { buildToolScript, escapeForExtendScript } from "../bridge/script-builder.js";
+import {
+  buildToolScript,
+  escapeForExtendScript,
+} from "../bridge/script-builder.js";
 import { sendCommand, BridgeOptions } from "../bridge/file-bridge.js";
 
 export function getProjectTools(bridgeOptions: BridgeOptions) {
@@ -24,7 +27,8 @@ export function getProjectTools(bridgeOptions: BridgeOptions) {
         properties: {
           path: {
             type: "string",
-            description: "Full file path to save the project to (e.g., '/Users/me/projects/MyProject.prproj')",
+            description:
+              "Full file path to save the project to (e.g., '/Users/me/projects/MyProject.prproj')",
           },
         },
         required: ["path"],
@@ -178,7 +182,9 @@ export function getProjectTools(bridgeOptions: BridgeOptions) {
           },
           comp_names: {
             type: "array",
-            description: "Array of composition names to import. If omitted, imports all comps.",
+            items: { type: "string" },
+            description:
+              "Array of composition names to import. If omitted, imports all comps.",
           },
           target_bin: {
             type: "string",
@@ -187,13 +193,19 @@ export function getProjectTools(bridgeOptions: BridgeOptions) {
         },
         required: ["ae_project_path"],
       },
-      handler: async (args: { ae_project_path: string; comp_names?: string[]; target_bin?: string }) => {
+      handler: async (args: {
+        ae_project_path: string;
+        comp_names?: string[];
+        target_bin?: string;
+      }) => {
         const binLookup = args.target_bin
           ? `var targetBin = __findProjectItem("${escapeForExtendScript(args.target_bin)}"); if (!targetBin) return __error("Bin not found");`
           : `var targetBin = app.project.rootItem;`;
 
         if (args.comp_names && args.comp_names.length > 0) {
-          const comps = args.comp_names.map(c => `"${escapeForExtendScript(c)}"`).join(", ");
+          const comps = args.comp_names
+            .map((c) => `"${escapeForExtendScript(c)}"`)
+            .join(", ");
           const script = buildToolScript(`
             ${binLookup}
             app.project.importAEComps("${escapeForExtendScript(args.ae_project_path)}", [${comps}], targetBin);
@@ -291,7 +303,8 @@ export function getProjectTools(bridgeOptions: BridgeOptions) {
     },
 
     find_items_by_media_path: {
-      description: "Find project items whose media path contains the given search string",
+      description:
+        "Find project items whose media path contains the given search string",
       parameters: {
         type: "object" as const,
         properties: {
@@ -323,7 +336,8 @@ export function getProjectTools(bridgeOptions: BridgeOptions) {
     },
 
     start_batch_encode: {
-      description: "Start encoding all items in the Adobe Media Encoder render queue",
+      description:
+        "Start encoding all items in the Adobe Media Encoder render queue",
       parameters: {},
       handler: async () => {
         const script = buildToolScript(`
@@ -335,7 +349,8 @@ export function getProjectTools(bridgeOptions: BridgeOptions) {
     },
 
     add_custom_metadata_field: {
-      description: "Add a custom metadata field to the project's metadata schema",
+      description:
+        "Add a custom metadata field to the project's metadata schema",
       parameters: {
         type: "object" as const,
         properties: {
@@ -349,12 +364,17 @@ export function getProjectTools(bridgeOptions: BridgeOptions) {
           },
           field_type: {
             type: "number",
-            description: "Type of the field: 0 = Integer, 1 = Real, 2 = String, 3 = Boolean",
+            description:
+              "Type of the field: 0 = Integer, 1 = Real, 2 = String, 3 = Boolean",
           },
         },
         required: ["field_name", "field_label", "field_type"],
       },
-      handler: async (args: { field_name: string; field_label: string; field_type: number }) => {
+      handler: async (args: {
+        field_name: string;
+        field_label: string;
+        field_type: number;
+      }) => {
         const script = buildToolScript(`
           app.project.addPropertyToProjectMetadataSchema("${escapeForExtendScript(args.field_name)}", "${escapeForExtendScript(args.field_label)}", ${args.field_type});
           return __result({ added: true, name: "${escapeForExtendScript(args.field_name)}", label: "${escapeForExtendScript(args.field_label)}" });
@@ -373,14 +393,21 @@ export function getProjectTools(bridgeOptions: BridgeOptions) {
           },
           sequence_ids: {
             type: "array",
-            description: "Array of sequence IDs to import from the source project. If omitted, all sequences are imported.",
+            items: { type: "string" },
+            description:
+              "Array of sequence IDs to import from the source project. If omitted, all sequences are imported.",
           },
         },
         required: ["project_path"],
       },
-      handler: async (args: { project_path: string; sequence_ids?: string[] }) => {
+      handler: async (args: {
+        project_path: string;
+        sequence_ids?: string[];
+      }) => {
         if (args.sequence_ids && args.sequence_ids.length > 0) {
-          const ids = args.sequence_ids.map(id => `"${escapeForExtendScript(id)}"`).join(", ");
+          const ids = args.sequence_ids
+            .map((id) => `"${escapeForExtendScript(id)}"`)
+            .join(", ");
           const script = buildToolScript(`
             app.project.importSequences("${escapeForExtendScript(args.project_path)}", [${ids}]);
             return __result({ imported: true, sequenceIds: [${ids}] });
@@ -397,7 +424,8 @@ export function getProjectTools(bridgeOptions: BridgeOptions) {
     },
 
     create_bars_and_tone: {
-      description: "Create a Bars and Tone synthetic media item in the project (useful for leader/calibration)",
+      description:
+        "Create a Bars and Tone synthetic media item in the project (useful for leader/calibration)",
       parameters: {
         type: "object" as const,
         properties: {
@@ -411,15 +439,22 @@ export function getProjectTools(bridgeOptions: BridgeOptions) {
           },
           timebase: {
             type: "string",
-            description: "Timebase as ticks-per-second string (default uses sequence timebase)",
+            description:
+              "Timebase as ticks-per-second string (default uses sequence timebase)",
           },
           name: {
             type: "string",
-            description: "Name for the bars and tone item (default: 'Bars and Tone')",
+            description:
+              "Name for the bars and tone item (default: 'Bars and Tone')",
           },
         },
       },
-      handler: async (args: { width?: number; height?: number; timebase?: string; name?: string }) => {
+      handler: async (args: {
+        width?: number;
+        height?: number;
+        timebase?: string;
+        name?: string;
+      }) => {
         const w = args.width ?? 1920;
         const h = args.height ?? 1080;
         const name = args.name ?? "Bars and Tone";
@@ -476,7 +511,8 @@ export function getProjectTools(bridgeOptions: BridgeOptions) {
     },
 
     get_insertion_bin: {
-      description: "Get the current target bin for new imports (the bin that is currently focused in the Project panel)",
+      description:
+        "Get the current target bin for new imports (the bin that is currently focused in the Project panel)",
       parameters: {},
       handler: async () => {
         const script = buildToolScript(`
@@ -489,7 +525,8 @@ export function getProjectTools(bridgeOptions: BridgeOptions) {
     },
 
     get_project_panel_metadata: {
-      description: "Get the current project panel metadata/column configuration as XML",
+      description:
+        "Get the current project panel metadata/column configuration as XML",
       parameters: {},
       handler: async () => {
         const script = buildToolScript(`
@@ -502,13 +539,15 @@ export function getProjectTools(bridgeOptions: BridgeOptions) {
     },
 
     set_project_panel_metadata: {
-      description: "Set the project panel metadata/column configuration from XML",
+      description:
+        "Set the project panel metadata/column configuration from XML",
       parameters: {
         type: "object" as const,
         properties: {
           metadata_xml: {
             type: "string",
-            description: "XML string containing the project panel metadata configuration",
+            description:
+              "XML string containing the project panel metadata configuration",
           },
         },
         required: ["metadata_xml"],
@@ -523,7 +562,8 @@ export function getProjectTools(bridgeOptions: BridgeOptions) {
     },
 
     get_graphics_white_luminance: {
-      description: "Get the graphics white luminance value (HDR setting) for the project",
+      description:
+        "Get the graphics white luminance value (HDR setting) for the project",
       parameters: {},
       handler: async () => {
         const script = buildToolScript(`
@@ -535,7 +575,8 @@ export function getProjectTools(bridgeOptions: BridgeOptions) {
     },
 
     set_graphics_white_luminance: {
-      description: "Set the graphics white luminance value (HDR setting) for the project",
+      description:
+        "Set the graphics white luminance value (HDR setting) for the project",
       parameters: {
         type: "object" as const,
         properties: {
@@ -562,7 +603,8 @@ export function getProjectTools(bridgeOptions: BridgeOptions) {
         properties: {
           scratch_disk_type: {
             type: "string",
-            description: "Type: 'capturedVideo', 'capturedAudio', 'videoPreview', 'audioPreview', 'autoSave', 'ccLibraries'",
+            description:
+              "Type: 'capturedVideo', 'capturedAudio', 'videoPreview', 'audioPreview', 'autoSave', 'ccLibraries'",
           },
           path: {
             type: "string",

--- a/src/tools/track-targeting.ts
+++ b/src/tools/track-targeting.ts
@@ -1,10 +1,14 @@
-import { buildToolScript, escapeForExtendScript } from "../bridge/script-builder.js";
+import {
+  buildToolScript,
+  escapeForExtendScript,
+} from "../bridge/script-builder.js";
 import { sendCommand, BridgeOptions } from "../bridge/file-bridge.js";
 
 export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
   return {
     set_target_track: {
-      description: "Set a track as targeted (active for insert/overwrite edits). Only one video and one audio track can be targeted at a time.",
+      description:
+        "Set a track as targeted (active for insert/overwrite edits). Only one video and one audio track can be targeted at a time.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -19,12 +23,17 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
           },
           targeted: {
             type: "boolean",
-            description: "Whether to target (true) or untarget (false) the track",
+            description:
+              "Whether to target (true) or untarget (false) the track",
           },
         },
         required: ["track_type", "track_index", "targeted"],
       },
-      handler: async (args: { track_type: string; track_index: number; targeted: boolean }) => {
+      handler: async (args: {
+        track_type: string;
+        track_index: number;
+        targeted: boolean;
+      }) => {
         const script = buildToolScript(`
           var seq = app.project.activeSequence;
           if (!seq) return __error("No active sequence");
@@ -79,13 +88,15 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
     },
 
     set_all_tracks_targeted: {
-      description: "Set all tracks targeted or untargeted. Useful before insert/overwrite edits.",
+      description:
+        "Set all tracks targeted or untargeted. Useful before insert/overwrite edits.",
       parameters: {
         type: "object" as const,
         properties: {
           targeted: {
             type: "boolean",
-            description: "Whether to target (true) or untarget (false) all tracks",
+            description:
+              "Whether to target (true) or untarget (false) all tracks",
           },
           track_type: {
             type: "string",
@@ -140,7 +151,11 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
         },
         required: ["track_type", "track_index", "name"],
       },
-      handler: async (args: { track_type: string; track_index: number; name: string }) => {
+      handler: async (args: {
+        track_type: string;
+        track_index: number;
+        name: string;
+      }) => {
         const script = buildToolScript(`
           var seq = app.project.activeSequence;
           if (!seq) return __error("No active sequence");
@@ -159,7 +174,8 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
     },
 
     get_track_info: {
-      description: "Get detailed information about a specific track: name, clip count, muted, locked, targeted, and list of all clips.",
+      description:
+        "Get detailed information about a specific track: name, clip count, muted, locked, targeted, and list of all clips.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -228,13 +244,15 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
     },
 
     razor_all_tracks: {
-      description: "Razor (split) all clips at the playhead position across all tracks, or at a specific time.",
+      description:
+        "Razor (split) all clips at the playhead position across all tracks, or at a specific time.",
       parameters: {
         type: "object" as const,
         properties: {
           time_seconds: {
             type: "number",
-            description: "Time to razor at in seconds (uses playhead position if omitted)",
+            description:
+              "Time to razor at in seconds (uses playhead position if omitted)",
           },
           track_type: {
             type: "string",
@@ -251,9 +269,11 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
           if (!seq) return __error("No active sequence");
 
           var qeSeq = qe.project.getActiveSequence();
-          ${args.time_seconds !== undefined
-            ? `var ticks = __secondsToTicks(${args.time_seconds}).toString();`
-            : `var ticks = seq.getPlayerPosition().ticks;`}
+          ${
+            args.time_seconds !== undefined
+              ? `var ticks = __secondsToTicks(${args.time_seconds}).toString();`
+              : `var ticks = seq.getPlayerPosition().ticks;`
+          }
 
           var razored = 0;
           if ("${trackType}" !== "audio") {
@@ -280,7 +300,8 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
     },
 
     set_clip_start_time: {
-      description: "Set the start time (timecode offset) of a project item. This shifts where timecode begins for the source media.",
+      description:
+        "Set the start time (timecode offset) of a project item. This shifts where timecode begins for the source media.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -311,7 +332,8 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
     },
 
     clear_item_in_out: {
-      description: "Clear in and/or out points on a project item (reset to full duration).",
+      description:
+        "Clear in and/or out points on a project item (reset to full duration).",
       parameters: {
         type: "object" as const,
         properties: {
@@ -330,7 +352,11 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
         },
         required: ["item_id"],
       },
-      handler: async (args: { item_id: string; clear_in?: boolean; clear_out?: boolean }) => {
+      handler: async (args: {
+        item_id: string;
+        clear_in?: boolean;
+        clear_out?: boolean;
+      }) => {
         const clearIn = args.clear_in !== false;
         const clearOut = args.clear_out !== false;
         const script = buildToolScript(`
@@ -347,7 +373,8 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
     },
 
     set_item_in_out: {
-      description: "Set in and/or out points on a project item in the project panel (marks source range for editing).",
+      description:
+        "Set in and/or out points on a project item in the project panel (marks source range for editing).",
       parameters: {
         type: "object" as const,
         properties: {
@@ -370,23 +397,36 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
         },
         required: ["item_id"],
       },
-      handler: async (args: { item_id: string; in_seconds?: number; out_seconds?: number; media_type?: number }) => {
+      handler: async (args: {
+        item_id: string;
+        in_seconds?: number;
+        out_seconds?: number;
+        media_type?: number;
+      }) => {
         const mediaType = args.media_type ?? 4;
         const script = buildToolScript(`
           var item = __findProjectItem("${escapeForExtendScript(args.item_id)}");
           if (!item) return __error("Item not found");
 
-          ${args.in_seconds !== undefined ? `
+          ${
+            args.in_seconds !== undefined
+              ? `
           var inTime = new Time();
           inTime.seconds = ${args.in_seconds};
           item.setInPoint(inTime.ticks, ${mediaType});
-          ` : ""}
+          `
+              : ""
+          }
 
-          ${args.out_seconds !== undefined ? `
+          ${
+            args.out_seconds !== undefined
+              ? `
           var outTime = new Time();
           outTime.seconds = ${args.out_seconds};
           item.setOutPoint(outTime.ticks, ${mediaType});
-          ` : ""}
+          `
+              : ""
+          }
 
           return __result({ item: item.name, inSet: ${args.in_seconds !== undefined}, outSet: ${args.out_seconds !== undefined} });
         `);
@@ -401,22 +441,31 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
         properties: {
           first_file_path: {
             type: "string",
-            description: "Full path to the first image in the sequence (e.g., /path/to/frame_001.png)",
+            description:
+              "Full path to the first image in the sequence (e.g., /path/to/frame_001.png)",
           },
           target_bin: {
             type: "string",
-            description: "Target bin name to import into (optional, imports to root if omitted)",
+            description:
+              "Target bin name to import into (optional, imports to root if omitted)",
           },
         },
         required: ["first_file_path"],
       },
-      handler: async (args: { first_file_path: string; target_bin?: string }) => {
+      handler: async (args: {
+        first_file_path: string;
+        target_bin?: string;
+      }) => {
         const script = buildToolScript(`
           var targetBin = app.project.rootItem;
-          ${args.target_bin ? `
+          ${
+            args.target_bin
+              ? `
           var found = __findProjectItem("${escapeForExtendScript(args.target_bin)}");
           if (found && found.type === 2) targetBin = found;
-          ` : ""}
+          `
+              : ""
+          }
 
           app.project.importFiles(["${escapeForExtendScript(args.first_file_path)}"], true, targetBin, true);
 
@@ -427,7 +476,8 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
     },
 
     set_clip_position: {
-      description: "Set the Position property on a video clip's Motion effect. Values are in pixels.",
+      description:
+        "Set the Position property on a video clip's Motion effect. Values are in pixels.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -483,7 +533,8 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
           },
           scale: {
             type: "number",
-            description: "Scale value (100 = original size, 200 = 2x, 50 = half)",
+            description:
+              "Scale value (100 = original size, 200 = 2x, 50 = half)",
           },
         },
         required: ["node_id", "scale"],
@@ -525,7 +576,8 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
           },
           degrees: {
             type: "number",
-            description: "Rotation in degrees (0-360, can exceed for multiple rotations)",
+            description:
+              "Rotation in degrees (0-360, can exceed for multiple rotations)",
           },
         },
         required: ["node_id", "degrees"],
@@ -557,7 +609,8 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
     },
 
     set_clip_anchor_point: {
-      description: "Set the Anchor Point property on a video clip's Motion effect.",
+      description:
+        "Set the Anchor Point property on a video clip's Motion effect.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -655,7 +708,8 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
           },
           volume_db: {
             type: "number",
-            description: "Volume in dB (0 = unity, negative = quieter, positive = louder)",
+            description:
+              "Volume in dB (0 = unity, negative = quieter, positive = louder)",
           },
         },
         required: ["node_id", "volume_db"],
@@ -697,7 +751,8 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
           },
           pan: {
             type: "number",
-            description: "Pan value (-100 = full left, 0 = center, 100 = full right)",
+            description:
+              "Pan value (-100 = full left, 0 = center, 100 = full right)",
           },
         },
         required: ["node_id", "pan"],
@@ -729,13 +784,15 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
     },
 
     batch_rename_clips: {
-      description: "Rename multiple clips on the timeline using a pattern. Supports sequential numbering.",
+      description:
+        "Rename multiple clips on the timeline using a pattern. Supports sequential numbering.",
       parameters: {
         type: "object" as const,
         properties: {
           pattern: {
             type: "string",
-            description: "Name pattern. Use {n} for sequential number, {name} for original name (e.g., 'Scene_{n}', '{name}_v2')",
+            description:
+              "Name pattern. Use {n} for sequential number, {name} for original name (e.g., 'Scene_{n}', '{name}_v2')",
           },
           track_type: {
             type: "string",
@@ -748,7 +805,8 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
           },
           selected_only: {
             type: "boolean",
-            description: "Only rename selected clips (default: false, renames all on track)",
+            description:
+              "Only rename selected clips (default: false, renames all on track)",
           },
           start_number: {
             type: "number",
@@ -757,7 +815,13 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
         },
         required: ["pattern", "track_type", "track_index"],
       },
-      handler: async (args: { pattern: string; track_type: string; track_index: number; selected_only?: boolean; start_number?: number }) => {
+      handler: async (args: {
+        pattern: string;
+        track_type: string;
+        track_index: number;
+        selected_only?: boolean;
+        start_number?: number;
+      }) => {
         const startNum = args.start_number ?? 1;
         const script = buildToolScript(`
           app.enableQE();
@@ -768,9 +832,11 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
           if (${args.track_index} >= tracks.numTracks) return __error("Track index out of range");
 
           var qeSeq = qe.project.getActiveSequence();
-          var qeTrack = ${args.track_type === "video"
-            ? `qeSeq.getVideoTrackAt(${args.track_index})`
-            : `qeSeq.getAudioTrackAt(${args.track_index})`};
+          var qeTrack = ${
+            args.track_type === "video"
+              ? `qeSeq.getVideoTrackAt(${args.track_index})`
+              : `qeSeq.getAudioTrackAt(${args.track_index})`
+          };
 
           var track = tracks[${args.track_index}];
           var renamed = 0;
@@ -797,7 +863,8 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
     },
 
     batch_enable_disable: {
-      description: "Enable or disable multiple clips at once (selected, track, or all).",
+      description:
+        "Enable or disable multiple clips at once (selected, track, or all).",
       parameters: {
         type: "object" as const,
         properties: {
@@ -822,7 +889,12 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
         },
         required: ["enabled", "target"],
       },
-      handler: async (args: { enabled: boolean; target: string; track_type?: string; track_index?: number }) => {
+      handler: async (args: {
+        enabled: boolean;
+        target: string;
+        track_type?: string;
+        track_index?: number;
+      }) => {
         const script = buildToolScript(`
           var seq = app.project.activeSequence;
           if (!seq) return __error("No active sequence");
@@ -862,7 +934,8 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
         properties: {
           ripple: {
             type: "boolean",
-            description: "If true, close the gap after removing (ripple delete). Default: false",
+            description:
+              "If true, close the gap after removing (ripple delete). Default: false",
           },
         },
       },
@@ -952,8 +1025,9 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
             return __error("No .epr presets found. Is Adobe Media Encoder installed alongside Premiere Pro?");
           }
 
-          ${args.format
-            ? `var needle = "${escapeForExtendScript(args.format)}".toLowerCase();
+          ${
+            args.format
+              ? `var needle = "${escapeForExtendScript(args.format)}".toLowerCase();
                var filtered = [];
                for (var i = 0; i < presets.length; i++) {
                  var p = presets[i];
@@ -962,7 +1036,8 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
                  }
                }
                presets = filtered;`
-            : ""}
+              : ""
+          }
 
           return __result({ count: presets.length, presets: presets });
         `);
@@ -971,7 +1046,8 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
     },
 
     get_qe_clip_info: {
-      description: "Get QE DOM information about a clip, including properties not available through the standard API.",
+      description:
+        "Get QE DOM information about a clip, including properties not available through the standard API.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -991,15 +1067,21 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
         },
         required: ["track_type", "track_index", "clip_index"],
       },
-      handler: async (args: { track_type: string; track_index: number; clip_index: number }) => {
+      handler: async (args: {
+        track_type: string;
+        track_index: number;
+        clip_index: number;
+      }) => {
         const script = buildToolScript(`
           app.enableQE();
           var qeSeq = qe.project.getActiveSequence();
           if (!qeSeq) return __error("No active sequence");
 
-          var qeTrack = ${args.track_type === "video"
-            ? `qeSeq.getVideoTrackAt(${args.track_index})`
-            : `qeSeq.getAudioTrackAt(${args.track_index})`};
+          var qeTrack = ${
+            args.track_type === "video"
+              ? `qeSeq.getVideoTrackAt(${args.track_index})`
+              : `qeSeq.getAudioTrackAt(${args.track_index})`
+          };
           if (!qeTrack) return __error("Track not found");
 
           var qeClip = qeTrack.getItemAt(${args.clip_index});
@@ -1087,7 +1169,8 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
     },
 
     set_poster_frame: {
-      description: "Set the poster frame (thumbnail) for a project item at a specific time.",
+      description:
+        "Set the poster frame (thumbnail) for a project item at a specific time.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -1145,6 +1228,7 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
         properties: {
           item_ids: {
             type: "array",
+            items: { type: "string" },
             description: "Array of node IDs or names of items to move",
           },
           target_bin: {
@@ -1179,7 +1263,8 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
     },
 
     set_anti_alias_quality: {
-      description: "Set the anti-alias quality on a clip's Motion effect (useful for scaled/rotated clips).",
+      description:
+        "Set the anti-alias quality on a clip's Motion effect (useful for scaled/rotated clips).",
       parameters: {
         type: "object" as const,
         properties: {
@@ -1222,7 +1307,8 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
     },
 
     set_uniform_scale: {
-      description: "Toggle uniform scale on a clip's Motion effect. When enabled, Scale Width and Scale Height are linked.",
+      description:
+        "Toggle uniform scale on a clip's Motion effect. When enabled, Scale Width and Scale Height are linked.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -1232,7 +1318,8 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
           },
           uniform: {
             type: "boolean",
-            description: "true for uniform (linked), false for non-uniform (independent width/height)",
+            description:
+              "true for uniform (linked), false for non-uniform (independent width/height)",
           },
         },
         required: ["node_id", "uniform"],
@@ -1264,7 +1351,8 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
     },
 
     set_scale_width_height: {
-      description: "Set independent Scale Width and Scale Height on a clip (requires Uniform Scale to be OFF).",
+      description:
+        "Set independent Scale Width and Scale Height on a clip (requires Uniform Scale to be OFF).",
       parameters: {
         type: "object" as const,
         properties: {
@@ -1283,7 +1371,11 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
         },
         required: ["node_id", "scale_width", "scale_height"],
       },
-      handler: async (args: { node_id: string; scale_width: number; scale_height: number }) => {
+      handler: async (args: {
+        node_id: string;
+        scale_width: number;
+        scale_height: number;
+      }) => {
         const script = buildToolScript(`
           var result = __findClip("${escapeForExtendScript(args.node_id)}");
           if (!result) return __error("Clip not found");

--- a/src/tools/utility.ts
+++ b/src/tools/utility.ts
@@ -1,10 +1,14 @@
-import { buildToolScript, escapeForExtendScript } from "../bridge/script-builder.js";
+import {
+  buildToolScript,
+  escapeForExtendScript,
+} from "../bridge/script-builder.js";
 import { sendCommand, BridgeOptions } from "../bridge/file-bridge.js";
 
 export function getUtilityTools(bridgeOptions: BridgeOptions) {
   return {
     delete_project_item: {
-      description: "Delete a project item (clip, bin, etc.) from the project panel. This removes it from the project but does not affect timeline instances.",
+      description:
+        "Delete a project item (clip, bin, etc.) from the project panel. This removes it from the project but does not affect timeline instances.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -29,12 +33,14 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
     },
 
     delete_multiple_project_items: {
-      description: "Delete multiple project items at once from the project panel.",
+      description:
+        "Delete multiple project items at once from the project panel.",
       parameters: {
         type: "object" as const,
         properties: {
           item_ids: {
             type: "array",
+            items: { type: "string" },
             description: "Array of node IDs or names of items to delete",
           },
         },
@@ -89,7 +95,8 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
     },
 
     add_adjustment_layer: {
-      description: "Add an adjustment layer to the active sequence via QE DOM. The layer is added at the playhead position on the specified track.",
+      description:
+        "Add an adjustment layer to the active sequence via QE DOM. The layer is added at the playhead position on the specified track.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -162,33 +169,43 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
     },
 
     freeze_frame: {
-      description: "Create a freeze frame from a clip at a specific time. Exports the frame and imports it back as a still image.",
+      description:
+        "Create a freeze frame from a clip at a specific time. Exports the frame and imports it back as a still image.",
       parameters: {
         type: "object" as const,
         properties: {
           time_seconds: {
             type: "number",
-            description: "Time in the sequence to freeze (in seconds). Uses playhead if omitted.",
+            description:
+              "Time in the sequence to freeze (in seconds). Uses playhead if omitted.",
           },
           output_path: {
             type: "string",
-            description: "Full path for the exported frame (e.g., /path/to/freeze.png)",
+            description:
+              "Full path for the exported frame (e.g., /path/to/freeze.png)",
           },
           duration_seconds: {
             type: "number",
-            description: "Duration of the freeze frame on the timeline (default: 2)",
+            description:
+              "Duration of the freeze frame on the timeline (default: 2)",
           },
         },
         required: ["output_path"],
       },
-      handler: async (args: { time_seconds?: number; output_path: string; duration_seconds?: number }) => {
+      handler: async (args: {
+        time_seconds?: number;
+        output_path: string;
+        duration_seconds?: number;
+      }) => {
         const script = buildToolScript(`
           var seq = app.project.activeSequence;
           if (!seq) return __error("No active sequence");
 
-          ${args.time_seconds !== undefined
-            ? `var timeTicks = __secondsToTicks(${args.time_seconds}).toString();`
-            : `var timeTicks = seq.getPlayerPosition().ticks;`}
+          ${
+            args.time_seconds !== undefined
+              ? `var timeTicks = __secondsToTicks(${args.time_seconds}).toString();`
+              : `var timeTicks = seq.getPlayerPosition().ticks;`
+          }
 
           var res = __exportStillFrame("${escapeForExtendScript(args.output_path)}", timeTicks);
           if (!res.ok) return __error(res.error + " [" + res.notes.join("; ") + "]");
@@ -215,7 +232,8 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
         properties: {
           frame_rate: {
             type: "number",
-            description: "New frame rate (e.g., 23.976, 24, 25, 29.97, 30, 50, 59.94, 60)",
+            description:
+              "New frame rate (e.g., 23.976, 24, 25, 29.97, 30, 50, 59.94, 60)",
           },
         },
         required: ["frame_rate"],
@@ -272,7 +290,8 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
     },
 
     set_sequence_audio_settings: {
-      description: "Change audio settings of the active sequence (sample rate, channel type).",
+      description:
+        "Change audio settings of the active sequence (sample rate, channel type).",
       parameters: {
         type: "object" as const,
         properties: {
@@ -282,11 +301,15 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
           },
           channel_type: {
             type: "number",
-            description: "Channel type: 0=Mono, 1=Stereo, 2=5.1, 3=Multichannel",
+            description:
+              "Channel type: 0=Mono, 1=Stereo, 2=5.1, 3=Multichannel",
           },
         },
       },
-      handler: async (args: { sample_rate?: number; channel_type?: number }) => {
+      handler: async (args: {
+        sample_rate?: number;
+        channel_type?: number;
+      }) => {
         const script = buildToolScript(`
           var seq = app.project.activeSequence;
           if (!seq) return __error("No active sequence");
@@ -311,7 +334,8 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
         properties: {
           ratio: {
             type: "number",
-            description: "Pixel aspect ratio (1.0 for square pixels, 1.4222 for 16:9 DV, etc.)",
+            description:
+              "Pixel aspect ratio (1.0 for square pixels, 1.4222 for 16:9 DV, etc.)",
           },
         },
         required: ["ratio"],
@@ -340,7 +364,8 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
         properties: {
           field_type: {
             type: "number",
-            description: "0=No Fields (Progressive), 1=Upper Field First, 2=Lower Field First",
+            description:
+              "0=No Fields (Progressive), 1=Upper Field First, 2=Lower Field First",
           },
         },
         required: ["field_type"],
@@ -363,7 +388,8 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
     },
 
     get_all_project_paths: {
-      description: "Get all unique media file paths used in the project. Useful for asset management and archiving.",
+      description:
+        "Get all unique media file paths used in the project. Useful for asset management and archiving.",
       parameters: {},
       handler: async () => {
         const script = buildToolScript(`
@@ -399,7 +425,8 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
     },
 
     get_unused_media: {
-      description: "Find all project items that are NOT used in any sequence. Useful for cleaning up projects.",
+      description:
+        "Find all project items that are NOT used in any sequence. Useful for cleaning up projects.",
       parameters: {},
       handler: async () => {
         const script = buildToolScript(`
@@ -449,7 +476,8 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
     },
 
     get_duplicate_media: {
-      description: "Find project items that reference the same source media file. Useful for consolidation.",
+      description:
+        "Find project items that reference the same source media file. Useful for consolidation.",
       parameters: {},
       handler: async () => {
         const script = buildToolScript(`
@@ -483,7 +511,8 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
     },
 
     lift_selection: {
-      description: "Lift (remove without closing gap) the content between sequence in/out points or selected clips.",
+      description:
+        "Lift (remove without closing gap) the content between sequence in/out points or selected clips.",
       parameters: {},
       handler: async () => {
         const script = buildToolScript(`
@@ -504,7 +533,8 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
     },
 
     extract_selection: {
-      description: "Extract (remove and close gap) the content between sequence in/out points.",
+      description:
+        "Extract (remove and close gap) the content between sequence in/out points.",
       parameters: {},
       handler: async () => {
         const script = buildToolScript(`
@@ -525,7 +555,8 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
     },
 
     get_clip_links: {
-      description: "Get information about linked clips (audio/video linked together) for a given clip.",
+      description:
+        "Get information about linked clips (audio/video linked together) for a given clip.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -593,18 +624,26 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
     },
 
     get_sequence_markers_by_type: {
-      description: "Get all markers of a specific type (comment, chapter, web link, etc.) from a sequence.",
+      description:
+        "Get all markers of a specific type (comment, chapter, web link, etc.) from a sequence.",
       parameters: {
         type: "object" as const,
         properties: {
           marker_type: {
             type: "string",
-            enum: ["Comment", "Chapter", "Segmentation", "WebLink", "FlashCuePoint"],
+            enum: [
+              "Comment",
+              "Chapter",
+              "Segmentation",
+              "WebLink",
+              "FlashCuePoint",
+            ],
             description: "Type of marker to filter",
           },
           sequence_id: {
             type: "string",
-            description: "Sequence name or ID. Uses active sequence if omitted.",
+            description:
+              "Sequence name or ID. Uses active sequence if omitted.",
           },
         },
         required: ["marker_type"],
@@ -639,7 +678,8 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
     },
 
     get_clip_markers: {
-      description: "Get all markers on a specific project item (source clip markers, not sequence markers).",
+      description:
+        "Get all markers on a specific project item (source clip markers, not sequence markers).",
       parameters: {
         type: "object" as const,
         properties: {
@@ -701,7 +741,8 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
           },
           duration_seconds: {
             type: "number",
-            description: "Duration of the marker in seconds (0 for point marker)",
+            description:
+              "Duration of the marker in seconds (0 for point marker)",
           },
           type: {
             type: "string",
@@ -734,11 +775,15 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
           ${args.name ? `marker.name = "${escapeForExtendScript(args.name)}";` : ""}
           ${args.comments ? `marker.comments = "${escapeForExtendScript(args.comments)}";` : ""}
           ${args.type ? `marker.type = "${escapeForExtendScript(args.type)}";` : ""}
-          ${args.duration_seconds !== undefined ? `
+          ${
+            args.duration_seconds !== undefined
+              ? `
           var endTime = new Time();
           endTime.seconds = ${args.time_seconds + args.duration_seconds};
           marker.end = endTime;
-          ` : ""}
+          `
+              : ""
+          }
           ${args.color_index !== undefined ? `marker.setColorByIndex(${args.color_index});` : ""}
 
           return __result({ added: true, item: item.name, timeSeconds: ${args.time_seconds} });
@@ -754,7 +799,8 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
         properties: {
           video_display_format: {
             type: "number",
-            description: "Video: 0=24 Timecode, 1=25 Timecode, 2=29.97 Drop-frame, 3=29.97 Non-drop-frame, 4=30 Timecode, 5=50 Timecode, 6=59.94 Drop-frame, 7=59.94 Non-drop-frame, 8=60 Timecode, 9=Frames, 10=Feet+Frames 16mm, 11=Feet+Frames 35mm",
+            description:
+              "Video: 0=24 Timecode, 1=25 Timecode, 2=29.97 Drop-frame, 3=29.97 Non-drop-frame, 4=30 Timecode, 5=50 Timecode, 6=59.94 Drop-frame, 7=59.94 Non-drop-frame, 8=60 Timecode, 9=Frames, 10=Feet+Frames 16mm, 11=Feet+Frames 35mm",
           },
           audio_display_format: {
             type: "number",
@@ -762,7 +808,10 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
           },
         },
       },
-      handler: async (args: { video_display_format?: number; audio_display_format?: number }) => {
+      handler: async (args: {
+        video_display_format?: number;
+        audio_display_format?: number;
+      }) => {
         const script = buildToolScript(`
           var seq = app.project.activeSequence;
           if (!seq) return __error("No active sequence");
@@ -781,7 +830,8 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
     },
 
     get_clip_at_playhead: {
-      description: "Get all clips at the current playhead position across all tracks.",
+      description:
+        "Get all clips at the current playhead position across all tracks.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -839,7 +889,8 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
     },
 
     get_next_edit_point: {
-      description: "Find the next or previous edit point (clip boundary) from the playhead position.",
+      description:
+        "Find the next or previous edit point (clip boundary) from the playhead position.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -972,7 +1023,8 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
     },
 
     set_project_scratch_disk: {
-      description: "Set the project's scratch disk paths for captured video, audio, and previews.",
+      description:
+        "Set the project's scratch disk paths for captured video, audio, and previews.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -994,20 +1046,41 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
           },
         },
       },
-      handler: async (args: { captured_video?: string; captured_audio?: string; video_previews?: string; audio_previews?: string }) => {
+      handler: async (args: {
+        captured_video?: string;
+        captured_audio?: string;
+        video_previews?: string;
+        audio_previews?: string;
+      }) => {
         const script = buildToolScript(`
           var project = app.project;
           if (!project) return __error("No project open");
 
           var set = {};
-          ${args.captured_video ? `
-          try { project.setScratchDiskPath("${escapeForExtendScript(args.captured_video)}", 0); set.capturedVideo = "${escapeForExtendScript(args.captured_video)}"; } catch(e) {}` : ""}
-          ${args.captured_audio ? `
-          try { project.setScratchDiskPath("${escapeForExtendScript(args.captured_audio)}", 1); set.capturedAudio = "${escapeForExtendScript(args.captured_audio)}"; } catch(e) {}` : ""}
-          ${args.video_previews ? `
-          try { project.setScratchDiskPath("${escapeForExtendScript(args.video_previews)}", 2); set.videoPreviews = "${escapeForExtendScript(args.video_previews)}"; } catch(e) {}` : ""}
-          ${args.audio_previews ? `
-          try { project.setScratchDiskPath("${escapeForExtendScript(args.audio_previews)}", 3); set.audioPreviews = "${escapeForExtendScript(args.audio_previews)}"; } catch(e) {}` : ""}
+          ${
+            args.captured_video
+              ? `
+          try { project.setScratchDiskPath("${escapeForExtendScript(args.captured_video)}", 0); set.capturedVideo = "${escapeForExtendScript(args.captured_video)}"; } catch(e) {}`
+              : ""
+          }
+          ${
+            args.captured_audio
+              ? `
+          try { project.setScratchDiskPath("${escapeForExtendScript(args.captured_audio)}", 1); set.capturedAudio = "${escapeForExtendScript(args.captured_audio)}"; } catch(e) {}`
+              : ""
+          }
+          ${
+            args.video_previews
+              ? `
+          try { project.setScratchDiskPath("${escapeForExtendScript(args.video_previews)}", 2); set.videoPreviews = "${escapeForExtendScript(args.video_previews)}"; } catch(e) {}`
+              : ""
+          }
+          ${
+            args.audio_previews
+              ? `
+          try { project.setScratchDiskPath("${escapeForExtendScript(args.audio_previews)}", 3); set.audioPreviews = "${escapeForExtendScript(args.audio_previews)}"; } catch(e) {}`
+              : ""
+          }
 
           return __result(set);
         `);
@@ -1036,7 +1109,8 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
     },
 
     nest_clips: {
-      description: "Nest selected clips into a nested sequence. Select the clips first, then call this tool.",
+      description:
+        "Nest selected clips into a nested sequence. Select the clips first, then call this tool.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -1091,7 +1165,8 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
     },
 
     get_total_clip_count: {
-      description: "Get the total number of clips across all tracks in the active sequence.",
+      description:
+        "Get the total number of clips across all tracks in the active sequence.",
       parameters: {},
       handler: async () => {
         const script = buildToolScript(`
@@ -1109,7 +1184,8 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
     },
 
     match_frame: {
-      description: "Get source media info for the frame at the current playhead on a specific track. Useful for match frame operations.",
+      description:
+        "Get source media info for the frame at the current playhead on a specific track. Useful for match frame operations.",
       parameters: {
         type: "object" as const,
         properties: {

--- a/tests/schema-conversion.test.ts
+++ b/tests/schema-conversion.test.ts
@@ -22,7 +22,11 @@ const ALL_TYPES_TOOL = {
         str_param: { type: "string", description: "A string" },
         num_param: { type: "number", description: "A number" },
         bool_param: { type: "boolean", description: "A boolean" },
-        arr_param: { type: "array", description: "An array" },
+        arr_param: {
+          type: "array",
+          items: { type: "string" },
+          description: "An array",
+        },
         obj_param: { type: "object", description: "An object" },
         enum_param: {
           type: "string",
@@ -60,7 +64,9 @@ vi.mock("../src/tools/media.js", () => ({ getMediaTools: () => ({}) }));
 vi.mock("../src/tools/sequence.js", () => ({ getSequenceTools: () => ({}) }));
 vi.mock("../src/tools/timeline.js", () => ({ getTimelineTools: () => ({}) }));
 vi.mock("../src/tools/effects.js", () => ({ getEffectsTools: () => ({}) }));
-vi.mock("../src/tools/transitions.js", () => ({ getTransitionsTools: () => ({}) }));
+vi.mock("../src/tools/transitions.js", () => ({
+  getTransitionsTools: () => ({}),
+}));
 vi.mock("../src/tools/audio.js", () => ({ getAudioTools: () => ({}) }));
 vi.mock("../src/tools/text.js", () => ({ getTextTools: () => ({}) }));
 vi.mock("../src/tools/markers.js", () => ({ getMarkerTools: () => ({}) }));
@@ -71,17 +77,25 @@ vi.mock("../src/tools/export.js", () => ({ getExportTools: () => ({}) }));
 vi.mock("../src/tools/advanced.js", () => ({ getAdvancedTools: () => ({}) }));
 vi.mock("../src/tools/keyframes.js", () => ({ getKeyframeTools: () => ({}) }));
 vi.mock("../src/tools/scripting.js", () => ({ getScriptingTools: () => ({}) }));
-vi.mock("../src/tools/inspection.js", () => ({ getInspectionTools: () => ({}) }));
+vi.mock("../src/tools/inspection.js", () => ({
+  getInspectionTools: () => ({}),
+}));
 vi.mock("../src/tools/selection.js", () => ({ getSelectionTools: () => ({}) }));
 vi.mock("../src/tools/clipboard.js", () => ({ getClipboardTools: () => ({}) }));
-vi.mock("../src/tools/source-monitor.js", () => ({ getSourceMonitorTools: () => ({}) }));
-vi.mock("../src/tools/track-targeting.js", () => ({ getTrackTargetingTools: () => ({}) }));
+vi.mock("../src/tools/source-monitor.js", () => ({
+  getSourceMonitorTools: () => ({}),
+}));
+vi.mock("../src/tools/track-targeting.js", () => ({
+  getTrackTargetingTools: () => ({}),
+}));
 vi.mock("../src/tools/utility.js", () => ({ getUtilityTools: () => ({}) }));
 vi.mock("../src/tools/health.js", () => ({ getHealthTools: () => ({}) }));
 vi.mock("../src/tools/workspace.js", () => ({ getWorkspaceTools: () => ({}) }));
 vi.mock("../src/tools/captions.js", () => ({ getCaptionTools: () => ({}) }));
 vi.mock("../src/tools/playback.js", () => ({ getPlaybackTools: () => ({}) }));
-vi.mock("../src/tools/project-manager.js", () => ({ getProjectManagerTools: () => ({}) }));
+vi.mock("../src/tools/project-manager.js", () => ({
+  getProjectManagerTools: () => ({}),
+}));
 vi.mock("../src/resources/extendscript-reference.js", () => ({
   EXTENDSCRIPT_REFERENCE: "mock",
 }));
@@ -139,7 +153,7 @@ describe("Server tool registration callback", () => {
   it("returns text content on successful tool call", async () => {
     // The server wraps tool handlers in a callback that formats results.
     // We test this by verifying the server creates successfully.
-    // (The actual MCP protocol callback is internal to the SDK, 
+    // (The actual MCP protocol callback is internal to the SDK,
     //  but we validated handler return values in tool-modules.test.ts)
     const server = createServer({});
     expect(server).toBeDefined();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,17 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "cep-plugin"]
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "cep-plugin"
+  ]
 }


### PR DESCRIPTION
## Summary
- upgrade core deps and toolchain: TypeScript 7, Vitest 4, Zod 4, @modelcontextprotocol/sdk 1.29
- fix JSON-schema-to-Zod conversion for Zod 4 object/array semantics and add typed array items in tool parameter schemas
- add Node types to tsconfig for TS7 compile compatibility
- update docs, repo links, and debug logging notes

## Commits in this PR
1. chore(deps): upgrade TypeScript 7, Vitest 4, Zod 4 and MCP SDK
2. fix(schema): support Zod 4 JSON-schema conversion and typed array items
3. docs: update setup guidance, repo links, and debug logging notes

## Validation
- npm run build passes
- npm test passes