### PR TITLE
Upgrade cross-platform CI to setup-node v7

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -19,7 +19,7 @@ jobs:
         node: [20, 22, 24]
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node }}
           cache: npm


### PR DESCRIPTION
Completes the action upgrade superseding #26 and removes Node 20 action-runtime deprecation warnings from the release validation matrix.