### PR TITLE
Fix sequence frame-rate timebase corruption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-07-25
+
+### Fixed
+
+- Fixed `set_sequence_frame_rate` to convert frames per second into Premiere's required
+  ticks-per-frame `Time` value and verify the applied setting instead of assigning a numeric frame
+  period that could corrupt the sequence timebase. ([#37](https://github.com/leancoderkavy/premiere-pro-mcp/issues/37))
+
 ## [1.3.0] - 2026-07-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -27,10 +27,12 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 
 The AI handles the entire workflow through 269 tools spanning the supported ExtendScript, QE DOM, and safe edit-planning surfaces.
 
-### What's new in 1.3.0
+### What's new in 1.3.1
 
 - Windows npm releases now include a verified, signed CEP ZXP and install it automatically, covering
   hosts that reject the raw development bundle even when `PlayerDebugMode` is enabled.
+- `set_sequence_frame_rate` now converts frames per second to Premiere ticks per frame and verifies
+  the applied setting instead of assigning a numeric frame period.
 - `premiere-pro-mcp --diagnose-cep` checks the installed manifest, debug-key types, and recent
   Premiere signature failures.
 - TypeScript 7, Vitest 4, Zod 4, MCP SDK 1.29, Next.js 16.2, and patched transitive dependencies

--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.3.0" ExtensionBundleName="MCP Bridge">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.3.1" ExtensionBundleName="MCP Bridge">
   <ExtensionList>
-    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.3.0"/>
-    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.3.0"/>
+    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.3.1"/>
+    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.3.1"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "premiere-pro-mcp",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Adobe Premiere Pro MCP server with 269 AI video editing tools for timeline automation, effects, media management, and export.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/tools/utility.ts
+++ b/src/tools/utility.ts
@@ -232,6 +232,8 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
         properties: {
           frame_rate: {
             type: "number",
+            minimum: 1,
+            maximum: 240,
             description:
               "New frame rate (e.g., 23.976, 24, 25, 29.97, 30, 50, 59.94, 60)",
           },
@@ -239,6 +241,12 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
         required: ["frame_rate"],
       },
       handler: async (args: { frame_rate: number }) => {
+        if (!Number.isFinite(args.frame_rate) || args.frame_rate < 1 || args.frame_rate > 240) {
+          return {
+            success: false,
+            error: "frame_rate must be a finite value between 1 and 240 fps",
+          };
+        }
         const script = buildToolScript(`
           var seq = app.project.activeSequence;
           if (!seq) return __error("No active sequence");
@@ -246,10 +254,30 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
           var settings = seq.getSettings();
           if (!settings) return __error("Could not get sequence settings");
 
-          settings.videoFrameRate = ${args.frame_rate};
+          var requestedFps = ${args.frame_rate};
+          var requestedTicks = Math.round(TICKS_PER_SECOND / requestedFps);
+          var frameDuration = new Time();
+          frameDuration.ticks = requestedTicks.toString();
+          settings.videoFrameRate = frameDuration;
           seq.setSettings(settings);
 
-          return __result({ frameRate: ${args.frame_rate}, sequence: seq.name });
+          var applied = seq.getSettings();
+          if (!applied || !applied.videoFrameRate) {
+            return __error("Premiere did not return the updated sequence frame rate");
+          }
+          var appliedTicks = parseFloat(applied.videoFrameRate.ticks);
+          if (!isFinite(appliedTicks) || Math.abs(appliedTicks - requestedTicks) > 1) {
+            return __error(
+              "Premiere did not apply the requested frame rate: expected " +
+              requestedTicks + " ticks/frame, got " + appliedTicks
+            );
+          }
+
+          return __result({
+            frameRate: requestedFps,
+            ticksPerFrame: requestedTicks.toString(),
+            sequence: seq.name
+          });
         `);
         return sendCommand(script, bridgeOptions);
       },

--- a/tests/tools/regressions.test.ts
+++ b/tests/tools/regressions.test.ts
@@ -219,3 +219,27 @@ describe("script-builder helpers used by the fixes are actually defined", () => 
     }
   });
 });
+
+// https://github.com/leancoderkavy/premiere-pro-mcp/issues/37
+describe("issue #37 — sequence frame rate uses ticks per frame", () => {
+  const utility = getUtilityTools(bridgeOptions);
+
+  it("converts fps to a Time duration and verifies the applied ticks", async () => {
+    const script = await scriptFor(utility.set_sequence_frame_rate, { frame_rate: 30 });
+
+    expect(script).toContain("TICKS_PER_SECOND / requestedFps");
+    expect(script).toContain("var frameDuration = new Time()");
+    expect(script).toContain("frameDuration.ticks = requestedTicks.toString()");
+    expect(script).toContain("settings.videoFrameRate = frameDuration");
+    expect(script).toContain("Math.abs(appliedTicks - requestedTicks) > 1");
+    expect(script).not.toContain("settings.videoFrameRate = 30");
+  });
+
+  it("rejects invalid frame rates before sending a Premiere command", async () => {
+    mockedSendCommand.mockClear();
+    const result = await utility.set_sequence_frame_rate.handler({ frame_rate: 0 });
+
+    expect(result).toMatchObject({ success: false });
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+  });
+});

--- a/uxp-plugin/manifest.json
+++ b/uxp-plugin/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.ppmcp.premiere.uxp",
   "name": "Premiere Pro MCP Bridge",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "main": "index.html",
   "host": { "app": "premierepro", "minVersion": "25.6.0" },
   "entrypoints": [


### PR DESCRIPTION
Fixes #37 by assigning SequenceSettings.videoFrameRate a Premiere Time value whose ticks are TICKS_PER_SECOND / fps, validating the requested range, and verifying the applied ticks after setSettings. Adds regression coverage and prepares patch release 1.3.1. Validated with 349 tests, build, clean root audit, signed ZXP verification, and npm pack inspection.