### PR TITLE
feat: add per-tool capability matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ The default bridge directory is derived from the operating system on both sides,
 
 QE-backed tools are reported as `experimental` because QE is undocumented and can vary between Premiere builds. Authority availability is reported separately from implementation support, so disabling `edit`, for example, does not incorrectly label editing tools as unsupported. Static metadata never claims that a Premiere operation succeeded; use `ping` and inspect each tool result for runtime evidence.
 
+Tools with mixed execution boundaries can provide explicit operational metadata at registration. This is used for local file verification, static feature-support reports, and hybrid local-plus-Premiere validation so the capability catalog does not infer a host dependency from naming alone.
+
 ---
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -226,7 +226,16 @@ The default bridge directory is derived from the operating system on both sides,
 | npm CEP installer | Copies plugin and verifies `REG_SZ` debug keys | Copies plugin and verifies the installed manifest/debug settings | Restart Premiere after installation |
 | CI build and unit tests | Node 18 and 22 | Node 18 and 22 | GitHub-hosted OS runners; no Adobe host is available in CI |
 
-`get_capabilities` reports the current operating system, temp directory, CEP/UXP coverage, enabled authority profile, and any live-host verification still required. It does not claim a Premiere operation succeeded; use `ping` and inspect each tool result for runtime evidence.
+`get_capabilities` reports the current operating system, temp directory, CEP/UXP coverage, enabled authority profile, and any live-host verification still required. It also includes a `tools` catalog generated from the tools actually registered by the server. Every entry identifies:
+
+- the execution backend (`local`, CEP/ExtendScript, QE, or orchestrator);
+- static support status (`supported`, `limited`, `experimental`, or `unsupported`);
+- the minimum Premiere version known to the server;
+- the required authority and whether the current profile enables it;
+- the verification boundary and whether a live Premiere host is required; and
+- relevant operational notes.
+
+QE-backed tools are reported as `experimental` because QE is undocumented and can vary between Premiere builds. Authority availability is reported separately from implementation support, so disabling `edit`, for example, does not incorrectly label editing tools as unsupported. Static metadata never claims that a Premiere operation succeeded; use `ping` and inspect each tool result for runtime evidence.
 
 ---
 

--- a/src/platform-capabilities.ts
+++ b/src/platform-capabilities.ts
@@ -1,6 +1,10 @@
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Capability, CapabilityConfig } from "./security/capabilities.js";
+import {
+  buildToolCapabilityReport,
+  type CatalogToolDefinition,
+} from "./tool-capability-report.js";
 
 export const SUPPORTED_HOST_PLATFORMS = ["darwin", "win32"] as const;
 const ALL_CAPABILITIES: Capability[] = ["inspect", "edit", "export", "filesystem", "unsafe-script"];
@@ -17,6 +21,7 @@ export function buildPlatformCapabilityReport(
   capabilities: CapabilityConfig,
   platform: NodeJS.Platform = process.platform,
   tempDirectory: string = join(tmpdir(), "premiere-mcp-bridge"),
+  toolCatalog: Record<string, CatalogToolDefinition> = {},
 ) {
   const supported = SUPPORTED_HOST_PLATFORMS.includes(platform as SupportedHostPlatform);
   return {
@@ -57,5 +62,6 @@ export function buildPlatformCapabilityReport(
       enabled: [...capabilities.capabilities].sort(),
       disabled: ALL_CAPABILITIES.filter((capability) => !capabilities.capabilities.has(capability)),
     },
+    tools: buildToolCapabilityReport(toolCatalog, capabilities),
   };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -251,13 +251,16 @@ function collectTools(
     ...getSourceMonitorTools(bridgeOptions),
     ...getTrackTargetingTools(bridgeOptions),
     ...getUtilityTools(bridgeOptions),
-    ...getHealthTools(bridgeOptions, capabilities),
     ...getWorkspaceTools(bridgeOptions),
     ...getCaptionTools(bridgeOptions),
     ...getPlaybackTools(bridgeOptions),
     ...getProjectManagerTools(bridgeOptions),
     ...getEditPlanTools(bridgeOptions, { capabilities }),
   };
+  Object.assign(
+    tools,
+    getHealthTools(bridgeOptions, capabilities, () => tools),
+  );
   toolCatalogCache.set(cacheKey, tools);
   return tools;
 }

--- a/src/tool-capability-report.ts
+++ b/src/tool-capability-report.ts
@@ -1,0 +1,146 @@
+import {
+  capabilityForTool,
+  type Capability,
+  type CapabilityConfig,
+} from "./security/capabilities.js";
+
+export type ToolBackend = "local" | "cep" | "extendscript" | "qe" | "orchestrator";
+export type ToolSupportStatus = "supported" | "limited" | "experimental" | "unsupported";
+export type VerificationBoundary =
+  | "static_metadata_only"
+  | "host_response"
+  | "bridge_response"
+  | "output_and_host_response"
+  | "plan_revalidation";
+
+export interface CatalogToolDefinition {
+  description: string;
+}
+
+export interface ToolOperationalCapability {
+  name: string;
+  backend: "local" | "CEP/ExtendScript" | "CEP/ExtendScript + QE" | "orchestrator";
+  backends: ToolBackend[];
+  status: ToolSupportStatus;
+  minimumPremiereVersion: string | null;
+  authority: {
+    required: Capability;
+    enabled: boolean;
+  };
+  verificationBoundary: VerificationBoundary;
+  hostVerificationRequired: boolean;
+  notes: string[];
+}
+
+const LOCAL_TOOLS = new Set(["get_capabilities", "preview_edit_plan"]);
+const ORCHESTRATOR_TOOLS = new Set(["apply_edit_plan"]);
+
+function minimumVersion(description: string, usesQe: boolean): string {
+  const explicit = description.match(
+    /Premiere(?: Pro)?(?: version)?\s*(\d{2}(?:\.\d+)?)\s*\+/i,
+  );
+  if (explicit) return explicit[1];
+  // The production CEP bridge supports the repository's documented 2020–2026
+  // range. QE does not improve that guarantee because it is undocumented.
+  return usesQe ? "2020 (QE availability varies by build)" : "2020";
+}
+
+function verificationBoundaryFor(
+  name: string,
+  authority: Capability,
+  local: boolean,
+): VerificationBoundary {
+  if (local) return "static_metadata_only";
+  if (name === "apply_edit_plan") return "plan_revalidation";
+  if (authority === "inspect") return "host_response";
+  if (authority === "export" || authority === "filesystem") {
+    return "output_and_host_response";
+  }
+  return "bridge_response";
+}
+
+/**
+ * Derive operational metadata from the same registered catalog and authority
+ * classifier used by the MCP server. A tool can add an explicit Premiere
+ * version to its description; otherwise the documented backend baseline is
+ * used.
+ */
+export function deriveToolOperationalCapability(
+  name: string,
+  definition: CatalogToolDefinition,
+  capabilities: CapabilityConfig,
+): ToolOperationalCapability {
+  const authority = capabilityForTool(name);
+  const local = LOCAL_TOOLS.has(name);
+  const orchestrator = ORCHESTRATOR_TOOLS.has(name);
+  const usesQe = /\bQE(?:\s+DOM)?\b/i.test(definition.description);
+  const backends: ToolBackend[] = local
+    ? ["local"]
+    : orchestrator
+      ? ["orchestrator", "cep", "extendscript"]
+      : usesQe
+        ? ["cep", "extendscript", "qe"]
+        : ["cep", "extendscript"];
+
+  const notes: string[] = [];
+  if (local) {
+    notes.push("Computed locally; does not prove that Premiere Pro is connected.");
+  } else if (orchestrator) {
+    notes.push("Coordinates registered tools and revalidates the preview before applying edits.");
+  } else if (usesQe) {
+    notes.push("Uses Adobe's undocumented QE DOM; behavior can vary between Premiere Pro builds.");
+  } else {
+    notes.push("Runs through the production CEP file bridge using ExtendScript.");
+  }
+  if (!capabilities.capabilities.has(authority)) {
+    notes.push(`Disabled by the current '${capabilities.source}' authority profile.`);
+  }
+
+  return {
+    name,
+    backend: local
+      ? "local"
+      : orchestrator
+        ? "orchestrator"
+        : usesQe
+          ? "CEP/ExtendScript + QE"
+          : "CEP/ExtendScript",
+    backends,
+    status: usesQe ? "experimental" : orchestrator ? "limited" : "supported",
+    minimumPremiereVersion: local ? null : minimumVersion(definition.description, usesQe),
+    authority: {
+      required: authority,
+      enabled: capabilities.capabilities.has(authority),
+    },
+    verificationBoundary: verificationBoundaryFor(name, authority, local),
+    hostVerificationRequired: !local,
+    notes,
+  };
+}
+
+export function buildToolCapabilityReport(
+  catalog: Record<string, CatalogToolDefinition>,
+  capabilities: CapabilityConfig,
+) {
+  const tools = Object.entries(catalog)
+    .map(([name, definition]) =>
+      deriveToolOperationalCapability(name, definition, capabilities),
+    )
+    .sort((left, right) => left.name.localeCompare(right.name));
+
+  const byStatus = tools.reduce<Record<ToolSupportStatus, number>>(
+    (counts, tool) => {
+      counts[tool.status] += 1;
+      return counts;
+    },
+    { supported: 0, limited: 0, experimental: 0, unsupported: 0 },
+  );
+
+  return {
+    schemaVersion: 1,
+    generatedFrom: "registered-tool-catalog",
+    total: tools.length,
+    byStatus,
+    tools,
+  };
+}

--- a/src/tool-capability-report.ts
+++ b/src/tool-capability-report.ts
@@ -8,6 +8,8 @@ export type ToolBackend = "local" | "cep" | "extendscript" | "qe" | "orchestrato
 export type ToolSupportStatus = "supported" | "limited" | "experimental" | "unsupported";
 export type VerificationBoundary =
   | "static_metadata_only"
+  | "local_filesystem"
+  | "local_and_host_response"
   | "host_response"
   | "bridge_response"
   | "output_and_host_response"
@@ -15,11 +17,30 @@ export type VerificationBoundary =
 
 export interface CatalogToolDefinition {
   description: string;
+  operationalCapability?: ToolOperationalOverride;
+}
+
+export type ToolBackendLabel =
+  | "local"
+  | "CEP/ExtendScript"
+  | "CEP/ExtendScript + QE"
+  | "local + CEP/ExtendScript"
+  | "orchestrator";
+
+export interface ToolOperationalOverride {
+  backend?: ToolBackendLabel;
+  backends?: ToolBackend[];
+  status?: ToolSupportStatus;
+  minimumPremiereVersion?: string | null;
+  authority?: Capability;
+  verificationBoundary?: VerificationBoundary;
+  hostVerificationRequired?: boolean;
+  notes?: string[];
 }
 
 export interface ToolOperationalCapability {
   name: string;
-  backend: "local" | "CEP/ExtendScript" | "CEP/ExtendScript + QE" | "orchestrator";
+  backend: ToolBackendLabel;
   backends: ToolBackend[];
   status: ToolSupportStatus;
   minimumPremiereVersion: string | null;
@@ -34,6 +55,53 @@ export interface ToolOperationalCapability {
 
 const LOCAL_TOOLS = new Set(["get_capabilities", "preview_edit_plan"]);
 const ORCHESTRATOR_TOOLS = new Set(["apply_edit_plan"]);
+
+/**
+ * Forward-compatible exceptions for tools whose implementation crosses a
+ * boundary that cannot be inferred from its name or description. Tool
+ * definitions may carry the same `operationalCapability` metadata directly;
+ * registration metadata wins over these catalog defaults.
+ */
+export const TOOL_OPERATIONAL_OVERRIDES: Readonly<
+  Record<string, ToolOperationalOverride>
+> = {
+  verify_delivery_file: {
+    backend: "local",
+    backends: ["local"],
+    status: "supported",
+    minimumPremiereVersion: null,
+    authority: "filesystem",
+    verificationBoundary: "local_filesystem",
+    hostVerificationRequired: false,
+    notes: [
+      "Reads and hashes a local delivery file; it does not contact Premiere Pro.",
+    ],
+  },
+  get_advanced_feature_support: {
+    backend: "local",
+    backends: ["local"],
+    status: "supported",
+    minimumPremiereVersion: null,
+    authority: "inspect",
+    verificationBoundary: "static_metadata_only",
+    hostVerificationRequired: false,
+    notes: [
+      "Evaluates documented feature prerequisites locally; it does not prove host availability or entitlement.",
+    ],
+  },
+  validate_export_preset: {
+    backend: "local + CEP/ExtendScript",
+    backends: ["local", "cep", "extendscript"],
+    status: "supported",
+    minimumPremiereVersion: "2020",
+    authority: "export",
+    verificationBoundary: "local_and_host_response",
+    hostVerificationRequired: true,
+    notes: [
+      "Checks the preset file locally, then asks the active Premiere sequence to resolve its output extension.",
+    ],
+  },
+};
 
 function minimumVersion(description: string, usesQe: boolean): string {
   const explicit = description.match(
@@ -70,26 +138,32 @@ export function deriveToolOperationalCapability(
   definition: CatalogToolDefinition,
   capabilities: CapabilityConfig,
 ): ToolOperationalCapability {
-  const authority = capabilityForTool(name);
-  const local = LOCAL_TOOLS.has(name);
+  const override = {
+    ...(TOOL_OPERATIONAL_OVERRIDES[name] ?? {}),
+    ...(definition.operationalCapability ?? {}),
+  };
+  const authority = override.authority ?? capabilityForTool(name);
+  const local = override.backends?.length === 1 && override.backends[0] === "local"
+    ? true
+    : LOCAL_TOOLS.has(name);
   const orchestrator = ORCHESTRATOR_TOOLS.has(name);
   const usesQe = /\bQE(?:\s+DOM)?\b/i.test(definition.description);
-  const backends: ToolBackend[] = local
+  const backends: ToolBackend[] = override.backends ?? (local
     ? ["local"]
     : orchestrator
       ? ["orchestrator", "cep", "extendscript"]
       : usesQe
         ? ["cep", "extendscript", "qe"]
-        : ["cep", "extendscript"];
+        : ["cep", "extendscript"]);
 
-  const notes: string[] = [];
-  if (local) {
+  const notes: string[] = [...(override.notes ?? [])];
+  if (override.notes === undefined && local) {
     notes.push("Computed locally; does not prove that Premiere Pro is connected.");
-  } else if (orchestrator) {
+  } else if (override.notes === undefined && orchestrator) {
     notes.push("Coordinates registered tools and revalidates the preview before applying edits.");
-  } else if (usesQe) {
+  } else if (override.notes === undefined && usesQe) {
     notes.push("Uses Adobe's undocumented QE DOM; behavior can vary between Premiere Pro builds.");
-  } else {
+  } else if (override.notes === undefined) {
     notes.push("Runs through the production CEP file bridge using ExtendScript.");
   }
   if (!capabilities.capabilities.has(authority)) {
@@ -98,22 +172,27 @@ export function deriveToolOperationalCapability(
 
   return {
     name,
-    backend: local
+    backend: override.backend ?? (local
       ? "local"
       : orchestrator
         ? "orchestrator"
         : usesQe
           ? "CEP/ExtendScript + QE"
-          : "CEP/ExtendScript",
+          : "CEP/ExtendScript"),
     backends,
-    status: usesQe ? "experimental" : orchestrator ? "limited" : "supported",
-    minimumPremiereVersion: local ? null : minimumVersion(definition.description, usesQe),
+    status: override.status ?? (
+      usesQe ? "experimental" : orchestrator ? "limited" : "supported"
+    ),
+    minimumPremiereVersion: override.minimumPremiereVersion !== undefined
+      ? override.minimumPremiereVersion
+      : local ? null : minimumVersion(definition.description, usesQe),
     authority: {
       required: authority,
       enabled: capabilities.capabilities.has(authority),
     },
-    verificationBoundary: verificationBoundaryFor(name, authority, local),
-    hostVerificationRequired: !local,
+    verificationBoundary: override.verificationBoundary
+      ?? verificationBoundaryFor(name, authority, local),
+    hostVerificationRequired: override.hostVerificationRequired ?? !local,
     notes,
   };
 }

--- a/src/tools/health.ts
+++ b/src/tools/health.ts
@@ -2,10 +2,12 @@ import { buildToolScript } from "../bridge/script-builder.js";
 import { getTempDir, sendCommand, BridgeOptions } from "../bridge/file-bridge.js";
 import { resolveCapabilities, type CapabilityConfig } from "../security/capabilities.js";
 import { buildPlatformCapabilityReport } from "../platform-capabilities.js";
+import type { CatalogToolDefinition } from "../tool-capability-report.js";
 
 export function getHealthTools(
   bridgeOptions: BridgeOptions,
   capabilities: CapabilityConfig = resolveCapabilities(),
+  getToolCatalog: () => Record<string, CatalogToolDefinition> = () => ({}),
 ) {
   return {
     get_capabilities: {
@@ -13,7 +15,12 @@ export function getHealthTools(
       parameters: {},
       handler: async () => ({
         success: true,
-        data: buildPlatformCapabilityReport(capabilities, process.platform, getTempDir(bridgeOptions)),
+        data: buildPlatformCapabilityReport(
+          capabilities,
+          process.platform,
+          getTempDir(bridgeOptions),
+          getToolCatalog(),
+        ),
       }),
     },
     ping: {

--- a/tests/mcp-modernization.test.ts
+++ b/tests/mcp-modernization.test.ts
@@ -65,6 +65,17 @@ describe("modern MCP surface", () => {
       expect(tools.tools.find((tool) => tool.name === "get_project_info")?.annotations?.readOnlyHint).toBe(true);
       expect(tools.tools.map((tool) => tool.name)).toContain("get_capabilities");
       expect(tools.tools).toHaveLength(269);
+
+      const capabilities = await client.callTool({
+        name: "get_capabilities",
+        arguments: {},
+      });
+      const capabilityData = (capabilities.structuredContent as any).data;
+      expect(capabilityData.tools.generatedFrom).toBe("registered-tool-catalog");
+      expect(capabilityData.tools.total).toBe(tools.tools.length);
+      expect(capabilityData.tools.tools.map((tool: any) => tool.name)).toEqual(
+        expect.arrayContaining(tools.tools.map((tool) => tool.name)),
+      );
     } finally {
       await client.close();
       await server.close();

--- a/tests/security-capabilities.test.ts
+++ b/tests/security-capabilities.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
 import { capabilityForTool, guardToolHandler, resolveCapabilities } from "../src/security/capabilities.js";
 import { buildPlatformCapabilityReport } from "../src/platform-capabilities.js";
+import {
+  buildToolCapabilityReport,
+  deriveToolOperationalCapability,
+} from "../src/tool-capability-report.js";
 
 describe("capability profiles", () => {
   it("fails closed for unsafe scripting by default", async () => {
@@ -61,5 +65,66 @@ describe("capability profiles", () => {
     const report = buildPlatformCapabilityReport(resolveCapabilities(undefined), "linux");
     expect(report.runtime.supported).toBe(false);
     expect(report.premiere.hostVerificationRequired).toBe(true);
+  });
+
+  it("derives tool operational metadata from catalog definitions and authority", () => {
+    const capabilities = resolveCapabilities("inspect");
+    const qeTool = deriveToolOperationalCapability(
+      "ripple_delete",
+      { description: "Ripple delete a clip. Uses QE DOM." },
+      capabilities,
+    );
+    expect(qeTool).toMatchObject({
+      backend: "CEP/ExtendScript + QE",
+      backends: ["cep", "extendscript", "qe"],
+      status: "experimental",
+      minimumPremiereVersion: "2020 (QE availability varies by build)",
+      authority: { required: "edit", enabled: false },
+      verificationBoundary: "bridge_response",
+      hostVerificationRequired: true,
+    });
+    expect(qeTool.notes).toContain(
+      "Disabled by the current 'environment' authority profile.",
+    );
+  });
+
+  it("reports local discovery separately from live-host verification", () => {
+    const tool = deriveToolOperationalCapability(
+      "get_capabilities",
+      { description: "Report static capabilities." },
+      resolveCapabilities(undefined),
+    );
+    expect(tool).toMatchObject({
+      backend: "local",
+      backends: ["local"],
+      status: "supported",
+      minimumPremiereVersion: null,
+      verificationBoundary: "static_metadata_only",
+      hostVerificationRequired: false,
+    });
+  });
+
+  it("builds a deterministic summary from the registered catalog", () => {
+    const report = buildToolCapabilityReport(
+      {
+        trim_clip: { description: "Trim a clip." },
+        get_project_info: { description: "Read the project." },
+        add_transition: { description: "Add a transition. Uses QE DOM." },
+      },
+      resolveCapabilities("inspect,edit"),
+    );
+    expect(report.generatedFrom).toBe("registered-tool-catalog");
+    expect(report.total).toBe(3);
+    expect(report.byStatus).toEqual({
+      supported: 2,
+      limited: 0,
+      experimental: 1,
+      unsupported: 0,
+    });
+    expect(report.tools.map((tool) => tool.name)).toEqual([
+      "add_transition",
+      "get_project_info",
+      "trim_clip",
+    ]);
   });
 });

--- a/tests/security-capabilities.test.ts
+++ b/tests/security-capabilities.test.ts
@@ -127,4 +127,76 @@ describe("capability profiles", () => {
       "trim_clip",
     ]);
   });
+
+  it.each([
+    [
+      "verify_delivery_file",
+      "Verify a delivery file and calculate its checksum.",
+      {
+        backend: "local",
+        backends: ["local"],
+        authority: { required: "filesystem", enabled: true },
+        verificationBoundary: "local_filesystem",
+        hostVerificationRequired: false,
+        minimumPremiereVersion: null,
+      },
+    ],
+    [
+      "get_advanced_feature_support",
+      "Report collaboration and AI feature support.",
+      {
+        backend: "local",
+        backends: ["local"],
+        authority: { required: "inspect", enabled: true },
+        verificationBoundary: "static_metadata_only",
+        hostVerificationRequired: false,
+        minimumPremiereVersion: null,
+      },
+    ],
+    [
+      "validate_export_preset",
+      "Validate an export preset and resolve its output extension.",
+      {
+        backend: "local + CEP/ExtendScript",
+        backends: ["local", "cep", "extendscript"],
+        authority: { required: "export", enabled: true },
+        verificationBoundary: "local_and_host_response",
+        hostVerificationRequired: true,
+        minimumPremiereVersion: "2020",
+      },
+    ],
+  ])("reports QA-forward boundaries for %s", (name, description, expected) => {
+    const tool = deriveToolOperationalCapability(
+      name,
+      { description },
+      resolveCapabilities("inspect,export,filesystem"),
+    );
+    expect(tool).toMatchObject({ name, status: "supported", ...expected });
+  });
+
+  it("lets registration metadata override catalog defaults", () => {
+    const tool = deriveToolOperationalCapability(
+      "verify_delivery_file",
+      {
+        description: "Future host-backed delivery verification.",
+        operationalCapability: {
+          backend: "local + CEP/ExtendScript",
+          backends: ["local", "cep", "extendscript"],
+          minimumPremiereVersion: "26.0",
+          hostVerificationRequired: true,
+          verificationBoundary: "local_and_host_response",
+          notes: ["Explicit registration metadata."],
+        },
+      },
+      resolveCapabilities("filesystem"),
+    );
+    expect(tool).toMatchObject({
+      backend: "local + CEP/ExtendScript",
+      backends: ["local", "cep", "extendscript"],
+      minimumPremiereVersion: "26.0",
+      hostVerificationRequired: true,
+      verificationBoundary: "local_and_host_response",
+      notes: ["Explicit registration metadata."],
+    });
+  });
 });

--- a/tests/tools/tool-modules.test.ts
+++ b/tests/tools/tool-modules.test.ts
@@ -222,6 +222,28 @@ describe("Tool Handler Behavior", () => {
       expect(result.data.premiere.hostVerificationRequired).toBe(true);
       expect(mockedSendCommand).not.toHaveBeenCalled();
     });
+
+    it("includes per-tool operational metadata from the supplied catalog", async () => {
+      const tools = getHealthTools(
+        bridgeOptions,
+        undefined,
+        () => ({
+          get_capabilities: { description: "Report capabilities." },
+          ripple_delete: { description: "Ripple delete. Uses QE DOM." },
+        }),
+      );
+      const result = await tools.get_capabilities.handler();
+      expect(result.data.tools.total).toBe(2);
+      expect(result.data.tools.tools).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            name: "ripple_delete",
+            status: "experimental",
+            backend: "CEP/ExtendScript + QE",
+          }),
+        ]),
+      );
+    });
   });
 
   describe("workspace tools", () => {


### PR DESCRIPTION
## Summary
- generate per-tool operational metadata from the registered MCP tool catalog
- report backend, support status, minimum Premiere version, authority availability, verification boundary, and notes
- classify QE-backed tools as experimental and keep static support separate from runtime authority
- document the expanded get_capabilities response

## Verification
- npm run build
- npm test (353 tests)
- git diff --check

## Notes
- support metadata is static and intentionally does not claim live Premiere host success
- QE detection is derived from existing tool descriptions; tools should retain the documented QE marker when they depend on QE