### PR TITLE
feat(uxp): add documented video transition commands

### DIFF
--- a/tests/uxp/commands.test.ts
+++ b/tests/uxp/commands.test.ts
@@ -1,0 +1,97 @@
+import { createRequire } from "node:module";
+import { describe, expect, it, vi } from "vitest";
+const require = createRequire(import.meta.url);
+const Commands = require("../../uxp-plugin/commands.cjs");
+const Protocol = require("../../uxp-plugin/protocol.cjs");
+
+function host(options: { transitions?: boolean; commit?: boolean } = {}) {
+  const addAction = vi.fn(() => true);
+  const add = vi.fn(() => ({ kind: "add" }));
+  const remove = vi.fn(() => ({ kind: "remove" }));
+  const clip = { createAddVideoTransitionAction: add, createRemoveVideoTransitionAction: remove };
+  const track = { getTrackItems: vi.fn(async () => [clip]) };
+  const sequence = {
+    getVideoTrackCount: vi.fn(async () => 1),
+    getVideoTrack: vi.fn(async () => track),
+    getPlayerPosition: vi.fn(async () => ({ seconds: 3 }))
+  };
+  const project = {
+    getActiveSequence: vi.fn(async () => sequence),
+    lockedAccess: vi.fn((callback: () => void) => callback()),
+    executeTransaction: vi.fn((callback: (compound: unknown) => void) => {
+      callback({ addAction });
+      return options.commit !== false;
+    })
+  };
+  const optionValues: Record<string, unknown> = {};
+  const transitionApis = options.transitions === false ? {} : {
+    TransitionFactory: {
+      getVideoTransitionMatchNames: vi.fn(async () => ["CrossDissolve", "DipToBlack"]),
+      createVideoTransition: vi.fn(async (name: string) => ({ name }))
+    },
+    AddTransitionOptions: vi.fn(() => ({
+      setApplyToStart: vi.fn((value: boolean) => { optionValues.applyToStart = value; }),
+      setDuration: vi.fn((value: unknown) => { optionValues.duration = value; }),
+      setForceSingleSided: vi.fn((value: boolean) => { optionValues.forceSingleSided = value; }),
+      setTransitionAlignment: vi.fn((value: number) => { optionValues.transitionAlignment = value; })
+    }))
+  };
+  const ppro = {
+    Project: { getActiveProject: vi.fn(async () => project) },
+    TickTime: { createWithSeconds: vi.fn((seconds: number) => ({ seconds })) },
+    Constants: { TrackItemType: { CLIP: 1 }, TransitionPosition: { START: 0, END: 1 } },
+    ...transitionApis
+  };
+  return { registry: Commands.createCommandRegistry({ ppro, fs: {}, Protocol }), ppro, project, sequence, track, clip, add, remove, addAction, optionValues };
+}
+
+describe("UXP command registry", () => {
+  it("reports support per command from the runtime API surface", async () => {
+    const available = await host().registry.capabilities();
+    expect(available.commands["transition.video.add"]).toMatchObject({ supported: true, destructive: true, undoable: true, minHostVersion: "25.6.0" });
+    const unavailable = await host({ transitions: false }).registry.capabilities();
+    expect(unavailable.commands["transition.video.add"]).toMatchObject({ supported: false, reason: expect.any(String) });
+  });
+
+  it("lists installed video transition match names", async () => {
+    await expect(host().registry.dispatch("transition.video.list", {})).resolves.toEqual({
+      matchNames: ["CrossDissolve", "DipToBlack"], count: 2
+    });
+  });
+
+  it("adds a configured transition in a locked undoable transaction", async () => {
+    const value = host();
+    await expect(value.registry.dispatch("transition.video.add", {
+      videoTrackIndex: 0, clipIndex: 0, matchName: "CrossDissolve", position: "start",
+      durationSeconds: 0.5, forceSingleSided: true, transitionAlignment: 1
+    })).resolves.toMatchObject({ applied: true, verified: "transaction", position: "start" });
+    expect(value.project.lockedAccess).toHaveBeenCalledOnce();
+    expect(value.project.executeTransaction).toHaveBeenCalledWith(expect.any(Function), "Add video transition");
+    expect(value.add).toHaveBeenCalledWith({ name: "CrossDissolve" }, expect.any(Object));
+    expect(value.optionValues).toEqual({ applyToStart: true, duration: { seconds: 0.5 }, forceSingleSided: true, transitionAlignment: 1 });
+  });
+
+  it("removes the requested transition side in a transaction", async () => {
+    const value = host();
+    await expect(value.registry.dispatch("transition.video.remove", { videoTrackIndex: 0, clipIndex: 0, position: "end" }))
+      .resolves.toMatchObject({ removed: true, position: "end" });
+    expect(value.remove).toHaveBeenCalledWith(1);
+  });
+
+  it("rejects unknown transitions, invalid targets, and failed commits", async () => {
+    await expect(host().registry.dispatch("transition.video.add", { videoTrackIndex: 0, clipIndex: 0, matchName: "Missing" }))
+      .rejects.toMatchObject({ code: "UXP_TRANSITION_NOT_FOUND" });
+    await expect(host().registry.dispatch("transition.video.remove", { videoTrackIndex: 1, clipIndex: 0 }))
+      .rejects.toMatchObject({ code: "UXP_TARGET_NOT_FOUND" });
+    await expect(host({ commit: false }).registry.dispatch("transition.video.remove", { videoTrackIndex: 0, clipIndex: 0 }))
+      .rejects.toMatchObject({ code: "UXP_TRANSACTION_FAILED" });
+  });
+});
+
+describe("UXP transition argument validation", () => {
+  it("requires explicit non-negative clip coordinates and a match name", () => {
+    expect(() => Commands.validateAddArgs({ videoTrackIndex: 0, clipIndex: 0, matchName: "CrossDissolve" })).not.toThrow();
+    expect(() => Commands.validateAddArgs({ videoTrackIndex: -1, clipIndex: 0, matchName: "CrossDissolve" })).toThrow("videoTrackIndex");
+    expect(() => Commands.validateAddArgs({ videoTrackIndex: 0, clipIndex: 0, matchName: "CrossDissolve", surprise: true })).toThrow("Unknown argument");
+  });
+});

--- a/tests/uxp/protocol.test.ts
+++ b/tests/uxp/protocol.test.ts
@@ -13,6 +13,16 @@ describe("UXP bridge protocol", () => {
     expect(protocol.parseCommand('{"type":"command","command":"state.get"}')).toEqual({ requestId: null, command: "state.get", args: {} });
   });
   it("rejects malformed commands", () => expect(() => protocol.parseCommand({ type: "event" })).toThrow("Invalid UXP bridge command"));
+  it("rejects invalid protocol versions and argument shapes", () => {
+    expect(() => protocol.parseCommand({ protocolVersion: 2, type: "command", command: "state.get" })).toThrow("Unsupported UXP protocol version");
+    expect(() => protocol.parseCommand({ type: "command", command: "state.get", args: [] })).toThrow("args must be an object");
+    expect(() => protocol.parseCommand({ type: "command", command: "../state" })).toThrow("Invalid UXP bridge command");
+  });
+  it("bounds request identifiers and command size", () => {
+    expect(() => protocol.parseCommand({ type: "command", requestId: "", command: "state.get" })).toThrow("requestId");
+    const oversized = JSON.stringify({ type: "command", command: "state.get", padding: "x".repeat(protocol.MAX_COMMAND_BYTES) });
+    expect(() => protocol.parseCommand(oversized)).toThrow("64 KiB");
+  });
   it("prevents filename path traversal", () => {
     expect(protocol.safeFilename("shot-01.png")).toBe("shot-01.png");
     expect(() => protocol.safeFilename("../shot.png")).toThrow();

--- a/uxp-plugin/README.md
+++ b/uxp-plugin/README.md
@@ -2,7 +2,25 @@
 
 Production-oriented UXP transport for Premiere Pro 25.6+. Side-load `manifest.json` with UXP Developer Tool, open **Window → UXP Plugins → MCP Bridge**, then point it at the MCP-side WebSocket endpoint (default `ws://127.0.0.1:7777/uxp`).
 
-The bridge sends a versioned `hello`, emits `premiere.state.changed` events, and accepts `capabilities.get`, `state.get`, and `frame.export` commands. `frame.export` uses Adobe's supported `Exporter.exportSequenceFrame()` and verifies the file exists before reporting success. Example:
+The bridge sends a versioned `hello`, emits `premiere.state.changed` events, and accepts capability, state, frame-export, and video-transition commands. `frame.export` uses Adobe's supported `Exporter.exportSequenceFrame()` and verifies the file exists before reporting success.
+
+## Video transition commands
+
+Premiere Pro 25.6+ exposes documented UXP APIs for video transitions. Capability discovery reports each command separately:
+
+- `transition.video.list` returns installed transition match names.
+- `transition.video.add` targets a clip by zero-based video-track and clip index, and supports start/end placement, duration, single-sided behavior, and the host's numeric alignment value.
+- `transition.video.remove` removes the start or end transition from a targeted clip.
+
+Mutations are created and committed inside `Project.lockedAccess()` and `Project.executeTransaction()`, producing one Premiere undo-history entry. A successful response verifies that Premiere accepted the transaction; it does not claim visual or rendered-output verification.
+
+```json
+{"protocolVersion":1,"type":"command","requestId":"42","command":"transition.video.add","args":{"videoTrackIndex":0,"clipIndex":1,"matchName":"CrossDissolve","position":"start","durationSeconds":0.5,"forceSingleSided":false}}
+```
+
+Use `transition.video.list` rather than guessing localized display names: add operations require an exact match name returned by the active host. Audio-transition creation is not advertised because Adobe's documented UXP `TransitionFactory` currently exposes video transitions only.
+
+Frame export example:
 
 ```json
 {"type":"command","requestId":"42","command":"frame.export","args":{"outputDirectory":"C:/temp","filename":"frame.png"}}

--- a/uxp-plugin/commands.cjs
+++ b/uxp-plugin/commands.cjs
@@ -1,0 +1,163 @@
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api;
+  root.PremiereMcpCommands = api;
+})(typeof globalThis !== "undefined" ? globalThis : this, function () {
+  "use strict";
+
+  function createCommandRegistry(deps) {
+    const ppro = deps.ppro, fs = deps.fs, Protocol = deps.Protocol;
+    const definitions = {
+      "capabilities.get": { readOnly: true, handler: capabilities },
+      "state.get": { readOnly: true, handler: stateSnapshot },
+      "frame.export": { probe: canExportFrame, handler: exportFrame },
+      "transition.video.list": { readOnly: true, minHostVersion: "25.6.0", probe: canListTransitions, handler: listTransitions },
+      "transition.video.add": { destructive: true, undoable: true, minHostVersion: "25.6.0", probe: canMutateTransitions, handler: addTransition },
+      "transition.video.remove": { destructive: true, undoable: true, minHostVersion: "25.6.0", probe: canMutateTransitions, handler: removeTransition }
+    };
+
+    async function dispatch(command, args) {
+      const definition = definitions[command];
+      if (!definition) throw commandError("UXP_UNSUPPORTED_COMMAND", "Unsupported UXP command: " + command);
+      if (definition.probe && !definition.probe()) throw commandError("UXP_COMMAND_UNAVAILABLE", command + " is not supported by this Premiere build");
+      return definition.handler(args || {});
+    }
+    async function capabilities() {
+      let project = null, sequence = null;
+      try { project = await ppro.Project.getActiveProject(); sequence = project && await project.getActiveSequence(); } catch (_) {}
+      const commands = {};
+      Object.keys(definitions).forEach((name) => {
+        const definition = definitions[name], supported = !definition.probe || definition.probe();
+        commands[name] = { supported, readOnly: !!definition.readOnly, destructive: !!definition.destructive, undoable: !!definition.undoable };
+        if (definition.minHostVersion) commands[name].minHostVersion = definition.minHostVersion;
+        if (!supported) commands[name].reason = "Required Premiere UXP API is unavailable in this host";
+      });
+      return {
+        backend: "uxp", protocolVersion: Protocol.PROTOCOL_VERSION, hostMinVersion: "25.6.0",
+        activeProject: !!project, activeSequence: !!sequence, commands,
+        fallback: { backend: "cep", reason: "Use CEP/QE only when a command is absent or reports unsupported; never silently retry a failed UXP mutation." }
+      };
+    }
+    async function stateSnapshot() {
+      const project = await ppro.Project.getActiveProject();
+      const sequence = project && await project.getActiveSequence();
+      const position = sequence && await sequence.getPlayerPosition();
+      return { projectOpen: !!project, sequenceOpen: !!sequence, playheadSeconds: position ? position.seconds : null };
+    }
+    async function tickTime(seconds, name) {
+      const value = Number(seconds);
+      if (!Number.isFinite(value) || value < 0) throw commandError("UXP_INVALID_ARGUMENT", name + " must be a non-negative number");
+      if (ppro.TickTime && typeof ppro.TickTime.createWithSeconds === "function") return ppro.TickTime.createWithSeconds(value);
+      throw commandError("UXP_COMMAND_UNAVAILABLE", "This Premiere build cannot create TickTime");
+    }
+    async function activeContext(requireMutationApis) {
+      const project = await ppro.Project.getActiveProject();
+      if (!project) throw commandError("UXP_NO_ACTIVE_PROJECT", "No active project");
+      const sequence = await project.getActiveSequence();
+      if (!sequence) throw commandError("UXP_NO_ACTIVE_SEQUENCE", "No active sequence");
+      if (requireMutationApis && (typeof project.lockedAccess !== "function" || typeof project.executeTransaction !== "function")) {
+        throw commandError("UXP_COMMAND_UNAVAILABLE", "This Premiere build does not expose locked undoable transactions");
+      }
+      return { project, sequence };
+    }
+    async function exportFrame(args) {
+      const context = await activeContext(false);
+      if (!args.outputDirectory) throw commandError("UXP_INVALID_ARGUMENT", "outputDirectory is required");
+      const filename = Protocol.safeFilename(args.filename);
+      const position = args.seconds == null ? await context.sequence.getPlayerPosition() : await tickTime(args.seconds, "seconds");
+      const size = await context.sequence.getFrameSize();
+      const width = positiveInt(args.width, size.width, "width"), height = positiveInt(args.height, size.height, "height");
+      const returned = await ppro.Exporter.exportSequenceFrame(context.sequence, position, filename, args.outputDirectory, width, height);
+      const path = Protocol.joinPath(args.outputDirectory, filename);
+      let exists = false;
+      try { await fs.lstat(path); exists = true; } catch (_) {}
+      if (!exists) throw commandError("UXP_VERIFICATION_FAILED", "Exporter returned " + JSON.stringify(returned) + " but no frame exists at " + path);
+      return { path, width, height, seconds: position.seconds, exporterResult: returned };
+    }
+    async function listTransitions() {
+      const matchNames = Array.from(await ppro.TransitionFactory.getVideoTransitionMatchNames() || []);
+      return { matchNames, count: matchNames.length };
+    }
+    async function addTransition(args) {
+      const input = validateAddArgs(args), context = await activeContext(true);
+      const target = await videoClipAt(context.sequence, input.videoTrackIndex, input.clipIndex);
+      const available = Array.from(await ppro.TransitionFactory.getVideoTransitionMatchNames() || []);
+      if (!available.includes(input.matchName)) throw commandError("UXP_TRANSITION_NOT_FOUND", "Unknown video transition matchName: " + input.matchName);
+      const transition = await ppro.TransitionFactory.createVideoTransition(input.matchName);
+      if (!transition) throw commandError("UXP_TRANSITION_NOT_FOUND", "Premiere could not create video transition: " + input.matchName);
+      const options = ppro.AddTransitionOptions();
+      options.setApplyToStart(input.position === "start");
+      if (input.durationSeconds != null) options.setDuration(await tickTime(input.durationSeconds, "durationSeconds"));
+      if (input.forceSingleSided != null) options.setForceSingleSided(input.forceSingleSided);
+      if (input.transitionAlignment != null) options.setTransitionAlignment(input.transitionAlignment);
+      executeUndoable(context.project, "Add video transition", () => target.createAddVideoTransitionAction(transition, options));
+      return { applied: true, verified: "transaction", matchName: input.matchName, videoTrackIndex: input.videoTrackIndex, clipIndex: input.clipIndex, position: input.position };
+    }
+    async function removeTransition(args) {
+      const input = validateRemoveArgs(args), context = await activeContext(true);
+      const target = await videoClipAt(context.sequence, input.videoTrackIndex, input.clipIndex);
+      const positions = ppro.Constants && ppro.Constants.TransitionPosition;
+      const position = positions && positions[input.position.toUpperCase()];
+      if (position == null) throw commandError("UXP_COMMAND_UNAVAILABLE", "Premiere transition position constants are unavailable");
+      executeUndoable(context.project, "Remove video transition", () => target.createRemoveVideoTransitionAction(position));
+      return { removed: true, verified: "transaction", videoTrackIndex: input.videoTrackIndex, clipIndex: input.clipIndex, position: input.position };
+    }
+    async function videoClipAt(sequence, trackIndex, clipIndex) {
+      const trackCount = await sequence.getVideoTrackCount();
+      if (trackIndex >= trackCount) throw commandError("UXP_TARGET_NOT_FOUND", "videoTrackIndex " + trackIndex + " is out of range");
+      const track = await sequence.getVideoTrack(trackIndex), types = ppro.Constants && ppro.Constants.TrackItemType;
+      if (!track || !types || types.CLIP == null) throw commandError("UXP_COMMAND_UNAVAILABLE", "Premiere video track APIs are unavailable");
+      const clips = await track.getTrackItems(types.CLIP, false);
+      if (!clips || !clips[clipIndex]) throw commandError("UXP_TARGET_NOT_FOUND", "clipIndex " + clipIndex + " is out of range on video track " + trackIndex);
+      return clips[clipIndex];
+    }
+    function executeUndoable(project, label, createAction) {
+      let committed = false;
+      project.lockedAccess(() => {
+        committed = project.executeTransaction((compoundAction) => {
+          const action = createAction();
+          if (!action || compoundAction.addAction(action) === false) throw commandError("UXP_ACTION_REJECTED", "Premiere rejected the transition action");
+        }, label);
+      });
+      if (!committed) throw commandError("UXP_TRANSACTION_FAILED", "Premiere did not commit the transition transaction");
+    }
+    function canExportFrame() { return !!(ppro.Exporter && typeof ppro.Exporter.exportSequenceFrame === "function"); }
+    function canListTransitions() { return !!(ppro.TransitionFactory && typeof ppro.TransitionFactory.getVideoTransitionMatchNames === "function"); }
+    function canMutateTransitions() {
+      return canListTransitions() && typeof ppro.TransitionFactory.createVideoTransition === "function" &&
+        typeof ppro.AddTransitionOptions === "function" && !!(ppro.Constants && ppro.Constants.TrackItemType && ppro.Constants.TransitionPosition);
+    }
+    return { definitions, dispatch, capabilities, stateSnapshot };
+  }
+
+  function validateAddArgs(args) {
+    assertObject(args);
+    assertOnlyKeys(args, ["videoTrackIndex", "clipIndex", "matchName", "position", "durationSeconds", "forceSingleSided", "transitionAlignment"]);
+    const result = targetArgs(args);
+    if (typeof args.matchName !== "string" || !args.matchName.trim() || args.matchName.length > 256) throw commandError("UXP_INVALID_ARGUMENT", "matchName must be a non-empty string of at most 256 characters");
+    result.matchName = args.matchName; result.position = optionalPosition(args.position);
+    if (args.durationSeconds != null) result.durationSeconds = positiveNumber(args.durationSeconds, "durationSeconds");
+    if (args.forceSingleSided != null) {
+      if (typeof args.forceSingleSided !== "boolean") throw commandError("UXP_INVALID_ARGUMENT", "forceSingleSided must be a boolean");
+      result.forceSingleSided = args.forceSingleSided;
+    }
+    if (args.transitionAlignment != null) {
+      if (!Number.isInteger(args.transitionAlignment)) throw commandError("UXP_INVALID_ARGUMENT", "transitionAlignment must be an integer");
+      result.transitionAlignment = args.transitionAlignment;
+    }
+    return result;
+  }
+  function validateRemoveArgs(args) {
+    assertObject(args); assertOnlyKeys(args, ["videoTrackIndex", "clipIndex", "position"]);
+    const result = targetArgs(args); result.position = optionalPosition(args.position); return result;
+  }
+  function targetArgs(args) { return { videoTrackIndex: nonNegativeInt(args.videoTrackIndex, "videoTrackIndex"), clipIndex: nonNegativeInt(args.clipIndex, "clipIndex") }; }
+  function optionalPosition(value) { const result = value == null ? "end" : value; if (result !== "start" && result !== "end") throw commandError("UXP_INVALID_ARGUMENT", "position must be start or end"); return result; }
+  function assertObject(value) { if (!value || typeof value !== "object" || Array.isArray(value)) throw commandError("UXP_INVALID_ARGUMENT", "args must be an object"); }
+  function assertOnlyKeys(value, allowed) { const unknown = Object.keys(value).filter((key) => !allowed.includes(key)); if (unknown.length) throw commandError("UXP_INVALID_ARGUMENT", "Unknown argument: " + unknown[0]); }
+  function nonNegativeInt(value, name) { if (!Number.isInteger(value) || value < 0) throw commandError("UXP_INVALID_ARGUMENT", name + " must be a non-negative integer"); return value; }
+  function positiveNumber(value, name) { const number = Number(value); if (!Number.isFinite(number) || number <= 0) throw commandError("UXP_INVALID_ARGUMENT", name + " must be positive"); return number; }
+  function positiveInt(value, fallback, name) { return Math.round(positiveNumber(value == null ? fallback : value, name)); }
+  function commandError(code, message) { const error = new Error(message); error.code = code; return error; }
+  return { createCommandRegistry, validateAddArgs, validateRemoveArgs, commandError };
+});

--- a/uxp-plugin/index.cjs
+++ b/uxp-plugin/index.cjs
@@ -3,6 +3,8 @@ const { entrypoints } = require("uxp");
 const ppro = require("premierepro");
 const fs = require("fs");
 const Protocol = globalThis.PremiereMcpProtocol;
+const Commands = globalThis.PremiereMcpCommands;
+const commandRegistry = Commands.createCommandRegistry({ ppro, fs, Protocol });
 let socket = null;
 let reconnectTimer = null;
 let lastState = "";
@@ -15,64 +17,17 @@ document.addEventListener("DOMContentLoaded", () => {
   setInterval(() => publishState("poll"), 1000);
 });
 
-async function capabilities() {
-  let project = null, sequence = null;
-  try { project = await ppro.Project.getActiveProject(); sequence = project && await project.getActiveSequence(); } catch (_) {}
-  return {
-    backend: "uxp", protocolVersion: Protocol.PROTOCOL_VERSION,
-    hostMinVersion: "25.6.0", activeProject: !!project, activeSequence: !!sequence,
-    commands: {
-      "capabilities.get": { supported: true, readOnly: true },
-      "state.get": { supported: true, readOnly: true },
-      "frame.export": { supported: !!(ppro.Exporter && ppro.Exporter.exportSequenceFrame), destructive: false }
-    },
-    fallback: { backend: "cep", reason: "Use CEP/QE only when a command is absent or reports unsupported; never silently retry a failed UXP mutation." }
-  };
-}
-
-async function stateSnapshot() {
-  const project = await ppro.Project.getActiveProject();
-  const sequence = project && await project.getActiveSequence();
-  const position = sequence && await sequence.getPlayerPosition();
-  return { projectOpen: !!project, sequenceOpen: !!sequence, playheadSeconds: position ? position.seconds : null };
-}
-
-async function exportFrame(args) {
-  const project = await ppro.Project.getActiveProject();
-  if (!project) throw new Error("No active project");
-  const sequence = await project.getActiveSequence();
-  if (!sequence) throw new Error("No active sequence");
-  if (!args.outputDirectory) throw new Error("outputDirectory is required");
-  const filename = Protocol.safeFilename(args.filename);
-  const position = args.seconds == null ? await sequence.getPlayerPosition() : await tickTime(args.seconds);
-  const size = await sequence.getFrameSize();
-  const width = positiveInt(args.width, size.width), height = positiveInt(args.height, size.height);
-  const returned = await ppro.Exporter.exportSequenceFrame(sequence, position, filename, args.outputDirectory, width, height);
-  const path = Protocol.joinPath(args.outputDirectory, filename);
-  let exists = false;
-  try { await fs.lstat(path); exists = true; } catch (_) {}
-  if (!exists) throw new Error("Exporter returned " + JSON.stringify(returned) + " but no frame exists at " + path);
-  return { path, width, height, seconds: position.seconds, exporterResult: returned };
-}
-
-async function tickTime(seconds) {
-  if (ppro.TickTime && typeof ppro.TickTime.createWithSeconds === "function") return ppro.TickTime.createWithSeconds(Number(seconds));
-  throw new Error("This Premiere build cannot create TickTime; omit seconds to capture the playhead");
-}
-function positiveInt(value, fallback) { const n = Number(value == null ? fallback : value); if (!Number.isFinite(n) || n <= 0) throw new Error("frame dimensions must be positive"); return Math.round(n); }
+async function capabilities() { return commandRegistry.capabilities(); }
+async function stateSnapshot() { return commandRegistry.stateSnapshot(); }
 
 async function dispatch(raw) {
   let cmd;
   try {
     cmd = Protocol.parseCommand(raw);
-    let result;
-    if (cmd.command === "capabilities.get") result = await capabilities();
-    else if (cmd.command === "state.get") result = await stateSnapshot();
-    else if (cmd.command === "frame.export") result = await exportFrame(cmd.args);
-    else throw new Error("Unsupported UXP command: " + cmd.command);
+    const result = await commandRegistry.dispatch(cmd.command, cmd.args);
     send(Protocol.envelope("result", { ok: true, result }, cmd.requestId));
   } catch (error) {
-    send(Protocol.envelope("result", { ok: false, error: { code: "UXP_COMMAND_FAILED", message: error.message || String(error) } }, cmd && cmd.requestId));
+    send(Protocol.envelope("result", { ok: false, error: { code: error.code || "UXP_COMMAND_FAILED", message: error.message || String(error) } }, cmd && cmd.requestId));
   }
 }
 

--- a/uxp-plugin/index.html
+++ b/uxp-plugin/index.html
@@ -6,5 +6,5 @@ body{font:12px system-ui;margin:14px;color:#ddd;background:#242424}button,input{
 <label>Bridge URL <input id="bridge-url" value="ws://127.0.0.1:7777/uxp"></label>
 <button id="connect">Connect</button><button id="refresh">Refresh state</button>
 <pre id="status">Starting…</pre>
-<script src="protocol.cjs"></script><script src="index.cjs"></script>
+<script src="protocol.cjs"></script><script src="commands.cjs"></script><script src="index.cjs"></script>
 </body></html>

--- a/uxp-plugin/protocol.cjs
+++ b/uxp-plugin/protocol.cjs
@@ -5,21 +5,28 @@
 })(typeof globalThis !== "undefined" ? globalThis : this, function () {
   "use strict";
   const PROTOCOL_VERSION = 1;
+  const MAX_COMMAND_BYTES = 64 * 1024;
+  const COMMAND_NAME = /^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9]*)+$/;
   function envelope(type, payload, requestId) {
     const value = { protocolVersion: PROTOCOL_VERSION, type, payload: payload || {}, sentAt: new Date().toISOString() };
     if (requestId) value.requestId = requestId;
     return value;
   }
   function parseCommand(raw) {
+    if (typeof raw === "string" && raw.length > MAX_COMMAND_BYTES) throw new Error("UXP bridge command exceeds 64 KiB");
     const value = typeof raw === "string" ? JSON.parse(raw) : raw;
-    if (!value || value.type !== "command" || typeof value.command !== "string") throw new Error("Invalid UXP bridge command");
+    if (!isPlainObject(value) || value.type !== "command" || typeof value.command !== "string" || !COMMAND_NAME.test(value.command)) throw new Error("Invalid UXP bridge command");
+    if (value.protocolVersion != null && value.protocolVersion !== PROTOCOL_VERSION) throw new Error("Unsupported UXP protocol version: " + value.protocolVersion);
+    if (value.requestId != null && (typeof value.requestId !== "string" || value.requestId.length < 1 || value.requestId.length > 128)) throw new Error("requestId must be a non-empty string of at most 128 characters");
+    if (value.args != null && !isPlainObject(value.args)) throw new Error("command args must be an object");
     return { requestId: value.requestId || null, command: value.command, args: value.args || {} };
   }
+  function isPlainObject(value) { return !!value && typeof value === "object" && !Array.isArray(value); }
   function safeFilename(value) {
     const name = String(value || "mcp-frame.png");
     if (!/^[A-Za-z0-9][A-Za-z0-9._-]*\.png$/i.test(name)) throw new Error("filename must be a simple .png name");
     return name;
   }
   function joinPath(dir, name) { return /[\\\/]$/.test(dir) ? dir + name : dir + "/" + name; }
-  return { PROTOCOL_VERSION, envelope, parseCommand, safeFilename, joinPath };
+  return { PROTOCOL_VERSION, MAX_COMMAND_BYTES, envelope, parseCommand, safeFilename, joinPath };
 });


### PR DESCRIPTION
## Summary

- introduce a testable, registry-based UXP command layer so new commands can declare support, mutability, undo behavior, and minimum host version independently
- add documented Premiere Pro 25.6+ video-transition commands:
  - `transition.video.list`
  - `transition.video.add`
  - `transition.video.remove`
- create transition mutations inside `Project.lockedAccess()` and commit them through one `Project.executeTransaction()` undo entry
- validate protocol version, request IDs, command names, payload shape, payload size, transition names, target coordinates, placement, duration, single-sided behavior, and alignment values
- preserve explicit CEP fallback semantics and stable command-specific error codes
- document exact-match transition discovery, transaction-level verification, and the lack of a documented audio-transition factory

## Verification

- `npm test -- --run tests/uxp/protocol.test.ts tests/uxp/commands.test.ts` — 13 tests passed
- `npm test` — 357 tests passed across 13 files
- `npm run build` — passed
- `git diff --check` — passed

## Verification boundary

The transition workflow is covered with host-contract mocks based on Adobe's current UXP reference and official sample implementation. It has **not** been exercised in a live Premiere Pro host in this environment. A successful command result means Premiere accepted the locked transaction; it does not assert a rendered or visual transition inspection.

## Documented API scope

Adobe currently documents `TransitionFactory` for video transition discovery/creation plus `VideoClipTrackItem` add/remove actions. This PR therefore does not advertise audio-transition creation and does not fall back to QE after a failed UXP mutation.
