### PR TITLE
Add installable Codex plugin for Premiere Pro MCP

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "premiere-pro-mcp",
+  "interface": {
+    "displayName": "Premiere Pro MCP"
+  },
+  "plugins": [
+    {
+      "name": "premiere-pro",
+      "source": {
+        "source": "local",
+        "path": "./plugins/premiere-pro"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Creativity"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -217,6 +217,28 @@ Add to your VS Code MCP server configuration:
 
 The default bridge directory is derived from the operating system on both sides, so most local setups should not set `PREMIERE_TEMP_DIR`. If you override it, use the same absolute path in the MCP server and CEP panel; Windows and macOS paths are not interchangeable.
 
+### Codex plugin
+
+This repository includes an installable Codex plugin that bundles the local MCP
+server with a safety-oriented Premiere editing skill.
+
+From a clone of this repository:
+
+```bash
+codex plugin marketplace add .
+codex plugin add premiere-pro@premiere-pro-mcp
+npx -y premiere-pro-mcp@1.3.1 --install-cep
+```
+
+Restart Premiere Pro and start a new Codex session after installation. The plugin
+launches `premiere-pro-mcp@1.3.1` through `npx`; the separate CEP installation is
+required because the MCP server communicates with the running Premiere host through
+the local bridge.
+
+The plugin source lives in [`plugins/premiere-pro`](plugins/premiere-pro), and the
+repository marketplace manifest lives in
+[`.agents/plugins/marketplace.json`](.agents/plugins/marketplace.json).
+
 ### Windows and macOS capability coverage
 
 | Surface | Windows | macOS | Verification boundary |

--- a/plugins/premiere-pro/.codex-plugin/plugin.json
+++ b/plugins/premiere-pro/.codex-plugin/plugin.json
@@ -1,0 +1,30 @@
+{
+  "name": "premiere-pro",
+  "version": "1.3.1",
+  "description": "Plan, execute, verify, and export video edits in Adobe Premiere Pro through the Premiere Pro MCP server.",
+  "author": {
+    "name": "Premiere Pro MCP contributors",
+    "url": "https://github.com/leancoderkavy/premiere-pro-mcp"
+  },
+  "homepage": "https://premiere-pro-mcp.com/",
+  "repository": "https://github.com/leancoderkavy/premiere-pro-mcp",
+  "license": "MIT",
+  "keywords": ["premiere-pro", "video-editing", "mcp", "timeline", "captions", "export"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Premiere Pro MCP",
+    "shortDescription": "Edit, inspect, and export Premiere Pro projects",
+    "longDescription": "Control an open Adobe Premiere Pro project with safety-oriented workflows for rough cuts, timeline changes, dialogue cleanup, captions, project inspection, and delivery exports. The plugin connects Codex to the local Premiere Pro MCP server and its CEP bridge.",
+    "developerName": "Premiere Pro MCP contributors",
+    "category": "Creativity",
+    "capabilities": ["Interactive", "Read", "Write"],
+    "websiteURL": "https://premiere-pro-mcp.com/",
+    "defaultPrompt": [
+      "Inspect my open Premiere project and summarize its current edit",
+      "Build a rough cut from the selected media",
+      "Verify this sequence and export the final deliverable"
+    ],
+    "brandColor": "#9999FF"
+  },
+  "mcpServers": "./.mcp.json"
+}

--- a/plugins/premiere-pro/.mcp.json
+++ b/plugins/premiere-pro/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "premiere-pro": {
+      "title": "Premiere Pro MCP",
+      "description": "Inspect and edit a local Adobe Premiere Pro project through the Premiere Pro MCP bridge.",
+      "command": "npx",
+      "args": ["-y", "premiere-pro-mcp@1.3.1"]
+    }
+  }
+}

--- a/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: edit-premiere-project
+description: Inspect, edit, verify, save, and export an open Adobe Premiere Pro project through the premiere-pro MCP server. Use for rough cuts, timeline assembly or cleanup, clip and track changes, transitions and effects, dialogue or audio adjustments, captions, project organization, frame inspection, and delivery exports.
+---
+
+# Edit Premiere Project
+
+Operate Premiere through the `premiere-pro` MCP tools. Preserve the user's current
+project state, make only requested changes, and verify the timeline after mutations.
+
+## Establish a live session
+
+1. Call `get_capabilities` to inspect platform coverage and enabled authority.
+2. Call `ping` before any other Premiere operation.
+3. If `ping` fails, stop editing and tell the user to:
+   - Open or restart Premiere Pro.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.3.1 --install-cep` if needed.
+   - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
+4. Call `get_premiere_state` and inspect the active sequence before planning changes.
+5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.
+
+## Plan the edit
+
+- Clarify only missing choices that materially change the edit, such as target sequence,
+  source media, timing, track placement, or export preset.
+- Prefer the server's `premiere-rough-cut`, `premiere-dialogue-cleanup`,
+  `premiere-caption-and-style`, or `premiere-delivery` prompt when it matches the request.
+- Inspect project items and sequence structure before referring to item, clip, track, or
+  sequence identifiers.
+- Re-query identifiers after timeline mutations; do not reuse stale node IDs.
+- Keep existing tracks, effects, timing, and project organization unless the request
+  requires changing them.
+
+## Apply changes safely
+
+For compound insert or removal operations:
+
+1. Construct one exact edit plan.
+2. Call `preview_edit_plan`.
+3. Present the preview when it contains destructive operations or the user's intent is
+   ambiguous.
+4. Call `apply_edit_plan` only with the unchanged plan and exact confirmation token.
+5. Preview again after any plan change.
+
+For other mutations:
+
+- Validate the active project, sequence, tracks, media paths, and relevant identifiers
+  immediately before the call.
+- Ask before deleting media, sequences, tracks, or clips unless the user explicitly
+  requested that exact deletion.
+- Ask before overwriting a project or export destination.
+- Never enable `unsafe-script`, call `execute_extendscript`, `send_raw_script`, or
+  `evaluate_expression` unless the user explicitly requests raw scripting and accepts
+  the expanded authority.
+- Stop after an error that makes later steps depend on unknown state. Re-inspect before
+  retrying.
+
+## Verify and finish
+
+1. Inspect the affected sequence with `get_sequence_structure`,
+   `get_timeline_summary`, or the narrowest relevant inspection tool.
+2. Compare the result against the requested timing, ordering, tracks, effects, audio,
+   and captions.
+3. Save only after successful verification when the user requested persistent changes.
+4. For exports, validate the active sequence, destination, filename, and preset before
+   calling `export_sequence`; then verify and report the returned artifact path.
+5. Report completed, skipped, and failed work separately. Include any remaining
+   verification that requires playback or human visual judgment.
+
+## Editing judgment
+
+- Prefer reversible operations and conservative parameter values.
+- Do not invent creative choices the user did not request when those choices affect
+  pacing, story, color, mix, typography, or delivery requirements.
+- Use frame capture or playback inspection when useful, while clearly separating
+  machine verification from subjective editorial approval.
+- Treat file paths as local to the Premiere host. Never expose unrelated files or
+  secrets from the machine in the response.

--- a/plugins/premiere-pro/skills/edit-premiere-project/agents/openai.yaml
+++ b/plugins/premiere-pro/skills/edit-premiere-project/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Edit in Premiere Pro"
+  short_description: "Plan, edit, verify, and export Premiere projects"
+  default_prompt: "Use $edit-premiere-project to inspect my open Premiere project and make the requested edit safely."

--- a/tests/codex-plugin.test.ts
+++ b/tests/codex-plugin.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const readJson = (path: string) =>
+  JSON.parse(readFileSync(join(root, path), "utf8"));
+
+describe("Codex plugin package", () => {
+  it("keeps the plugin and MCP package versions aligned", () => {
+    const pkg = readJson("package.json");
+    const plugin = readJson("plugins/premiere-pro/.codex-plugin/plugin.json");
+    const mcp = readJson("plugins/premiere-pro/.mcp.json");
+
+    expect(plugin.name).toBe("premiere-pro");
+    expect(plugin.version).toBe(pkg.version);
+    expect(plugin.skills).toBe("./skills/");
+    expect(plugin.mcpServers).toBe("./.mcp.json");
+    expect(mcp.mcpServers["premiere-pro"].args).toContain(
+      `premiere-pro-mcp@${pkg.version}`,
+    );
+  });
+
+  it("publishes the plugin through the repository marketplace", () => {
+    const marketplace = readJson(".agents/plugins/marketplace.json");
+    const entry = marketplace.plugins.find(
+      (plugin: { name: string }) => plugin.name === "premiere-pro",
+    );
+
+    expect(marketplace.name).toBe("premiere-pro-mcp");
+    expect(entry).toMatchObject({
+      source: { source: "local", path: "./plugins/premiere-pro" },
+      policy: { installation: "AVAILABLE", authentication: "ON_INSTALL" },
+      category: "Creativity",
+    });
+  });
+
+  it("ships a complete Premiere editing skill without placeholders", () => {
+    const skill = readFileSync(
+      join(
+        root,
+        "plugins",
+        "premiere-pro",
+        "skills",
+        "edit-premiere-project",
+        "SKILL.md",
+      ),
+      "utf8",
+    );
+
+    expect(skill).toContain("name: edit-premiere-project");
+    expect(skill).toContain("Call `ping`");
+    expect(skill).toContain("preview_edit_plan");
+    expect(skill).toContain("export_sequence");
+    expect(skill).not.toContain("TODO");
+  });
+});


### PR DESCRIPTION
## Summary

- add a repository marketplace entry and validated Codex plugin manifest
- launch the published `premiere-pro-mcp@1.3.1` package through the bundled MCP configuration
- add an `edit-premiere-project` skill covering connection checks, safe edit planning, mutation safeguards, verification, saving, and exports
- document local plugin and CEP bridge installation
- add regression coverage that keeps package, plugin, MCP, marketplace, and skill metadata aligned

## Why

The MCP server was available to configure manually, but it was not packaged as an installable Codex plugin and did not include a reusable workflow skill. This adds the supported plugin structure while preserving the local Premiere bridge architecture.

## User impact

Users can add the repository as a Codex marketplace, install `premiere-pro@premiere-pro-mcp`, and start a new session with both the MCP tools and a focused Premiere editing workflow available.

The CEP extension remains a separate local installation because the MCP server communicates with the running Premiere host through the local file bridge.

## Validation

- plugin validator passed
- skill validator passed
- TypeScript build passed
- 13 test files passed, 352 tests total
- verified `premiere-pro-mcp@1.3.1` is published on npm