### PR TITLE
feat: add documented AV inspection and capability boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Give AI full control over Adobe Premiere Pro.**
 
-269 tools across 29 modules, 3 resources, and 4 guided workflows.
+273 tools across 30 modules, 3 resources, and 4 guided workflows.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Node.js](https://img.shields.io/badge/Node.js-20.19%2B-green.svg)](https://nodejs.org)
@@ -25,7 +25,7 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 "Add the B-roll clips to V2, apply a cross dissolve between each, color correct them to match the A-roll, and export a 1080p ProRes."
 ```
 
-The AI handles the entire workflow through 269 tools spanning the supported ExtendScript, QE DOM, and safe edit-planning surfaces.
+The AI handles the entire workflow through 273 tools spanning the supported ExtendScript, QE DOM, and safe edit-planning surfaces.
 
 ### What's new in 1.3.1
 
@@ -495,11 +495,11 @@ premiere-pro-mcp/
 ├── src/
 │   ├── index.ts                 # Entry point — stdio transport setup
 │   ├── http-server.ts           # Entry point — HTTP/SSE transport (Fly.io / remote)
-│   ├── server.ts                # MCP server — registers 269 tools + 3 resources + 4 prompts
+│   ├── server.ts                # MCP server — registers 273 tools + 3 resources + 4 prompts
 │   ├── bridge/
 │   │   ├── file-bridge.ts       # File-based IPC (write .jsx, poll .json)
 │   │   └── script-builder.ts    # ExtendScript generator with ES3 helpers
-│   ├── tools/                   # 29 tool modules
+│   ├── tools/                   # 30 tool modules
 │   │   ├── discovery.ts         # Project discovery and queries
 │   │   ├── project.ts           # Project management and import
 │   │   ├── media.ts             # Media and proxy management
@@ -508,6 +508,7 @@ premiere-pro-mcp/
 │   │   ├── effects.ts           # Effect application and color correction
 │   │   ├── transitions.ts       # Transition management (QE DOM)
 │   │   ├── audio.ts             # Audio levels and keyframes
+│   │   ├── av-settings.ts       # Documented AV inspection, mapping, and capability boundaries
 │   │   ├── text.ts              # Text overlays and MOGRTs
 │   │   ├── markers.ts           # Sequence and clip markers
 │   │   ├── tracks.ts            # Track add/delete/lock/visibility

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ const args = process.argv.slice(2);
 
 if (args.includes("--help") || args.includes("-h")) {
   console.log(`
-premiere-pro-mcp — MCP server for Adobe Premiere Pro (269 tools)
+premiere-pro-mcp — MCP server for Adobe Premiere Pro (273 tools)
 
 Usage:
   premiere-pro-mcp              Start the MCP server (stdio transport)

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,6 +29,7 @@ import { getCaptionTools } from "./tools/captions.js";
 import { getPlaybackTools } from "./tools/playback.js";
 import { getProjectManagerTools } from "./tools/project-manager.js";
 import { getEditPlanTools } from "./tools/edit-plans.js";
+import { getAvSettingsTools } from "./tools/av-settings.js";
 import { guardToolHandler, resolveCapabilities } from "./security/index.js";
 import { EXTENDSCRIPT_REFERENCE } from "./resources/extendscript-reference.js";
 import { WORKFLOW_PROMPTS, WORKFLOW_RESOURCE } from "./workflows/catalog.js";
@@ -257,6 +258,7 @@ function collectTools(
     ...getPlaybackTools(bridgeOptions),
     ...getProjectManagerTools(bridgeOptions),
     ...getEditPlanTools(bridgeOptions, { capabilities }),
+    ...getAvSettingsTools(bridgeOptions),
   };
   toolCatalogCache.set(cacheKey, tools);
   return tools;

--- a/src/tools/av-settings.ts
+++ b/src/tools/av-settings.ts
@@ -1,0 +1,226 @@
+import {
+  buildToolScript,
+  escapeForExtendScript,
+} from "../bridge/script-builder.js";
+import { sendCommand, type BridgeOptions } from "../bridge/file-bridge.js";
+
+const BLOCKED_REASON =
+  "No documented ExtendScript or Premiere UXP API exposes this operation. Use Premiere Pro's UI; MCP will not invoke QE or guess private component parameters.";
+
+export function getAvSettingsTools(bridgeOptions: BridgeOptions) {
+  return {
+    get_av_feature_support: {
+      description:
+        "Report the documented automation boundary for advanced audio and modern color management, including actionable reasons for UI-only features.",
+      parameters: {},
+      handler: async () => ({
+        success: true,
+        data: {
+          schemaVersion: 1,
+          supported: {
+            sequenceAvInspection: {
+              status: "supported",
+              backend: "cep",
+              fields: [
+                "audioChannelCount",
+                "audioChannelType",
+                "audioSampleRate",
+                "audioDisplayFormat",
+                "autoToneMapEnabled",
+                "compositeLinearColor",
+                "maximumBitDepth",
+                "maximumRenderQuality",
+              ],
+              note: "Field availability varies by Premiere version and sequence preset.",
+            },
+            projectItemColorInspection: {
+              status: "supported",
+              backend: "cep",
+              fields: [
+                "effectiveColorSpace",
+                "originalColorSpace",
+                "overrideColorSpaceOptions",
+                "embeddedLutId",
+                "inputLutId",
+              ],
+            },
+            projectItemAudioChannelInspection: {
+              status: "supported",
+              backend: "cep",
+              fields: ["audioChannelsType", "audioClipsNumber"],
+            },
+            projectItemAudioChannelMapping: {
+              status: "supported_with_limitations",
+              backend: "cep",
+              note: "The documented mapping object can set one output-to-source channel mapping and reports whether Premiere accepted it; the API does not expose a per-channel mapping getter for post-write comparison.",
+            },
+            projectGraphicsWhiteLuminance: {
+              status: "uxp_only",
+              minPremiereVersion: "25.6",
+              note: "Documented UXP inspection exists, but the current MCP UXP transport does not yet route this command.",
+            },
+          },
+          blocked: {
+            sequenceWorkingColorSpace: { status: "unsupported", reason: BLOCKED_REASON },
+            sequenceOutputColorSpace: { status: "unsupported", reason: BLOCKED_REASON },
+            projectItemColorSpaceOverrideMutation: { status: "unsupported", reason: BLOCKED_REASON },
+            loudnessMeasurementAndNormalization: { status: "unsupported", reason: BLOCKED_REASON },
+            audioTrackMixerRoutingAndSubmixes: { status: "unsupported", reason: BLOCKED_REASON },
+            enhanceSpeech: { status: "ui_only", reason: BLOCKED_REASON },
+            remix: { status: "ui_only", reason: BLOCKED_REASON },
+          },
+        },
+      }),
+    },
+
+    inspect_sequence_av_settings: {
+      description:
+        "Inspect documented audio, tone-mapping, linear-compositing, bit-depth, render-quality, and display settings for the active sequence.",
+      parameters: {},
+      handler: async () => {
+        const script = buildToolScript(`
+          var seq = app.project.activeSequence;
+          if (!seq) return __error("No active sequence");
+          var settings = seq.getSettings();
+          if (!settings) return __error("Could not get sequence settings");
+
+          function valueOfTime(value) {
+            if (value === undefined || value === null) return null;
+            var result = {};
+            try { if (value.seconds !== undefined) result.seconds = value.seconds; } catch (_) {}
+            try { if (value.ticks !== undefined) result.ticks = value.ticks.toString(); } catch (_) {}
+            return result;
+          }
+          function optional(name) {
+            try { return settings[name] === undefined ? null : settings[name]; } catch (_) { return null; }
+          }
+
+          return __result({
+            sequence: seq.name,
+            audio: {
+              channelCount: optional("audioChannelCount"),
+              channelType: optional("audioChannelType"),
+              channelTypeLabels: { "0": "mono", "1": "stereo", "2": "5.1", "3": "multichannel", "4": "4-channel", "5": "8-channel" },
+              sampleRate: valueOfTime(optional("audioSampleRate")),
+              displayFormat: optional("audioDisplayFormat")
+            },
+            colorAndRender: {
+              autoToneMapEnabled: optional("autoToneMapEnabled"),
+              compositeLinearColor: optional("compositeLinearColor"),
+              maximumBitDepth: optional("maximumBitDepth"),
+              maximumRenderQuality: optional("maximumRenderQuality")
+            },
+            unavailableThroughDocumentedApi: ["sequenceWorkingColorSpace", "sequenceOutputColorSpace"],
+            note: "null means the current Premiere build or sequence preset did not expose that documented field."
+          });
+        `);
+        return sendCommand(script, bridgeOptions);
+      },
+    },
+
+    inspect_project_item_av_metadata: {
+      description:
+        "Inspect a project item's documented effective/original color space, LUT IDs, available color-space overrides, and audio channel shape.",
+      parameters: {
+        type: "object" as const,
+        properties: {
+          item_id: {
+            type: "string",
+            description: "Project item node ID or exact name",
+          },
+        },
+        required: ["item_id"],
+      },
+      handler: async (args: { item_id: string }) => {
+        const script = buildToolScript(`
+          var item = __findProjectItem("${escapeForExtendScript(args.item_id)}");
+          if (!item) return __error("Item not found: ${escapeForExtendScript(args.item_id)}");
+          function optionalCall(name) {
+            try { return typeof item[name] === "function" ? item[name]() : null; } catch (_) { return null; }
+          }
+          function optionalProperty(name) {
+            try { return item[name] === undefined ? null : item[name]; } catch (_) { return null; }
+          }
+          var mapping = optionalProperty("getAudioChannelMapping");
+          if (typeof mapping === "function" || !mapping) mapping = optionalCall("getAudioChannelMapping");
+          var overrideList = optionalProperty("getOverrideColorSpaceList");
+          if (typeof overrideList === "function" || !overrideList) overrideList = optionalCall("getOverrideColorSpaceList");
+          return __result({
+            item: item.name,
+            nodeId: item.nodeId,
+            color: {
+              effective: optionalCall("getColorSpace"),
+              original: optionalCall("getOriginalColorSpace"),
+              overrideOptions: overrideList,
+              embeddedLutId: optionalCall("getEmbeddedLUTID"),
+              inputLutId: optionalCall("getInputLUTID")
+            },
+            audio: mapping ? {
+              channelType: mapping.audioChannelsType,
+              clipCount: mapping.audioClipsNumber
+            } : null
+          });
+        `);
+        return sendCommand(script, bridgeOptions);
+      },
+    },
+
+    set_project_item_audio_channel_mapping: {
+      description:
+        "Map one output audio channel of a project item to a source channel using Premiere's documented AudioChannelMapping API.",
+      parameters: {
+        type: "object" as const,
+        properties: {
+          item_id: {
+            type: "string",
+            description: "Project item node ID or exact name",
+          },
+          channel_index: {
+            type: "number",
+            description: "Zero-based output channel index to configure",
+          },
+          source_channel_index: {
+            type: "number",
+            description: "Zero-based source channel index to map",
+          },
+        },
+        required: ["item_id", "channel_index", "source_channel_index"],
+      },
+      handler: async (args: {
+        item_id: string;
+        channel_index: number;
+        source_channel_index: number;
+      }) => {
+        if (!Number.isInteger(args.channel_index) || args.channel_index < 0) {
+          return { success: false, error: "channel_index must be a non-negative integer" };
+        }
+        if (!Number.isInteger(args.source_channel_index) || args.source_channel_index < 0) {
+          return { success: false, error: "source_channel_index must be a non-negative integer" };
+        }
+        const script = buildToolScript(`
+          var item = __findProjectItem("${escapeForExtendScript(args.item_id)}");
+          if (!item) return __error("Item not found: ${escapeForExtendScript(args.item_id)}");
+          var mapping = null;
+          try { mapping = item.getAudioChannelMapping; } catch (_) {}
+          if (typeof mapping === "function" || !mapping) {
+            try { if (typeof item.getAudioChannelMapping === "function") mapping = item.getAudioChannelMapping(); } catch (_) {}
+          }
+          if (!mapping || typeof mapping.setMappingForChannel !== "function") {
+            return __error("This item or Premiere build does not expose AudioChannelMapping.setMappingForChannel");
+          }
+          var accepted = mapping.setMappingForChannel(${args.channel_index}, ${args.source_channel_index});
+          if (accepted !== true) return __error("Premiere rejected this channel mapping");
+          return __result({
+            item: item.name,
+            channelIndex: ${args.channel_index},
+            sourceChannelIndex: ${args.source_channel_index},
+            accepted: true,
+            verification: "api-return",
+            limitation: "The documented API does not expose a per-channel mapping getter for post-write comparison."
+          });
+        `);
+        return sendCommand(script, bridgeOptions);
+      },
+    },
+  };
+}

--- a/tests/mcp-modernization.test.ts
+++ b/tests/mcp-modernization.test.ts
@@ -64,7 +64,7 @@ describe("modern MCP surface", () => {
       const tools = await client.listTools();
       expect(tools.tools.find((tool) => tool.name === "get_project_info")?.annotations?.readOnlyHint).toBe(true);
       expect(tools.tools.map((tool) => tool.name)).toContain("get_capabilities");
-      expect(tools.tools).toHaveLength(269);
+      expect(tools.tools).toHaveLength(273);
     } finally {
       await client.close();
       await server.close();

--- a/tests/tools/av-settings.test.ts
+++ b/tests/tools/av-settings.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/bridge/file-bridge.js", () => ({
+  sendCommand: vi.fn().mockResolvedValue({ success: true, data: {} }),
+}));
+
+import { sendCommand } from "../../src/bridge/file-bridge.js";
+import { getAvSettingsTools } from "../../src/tools/av-settings.js";
+
+const mockedSendCommand = vi.mocked(sendCommand);
+const tools = getAvSettingsTools({ tempDir: "/tmp/test", timeoutMs: 1000 });
+
+describe("AV feature support", () => {
+  it("identifies documented support and UI-only boundaries without a host call", async () => {
+    const result = await tools.get_av_feature_support.handler();
+    expect(result.success).toBe(true);
+    expect(result.data.supported.projectItemAudioChannelMapping.status).toBe("supported_with_limitations");
+    expect(result.data.blocked.enhanceSpeech).toMatchObject({
+      status: "ui_only",
+      reason: expect.stringContaining("No documented"),
+    });
+    expect(result.data.blocked.audioTrackMixerRoutingAndSubmixes.status).toBe("unsupported");
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+  });
+});
+
+describe("AV inspection scripts", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("inspects documented sequence audio and color/render fields", async () => {
+    await tools.inspect_sequence_av_settings.handler();
+    const script = mockedSendCommand.mock.calls[0][0];
+    expect(script).toContain("audioChannelCount");
+    expect(script).toContain("autoToneMapEnabled");
+    expect(script).toContain("compositeLinearColor");
+    expect(script).toContain("sequenceWorkingColorSpace");
+  });
+
+  it("inspects project item color spaces, LUTs, override options, and channel shape", async () => {
+    await tools.inspect_project_item_av_metadata.handler({ item_id: 'clip "A"' });
+    const script = mockedSendCommand.mock.calls[0][0];
+    expect(script).toContain('clip \\"A\\"');
+    expect(script).toContain("getColorSpace");
+    expect(script).toContain("getOriginalColorSpace");
+    expect(script).toContain("getOverrideColorSpaceList");
+    expect(script).toContain("getAudioChannelMapping");
+  });
+});
+
+describe("audio channel mapping", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("rejects non-integer and negative indexes before bridge execution", async () => {
+    await expect(tools.set_project_item_audio_channel_mapping.handler({
+      item_id: "clip", channel_index: -1, source_channel_index: 0,
+    })).resolves.toEqual({ success: false, error: "channel_index must be a non-negative integer" });
+    await expect(tools.set_project_item_audio_channel_mapping.handler({
+      item_id: "clip", channel_index: 0, source_channel_index: 1.5,
+    })).resolves.toEqual({ success: false, error: "source_channel_index must be a non-negative integer" });
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+  });
+
+  it("requires Premiere to accept the documented mapping call", async () => {
+    await tools.set_project_item_audio_channel_mapping.handler({
+      item_id: "clip", channel_index: 1, source_channel_index: 0,
+    });
+    const script = mockedSendCommand.mock.calls[0][0];
+    expect(script).toContain("mapping.setMappingForChannel(1, 0)");
+    expect(script).toContain("accepted !== true");
+    expect(script).toContain('verification: "api-return"');
+  });
+});

--- a/tests/tools/tool-modules.test.ts
+++ b/tests/tools/tool-modules.test.ts
@@ -46,6 +46,7 @@ import { getWorkspaceTools } from "../../src/tools/workspace.js";
 import { getCaptionTools } from "../../src/tools/captions.js";
 import { getPlaybackTools } from "../../src/tools/playback.js";
 import { getProjectManagerTools } from "../../src/tools/project-manager.js";
+import { getAvSettingsTools } from "../../src/tools/av-settings.js";
 
 interface ToolDef {
   description: string;
@@ -89,6 +90,7 @@ const ALL_MODULES: Array<{
   { name: "captions", getter: getCaptionTools, minTools: 1 },
   { name: "playback", getter: getPlaybackTools, minTools: 3 },
   { name: "project-manager", getter: getProjectManagerTools, minTools: 1 },
+  { name: "av-settings", getter: getAvSettingsTools, minTools: 4 },
 ];
 
 describe("Tool Module Structure", () => {
@@ -170,16 +172,16 @@ describe("Tool Module Structure", () => {
 });
 
 describe("Total Tool Count", () => {
-  it("all modules together have 267 tools", () => {
+  it("all modules together have 271 tools", () => {
     let total = 0;
     for (const mod of ALL_MODULES) {
       total += Object.keys(mod.getter(bridgeOptions)).length;
     }
-    expect(total).toBe(267);
+    expect(total).toBe(271);
   });
 
-  it("there are 28 modules", () => {
-    expect(ALL_MODULES.length).toBe(28);
+  it("there are 29 modules", () => {
+    expect(ALL_MODULES.length).toBe(29);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds four reviewable AV tools grounded in Adobe's documented Premiere APIs:

- `get_av_feature_support`: machine-readable supported/limited/UXP-only/UI-only matrix with actionable reasons
- `inspect_sequence_av_settings`: audio channel count/type/sample rate/display plus Auto Tone Map, linear compositing, max bit depth, and max render quality
- `inspect_project_item_av_metadata`: effective/original color-space descriptors, available override options, embedded/input LUT IDs, and audio channel shape
- `set_project_item_audio_channel_mapping`: maps one output channel to one source channel through the documented `AudioChannelMapping.setMappingForChannel()` call and requires Premiere to return `true`

The implementation accepts both property- and function-shaped channel/override accessors because Premiere's scripting documentation describes these as properties while host builds and declarations may surface callable accessors.

## Intentional boundaries

This PR does **not** fake or use QE/private component parameters for APIs Adobe does not document:

- sequence working color space inspection/mutation
- sequence output color space inspection/mutation
- project-item color-space override mutation
- loudness measurement or normalization
- Audio Track Mixer routing, sends, submixes, or automation modes
- Enhance Speech
- Remix

`ProjectColorSettings.getGraphicsWhiteLuminance()` is documented in UXP 25.6+, but the current MCP-side UXP transport on `main` does not route arbitrary commands, so the capability matrix reports it as `uxp_only` rather than pretending CEP support.

Audio channel mapping has an explicit verification limit: Adobe documents a boolean acceptance result but no per-channel mapping getter for post-write comparison. Responses therefore report `verification: api-return`.

## Sources consulted

- Adobe Premiere UXP `SequenceSettings`, `ProjectColorSettings`, `ClipProjectItem`, and `AudioTrack` references
- Adobe Premiere ExtendScript `Sequence`, `ProjectItem`, and `AudioChannelMapping` references

## Verification

- focused AV/module tests: 241 passed
- full suite: 361 passed across 13 files
- `npm run build`: passed
- `git diff --check`: passed

## Live-host boundary

Generated bridge scripts and argument behavior are unit-tested, but this environment did not have a live Premiere Pro session. Field availability is version/preset dependent and is represented as `null` rather than guessed when a host does not expose it.
