### PR TITLE
Add export preset and delivery verification tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Give AI full control over Adobe Premiere Pro.**
 
-269 tools across 29 modules, 3 resources, and 4 guided workflows.
+271 tools across 29 modules, 3 resources, and 4 guided workflows.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Node.js](https://img.shields.io/badge/Node.js-20.19%2B-green.svg)](https://nodejs.org)
@@ -25,7 +25,7 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 "Add the B-roll clips to V2, apply a cross dissolve between each, color correct them to match the A-roll, and export a 1080p ProRes."
 ```
 
-The AI handles the entire workflow through 269 tools spanning the supported ExtendScript, QE DOM, and safe edit-planning surfaces.
+The AI handles the entire workflow through 271 tools spanning the supported ExtendScript, QE DOM, and safe edit-planning surfaces.
 
 ### What's new in 1.3.1
 
@@ -270,7 +270,7 @@ The file-based IPC bridge is simple, reliable, and works across macOS and Window
 
 ---
 
-## Tools (269)
+## Tools (271)
 
 ### Discovery & Inspection (10 + 10)
 
@@ -341,15 +341,22 @@ The file-based IPC bridge is simple, reliable, and works across macOS and Window
 | `get_value_at_time` | Query interpolated value at any time |
 | `set_color_value` | Set color properties on effects |
 
-### Export & Encoding (14)
+### Export & Encoding (16)
 
 | Tool | Description |
 | :--- | :---------- |
 | `export_sequence` | Export via Adobe Media Encoder |
+| `validate_export_preset` | Validate an `.epr` file and resolve its output extension in Premiere |
+| `verify_delivery_file` | Verify output size and calculate SHA-256/SHA-512 checksums |
 | `capture_frame` | Export frame as PNG, return as base64 image |
 | `export_as_fcp_xml` / `export_aaf` / `export_omf` | Interchange formats |
 | `encode_project_item` / `encode_file` | Direct encoding |
 | `start_batch_encode` | Start render queue |
+
+Premiere's documented automation surfaces do not currently expose OTIO or EDL
+interchange, Render and Replace, cloud publishing, or Content Credentials export
+configuration. `get_capabilities` reports these delivery gaps explicitly rather
+than presenting UI-only operations as available tools.
 
 ### Source Monitor & Playback (7 + 4)
 
@@ -495,7 +502,7 @@ premiere-pro-mcp/
 ├── src/
 │   ├── index.ts                 # Entry point — stdio transport setup
 │   ├── http-server.ts           # Entry point — HTTP/SSE transport (Fly.io / remote)
-│   ├── server.ts                # MCP server — registers 269 tools + 3 resources + 4 prompts
+│   ├── server.ts                # MCP server — registers 271 tools + 3 resources + 4 prompts
 │   ├── bridge/
 │   │   ├── file-bridge.ts       # File-based IPC (write .jsx, poll .json)
 │   │   └── script-builder.ts    # ExtendScript generator with ES3 helpers

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "premiere-pro-mcp",
   "version": "1.3.1",
-  "description": "Adobe Premiere Pro MCP server with 269 AI video editing tools for timeline automation, effects, media management, and export.",
+  "description": "Adobe Premiere Pro MCP server with 271 AI video editing tools for timeline automation, effects, media management, and export.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ const args = process.argv.slice(2);
 
 if (args.includes("--help") || args.includes("-h")) {
   console.log(`
-premiere-pro-mcp — MCP server for Adobe Premiere Pro (269 tools)
+premiere-pro-mcp — MCP server for Adobe Premiere Pro (271 tools)
 
 Usage:
   premiere-pro-mcp              Start the MCP server (stdio transport)

--- a/src/platform-capabilities.ts
+++ b/src/platform-capabilities.ts
@@ -42,6 +42,18 @@ export function buildPlatformCapabilityReport(
         premiereVersions: "2020–2026",
         transport: "local file bridge",
         capabilities: ALL_CAPABILITIES,
+        delivery: {
+          interchange: ["FCP XML export", "AAF export", "OMF export"],
+          presetValidation: true,
+          postExportChecksum: ["sha256", "sha512"],
+          unsupported: {
+            otio: "No documented Premiere ExtendScript or UXP OTIO import/export API.",
+            edl: "No documented Premiere ExtendScript or UXP EDL import/export API.",
+            cloudPublish: "No documented Premiere automation API for publishing to cloud destinations.",
+            contentCredentials: "No documented Premiere automation API for configuring Content Credentials.",
+            renderAndReplace: "No documented Premiere ExtendScript or UXP Render and Replace API.",
+          },
+        },
       },
       uxp: {
         status: "preview",

--- a/src/security/capabilities.ts
+++ b/src/security/capabilities.ts
@@ -56,12 +56,12 @@ export function requireCapability(
 export const UNSAFE_TOOL_NAMES = new Set(["execute_extendscript", "send_raw_script", "evaluate_expression"]);
 
 const INSPECT_TOOL_NAMES = new Set(["ping", "get_capabilities", "preview_edit_plan"]);
-const FILESYSTEM_TOOL_NAMES = new Set(["apply_lut", "set_scratch_disk_path"]);
+const FILESYSTEM_TOOL_NAMES = new Set(["apply_lut", "set_scratch_disk_path", "verify_delivery_file"]);
 
 /** A conservative classification for centralized server registration. */
 export function capabilityForTool(toolName: string): Capability {
   if (UNSAFE_TOOL_NAMES.has(toolName)) return "unsafe-script";
-  if (/^(export_|start_batch_encode|queue_|encode_|capture_frame)/.test(toolName)) return "export";
+  if (/^(export_|validate_export_|start_batch_encode|queue_|encode_|capture_frame)/.test(toolName)) return "export";
   if (/^(import_|relink_|create_project|open_project|save_|consolidate_)/.test(toolName)) return "filesystem";
   if (FILESYSTEM_TOOL_NAMES.has(toolName)) return "filesystem";
   if (INSPECT_TOOL_NAMES.has(toolName) || /^(get_|list_|inspect_|find_|check_)/.test(toolName)) return "inspect";

--- a/src/tools/export.ts
+++ b/src/tools/export.ts
@@ -1,11 +1,193 @@
 import { buildToolScript, escapeForExtendScript } from "../bridge/script-builder.js";
 import { sendCommand, BridgeOptions } from "../bridge/file-bridge.js";
-import { readFileSync, unlinkSync, existsSync } from "node:fs";
-import { join } from "node:path";
+import { createReadStream, readFileSync, unlinkSync, existsSync, statSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { extname, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
+
+export type DeliveryChecksumAlgorithm = "sha256" | "sha512";
+
+export interface DeliveryFileVerification {
+  path: string;
+  exists: true;
+  regularFile: true;
+  sizeBytes: number;
+  modifiedAt: string;
+  checksum: {
+    algorithm: DeliveryChecksumAlgorithm;
+    value: string;
+  };
+  matchesExpectedChecksum?: boolean;
+  matchesExpectedSize?: boolean;
+  valid: boolean;
+}
+
+export async function verifyDeliveryFile(
+  outputPath: string,
+  options: {
+    algorithm?: DeliveryChecksumAlgorithm;
+    expectedChecksum?: string;
+    expectedSizeBytes?: number;
+    minimumSizeBytes?: number;
+  } = {},
+): Promise<DeliveryFileVerification> {
+  const path = resolve(outputPath);
+  if (!existsSync(path)) throw new Error(`Delivery file does not exist: ${path}`);
+  const stats = statSync(path);
+  if (!stats.isFile()) throw new Error(`Delivery path is not a regular file: ${path}`);
+
+  const minimumSizeBytes = options.minimumSizeBytes ?? 1;
+  if (!Number.isSafeInteger(minimumSizeBytes) || minimumSizeBytes < 0) {
+    throw new Error("minimum_size_bytes must be a non-negative integer");
+  }
+  if (stats.size < minimumSizeBytes) {
+    throw new Error(`Delivery file is ${stats.size} bytes; expected at least ${minimumSizeBytes}`);
+  }
+
+  const algorithm = options.algorithm ?? "sha256";
+  if (algorithm !== "sha256" && algorithm !== "sha512") {
+    throw new Error("checksum_algorithm must be 'sha256' or 'sha512'");
+  }
+  const hash = createHash(algorithm);
+  await new Promise<void>((resolveHash, rejectHash) => {
+    const stream = createReadStream(path);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("error", rejectHash);
+    stream.on("end", resolveHash);
+  });
+  const checksum = hash.digest("hex");
+
+  const expectedChecksum = options.expectedChecksum?.trim().toLowerCase();
+  const expectedLength = algorithm === "sha256" ? 64 : 128;
+  if (expectedChecksum !== undefined && !new RegExp(`^[a-f0-9]{${expectedLength}}$`).test(expectedChecksum)) {
+    throw new Error(`expected_checksum must be a ${expectedLength}-character hexadecimal ${algorithm} digest`);
+  }
+  const expectedSize = options.expectedSizeBytes;
+  if (expectedSize !== undefined && (!Number.isSafeInteger(expectedSize) || expectedSize < 0)) {
+    throw new Error("expected_size_bytes must be a non-negative integer");
+  }
+  const matchesExpectedChecksum = expectedChecksum === undefined ? undefined : checksum === expectedChecksum;
+  const matchesExpectedSize = expectedSize === undefined ? undefined : stats.size === expectedSize;
+
+  return {
+    path,
+    exists: true,
+    regularFile: true,
+    sizeBytes: stats.size,
+    modifiedAt: stats.mtime.toISOString(),
+    checksum: { algorithm, value: checksum },
+    ...(matchesExpectedChecksum === undefined ? {} : { matchesExpectedChecksum }),
+    ...(matchesExpectedSize === undefined ? {} : { matchesExpectedSize }),
+    valid: matchesExpectedChecksum !== false && matchesExpectedSize !== false,
+  };
+}
+
+export function inspectExportPresetFile(presetPath: string) {
+  const path = resolve(presetPath);
+  if (extname(path).toLowerCase() !== ".epr") throw new Error("Export preset must use the .epr extension");
+  if (!existsSync(path)) throw new Error(`Export preset does not exist: ${path}`);
+  const stats = statSync(path);
+  if (!stats.isFile()) throw new Error(`Export preset path is not a regular file: ${path}`);
+  if (stats.size === 0) throw new Error(`Export preset is empty: ${path}`);
+  return { path, exists: true as const, regularFile: true as const, sizeBytes: stats.size, modifiedAt: stats.mtime.toISOString() };
+}
 
 export function getExportTools(bridgeOptions: BridgeOptions) {
   return {
+    validate_export_preset: {
+      description:
+        "Validate that an Adobe Media Encoder .epr preset exists and ask the active Premiere sequence which output extension it produces",
+      parameters: {
+        type: "object" as const,
+        properties: {
+          preset_path: {
+            type: "string",
+            description: "Full path to an Adobe Media Encoder export preset (.epr)",
+          },
+        },
+        required: ["preset_path"],
+      },
+      handler: async (args: { preset_path: string }) => {
+        let file;
+        try {
+          file = inspectExportPresetFile(args.preset_path);
+        } catch (error) {
+          return { success: false, error: error instanceof Error ? error.message : String(error) };
+        }
+        const script = buildToolScript(`
+          var seq = app.project.activeSequence;
+          if (!seq) return __error("No active sequence");
+          var presetPath = "${escapeForExtendScript(file.path)}";
+          var extension = seq.getExportFileExtension(presetPath);
+          if (!extension) return __error("Premiere could not resolve an output extension for this preset");
+          return __result({ presetPath: presetPath, outputExtension: extension });
+        `);
+        const result = await sendCommand(script, bridgeOptions);
+        if (!result.success) return result;
+        return {
+          success: true,
+          data: {
+            ...file,
+            ...((result.data ?? {}) as Record<string, unknown>),
+            hostValidated: true,
+          },
+        };
+      },
+    },
+
+    verify_delivery_file: {
+      description:
+        "Verify that an exported delivery is a non-empty regular file and calculate a SHA-256 or SHA-512 checksum; optionally compare expected size and checksum",
+      parameters: {
+        type: "object" as const,
+        properties: {
+          output_path: {
+            type: "string",
+            description: "Full path to the exported delivery file",
+          },
+          checksum_algorithm: {
+            type: "string",
+            enum: ["sha256", "sha512"],
+            description: "Checksum algorithm (default: sha256)",
+          },
+          expected_checksum: {
+            type: "string",
+            description: "Optional expected hexadecimal checksum to compare",
+          },
+          expected_size_bytes: {
+            type: "number",
+            description: "Optional exact expected file size in bytes",
+          },
+          minimum_size_bytes: {
+            type: "number",
+            description: "Minimum acceptable file size in bytes (default: 1)",
+          },
+        },
+        required: ["output_path"],
+      },
+      handler: async (args: {
+        output_path: string;
+        checksum_algorithm?: DeliveryChecksumAlgorithm;
+        expected_checksum?: string;
+        expected_size_bytes?: number;
+        minimum_size_bytes?: number;
+      }) => {
+        try {
+          const verification = await verifyDeliveryFile(args.output_path, {
+            algorithm: args.checksum_algorithm,
+            expectedChecksum: args.expected_checksum,
+            expectedSizeBytes: args.expected_size_bytes,
+            minimumSizeBytes: args.minimum_size_bytes,
+          });
+          return verification.valid
+            ? { success: true, data: verification }
+            : { success: false, error: "Delivery file did not match the expected checksum or size", data: verification };
+        } catch (error) {
+          return { success: false, error: error instanceof Error ? error.message : String(error) };
+        }
+      },
+    },
+
     export_sequence: {
       description: "Export the active sequence using Adobe Media Encoder",
       parameters: {

--- a/src/tools/export.ts
+++ b/src/tools/export.ts
@@ -22,6 +22,18 @@ export interface DeliveryFileVerification {
   valid: boolean;
 }
 
+export function deliveryFileChangedDuringHash(
+  before: { dev: number; ino: number; size: number; mtimeMs: number },
+  after: { dev: number; ino: number; size: number; mtimeMs: number },
+): boolean {
+  return (
+    before.dev !== after.dev ||
+    before.ino !== after.ino ||
+    before.size !== after.size ||
+    before.mtimeMs !== after.mtimeMs
+  );
+}
+
 export async function verifyDeliveryFile(
   outputPath: string,
   options: {
@@ -56,6 +68,10 @@ export async function verifyDeliveryFile(
     stream.on("end", resolveHash);
   });
   const checksum = hash.digest("hex");
+  const finalStats = statSync(path);
+  if (!finalStats.isFile() || deliveryFileChangedDuringHash(stats, finalStats)) {
+    throw new Error(`Delivery file changed while its checksum was being calculated: ${path}`);
+  }
 
   const expectedChecksum = options.expectedChecksum?.trim().toLowerCase();
   const expectedLength = algorithm === "sha256" ? 64 : 128;
@@ -179,9 +195,7 @@ export function getExportTools(bridgeOptions: BridgeOptions) {
             expectedSizeBytes: args.expected_size_bytes,
             minimumSizeBytes: args.minimum_size_bytes,
           });
-          return verification.valid
-            ? { success: true, data: verification }
-            : { success: false, error: "Delivery file did not match the expected checksum or size", data: verification };
+          return { success: true, data: verification };
         } catch (error) {
           return { success: false, error: error instanceof Error ? error.message : String(error) };
         }

--- a/tests/mcp-modernization.test.ts
+++ b/tests/mcp-modernization.test.ts
@@ -64,7 +64,7 @@ describe("modern MCP surface", () => {
       const tools = await client.listTools();
       expect(tools.tools.find((tool) => tool.name === "get_project_info")?.annotations?.readOnlyHint).toBe(true);
       expect(tools.tools.map((tool) => tool.name)).toContain("get_capabilities");
-      expect(tools.tools).toHaveLength(269);
+      expect(tools.tools).toHaveLength(271);
     } finally {
       await client.close();
       await server.close();

--- a/tests/security-capabilities.test.ts
+++ b/tests/security-capabilities.test.ts
@@ -25,6 +25,8 @@ describe("capability profiles", () => {
     expect(capabilityForTool("evaluate_expression")).toBe("unsafe-script");
     expect(capabilityForTool("export_sequence")).toBe("export");
     expect(capabilityForTool("capture_frame")).toBe("export");
+    expect(capabilityForTool("validate_export_preset")).toBe("export");
+    expect(capabilityForTool("verify_delivery_file")).toBe("filesystem");
     expect(capabilityForTool("import_media")).toBe("filesystem");
     expect(capabilityForTool("get_project_info")).toBe("inspect");
     expect(capabilityForTool("ping")).toBe("inspect");

--- a/tests/tools/delivery.test.ts
+++ b/tests/tools/delivery.test.ts
@@ -1,0 +1,81 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { inspectExportPresetFile, verifyDeliveryFile } from "../../src/tools/export.js";
+
+const temporaryDirectories: string[] = [];
+
+function temporaryFile(name: string, contents: string | Buffer): string {
+  const directory = mkdtempSync(join(tmpdir(), "premiere-delivery-test-"));
+  temporaryDirectories.push(directory);
+  const path = join(directory, name);
+  writeFileSync(path, contents);
+  return path;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("delivery file verification", () => {
+  it("returns deterministic SHA-256 metadata", async () => {
+    const path = temporaryFile("delivery.mov", "premiere delivery\n");
+    const result = await verifyDeliveryFile(path);
+    expect(result).toMatchObject({
+      path,
+      exists: true,
+      regularFile: true,
+      sizeBytes: 18,
+      checksum: {
+        algorithm: "sha256",
+        value: "beabfc0259a7213ae09fffc062f2bdfc69fc0e702ab19ff44b50259b1f02d843",
+      },
+      valid: true,
+    });
+  });
+
+  it("reports expected checksum and size mismatches without claiming validity", async () => {
+    const path = temporaryFile("delivery.mp4", "video");
+    const result = await verifyDeliveryFile(path, {
+      expectedChecksum: "0".repeat(64),
+      expectedSizeBytes: 99,
+    });
+    expect(result).toMatchObject({
+      matchesExpectedChecksum: false,
+      matchesExpectedSize: false,
+      valid: false,
+    });
+  });
+
+  it("rejects missing, empty, and invalid delivery targets", async () => {
+    await expect(verifyDeliveryFile("/definitely/missing/delivery.mov")).rejects.toThrow("does not exist");
+    const empty = temporaryFile("empty.mov", "");
+    await expect(verifyDeliveryFile(empty)).rejects.toThrow("expected at least 1");
+    const path = temporaryFile("delivery.mov", "content");
+    await expect(verifyDeliveryFile(path, { algorithm: "md5" as never })).rejects.toThrow("sha256");
+    await expect(verifyDeliveryFile(path, { expectedChecksum: "not-hex" })).rejects.toThrow("64-character");
+  });
+});
+
+describe("export preset inspection", () => {
+  it("accepts a non-empty regular .epr file", () => {
+    const path = temporaryFile("YouTube.epr", "<preset />");
+    expect(inspectExportPresetFile(path)).toMatchObject({
+      path,
+      exists: true,
+      regularFile: true,
+      sizeBytes: 10,
+    });
+  });
+
+  it("rejects wrong extensions and empty presets", () => {
+    const wrongExtension = temporaryFile("preset.xml", "<preset />");
+    expect(() => inspectExportPresetFile(wrongExtension)).toThrow(".epr");
+    const empty = temporaryFile("empty.epr", "");
+    expect(() => inspectExportPresetFile(empty)).toThrow("empty");
+  });
+});

--- a/tests/tools/delivery.test.ts
+++ b/tests/tools/delivery.test.ts
@@ -2,7 +2,12 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { inspectExportPresetFile, verifyDeliveryFile } from "../../src/tools/export.js";
+import {
+  deliveryFileChangedDuringHash,
+  getExportTools,
+  inspectExportPresetFile,
+  verifyDeliveryFile,
+} from "../../src/tools/export.js";
 
 const temporaryDirectories: string[] = [];
 
@@ -48,6 +53,32 @@ describe("delivery file verification", () => {
       matchesExpectedChecksum: false,
       matchesExpectedSize: false,
       valid: false,
+    });
+  });
+
+  it("detects a file replacement or write during hashing", () => {
+    const snapshot = { dev: 1, ino: 2, size: 100, mtimeMs: 500 };
+    expect(deliveryFileChangedDuringHash(snapshot, snapshot)).toBe(false);
+    expect(deliveryFileChangedDuringHash(snapshot, { ...snapshot, size: 101 })).toBe(true);
+    expect(deliveryFileChangedDuringHash(snapshot, { ...snapshot, mtimeMs: 501 })).toBe(true);
+    expect(deliveryFileChangedDuringHash(snapshot, { ...snapshot, ino: 3 })).toBe(true);
+  });
+
+  it("returns mismatch details through the MCP tool as a completed verification", async () => {
+    const path = temporaryFile("delivery.mp4", "video");
+    const result = await getExportTools({}).verify_delivery_file.handler({
+      output_path: path,
+      expected_checksum: "0".repeat(64),
+      expected_size_bytes: 99,
+    });
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        path,
+        valid: false,
+        matchesExpectedChecksum: false,
+        matchesExpectedSize: false,
+      },
     });
   });
 

--- a/tests/tools/tool-modules.test.ts
+++ b/tests/tools/tool-modules.test.ts
@@ -170,12 +170,12 @@ describe("Tool Module Structure", () => {
 });
 
 describe("Total Tool Count", () => {
-  it("all modules together have 267 tools", () => {
+  it("all modules together have 269 tools", () => {
     let total = 0;
     for (const mod of ALL_MODULES) {
       total += Object.keys(mod.getter(bridgeOptions)).length;
     }
-    expect(total).toBe(267);
+    expect(total).toBe(269);
   });
 
   it("there are 28 modules", () => {


### PR DESCRIPTION
## What changed

- add `validate_export_preset` to verify a non-empty `.epr` file and resolve its output extension through the active Premiere sequence
- add `verify_delivery_file` to require a non-empty regular output file, calculate SHA-256 or SHA-512, and optionally compare expected size/checksum
- classify delivery verification under filesystem authority and preset validation under export authority
- expose delivery support and explicit unsupported metadata in `get_capabilities`
- update the registered tool count to 271 and document the delivery workflow

## Why

Existing export tools report the host operation, but callers had no structured way to validate presets before export or prove the resulting artifact exists and matches a handoff checksum. These tools close that gap using documented Premiere and local filesystem surfaces.

## Validation

- `npm run build`
- `npm test` — 13 files / 354 tests passed
- `git diff --check`

## Limitations

- Preset output-extension validation requires an active Premiere sequence and a running CEP bridge.
- File verification proves filesystem integrity, size, and checksum; it does not decode media or validate codec/container conformance.
- Premiere host calls cannot run in CI and need live macOS/Windows verification.
- No documented Premiere ExtendScript or UXP API was found for OTIO, EDL, Render and Replace, cloud publishing, or Content Credentials configuration; capability discovery marks these unsupported rather than offering speculative tools.