### PR TITLE
feat: add safe recovery diagnostics and accessible bridge status

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Give AI full control over Adobe Premiere Pro.**
 
-269 tools across 29 modules, 3 resources, and 4 guided workflows.
+271 tools across 30 modules, 3 resources, and 4 guided workflows.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Node.js](https://img.shields.io/badge/Node.js-20.19%2B-green.svg)](https://nodejs.org)
@@ -25,7 +25,7 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 "Add the B-roll clips to V2, apply a cross dissolve between each, color correct them to match the A-roll, and export a 1080p ProRes."
 ```
 
-The AI handles the entire workflow through 269 tools spanning the supported ExtendScript, QE DOM, and safe edit-planning surfaces.
+The AI handles the entire workflow through 271 tools spanning the supported ExtendScript, QE DOM, and safe edit-planning surfaces.
 
 ### What's new in 1.3.1
 
@@ -495,12 +495,13 @@ premiere-pro-mcp/
 ├── src/
 │   ├── index.ts                 # Entry point — stdio transport setup
 │   ├── http-server.ts           # Entry point — HTTP/SSE transport (Fly.io / remote)
-│   ├── server.ts                # MCP server — registers 269 tools + 3 resources + 4 prompts
+│   ├── server.ts                # MCP server — registers 271 tools + 3 resources + 4 prompts
 │   ├── bridge/
 │   │   ├── file-bridge.ts       # File-based IPC (write .jsx, poll .json)
 │   │   └── script-builder.ts    # ExtendScript generator with ES3 helpers
-│   ├── tools/                   # 29 tool modules
+│   ├── tools/                   # 30 tool modules
 │   │   ├── discovery.ts         # Project discovery and queries
+│   │   ├── recovery.ts          # Read-only autosave discovery and private bridge telemetry
 │   │   ├── project.ts           # Project management and import
 │   │   ├── media.ts             # Media and proxy management
 │   │   ├── sequence.ts          # Sequence creation and settings

--- a/cep-plugin/index.html
+++ b/cep-plugin/index.html
@@ -17,7 +17,7 @@
       <div class="auto-start"><span></span>Auto-start</div>
     </header>
 
-    <section class="status-panel" aria-live="polite">
+    <section class="status-panel" role="status" aria-live="polite" aria-atomic="true">
       <div class="status-indicator" aria-hidden="true">
         <div class="status-ring"><div class="status-dot connected" id="statusDot"></div></div>
       </div>
@@ -46,17 +46,17 @@
       <label class="sr-only" for="tempDir">Temporary bridge directory</label>
       <div class="path-field">
         <svg viewBox="0 0 20 20" aria-hidden="true"><path d="M2.5 5.5h5l1.5 2h8.5v8h-15v-10Z"/></svg>
-        <input type="text" id="tempDir" value="" spellcheck="false">
+        <input type="text" id="tempDir" value="" spellcheck="false" autocomplete="off" aria-describedby="tempDirHelp">
       </div>
-      <p class="field-help">Commands and responses are exchanged through this local folder.</p>
+      <p class="field-help" id="tempDirHelp">Commands and responses are exchanged through this local folder.</p>
     </section>
 
     <div class="action-row">
-      <button id="btnStart" class="button button-primary" onclick="startBridge()" type="button">
+      <button id="btnStart" class="button button-primary" onclick="startBridge()" type="button" aria-controls="log">
         <svg viewBox="0 0 20 20" aria-hidden="true"><path class="fill-icon" d="m7 5 8 5-8 5V5Z"/></svg>
         Start Bridge
       </button>
-      <button id="btnStop" class="button button-stop" onclick="stopBridge()" type="button" disabled>
+      <button id="btnStop" class="button button-stop" onclick="stopBridge()" type="button" aria-controls="log" disabled>
         <svg viewBox="0 0 20 20" aria-hidden="true"><rect class="fill-icon" x="6" y="6" width="8" height="8" rx="1"/></svg>
         Stop
       </button>
@@ -70,7 +70,7 @@
         </div>
         <span class="activity-state"><span></span>Listening</span>
       </div>
-      <div id="log" role="log" aria-live="polite"></div>
+      <div id="log" role="log" aria-live="polite" aria-relevant="additions" tabindex="0" aria-label="Bridge activity log"></div>
     </section>
   </main>
 

--- a/cep-plugin/main.js
+++ b/cep-plugin/main.js
@@ -26,7 +26,9 @@ function log(msg, cls) {
 function setStatus(state, text) {
   var dot = document.getElementById("statusDot");
   dot.className = "status-dot " + state;
-  document.getElementById("statusText").textContent = text;
+  var statusText = document.getElementById("statusText");
+  statusText.textContent = text;
+  statusText.setAttribute("data-state", state || "stopped");
   var detail = document.getElementById("statusDetail");
   if (detail) {
     if (state === "connected") detail.textContent = "Premiere Pro link is active";
@@ -204,6 +206,7 @@ function startBridge() {
   tempDir = document.getElementById("tempDir").value.trim();
   if (!tempDir) {
     log("Please set a temp directory", "err");
+    document.getElementById("tempDir").focus();
     return;
   }
 

--- a/cep-plugin/styles.css
+++ b/cep-plugin/styles.css
@@ -117,6 +117,10 @@ button { -webkit-appearance: none; }
 .section-label { display: block; margin-bottom: 4px; color: var(--text-muted); font-size: 9px; font-weight: 650; letter-spacing: .09em; text-transform: uppercase; }
 .status-copy { min-width: 0; }
 .status-copy strong { display: block; overflow: hidden; color: var(--text); font-size: 14px; font-weight: 650; line-height: 1.3; text-overflow: ellipsis; white-space: nowrap; }
+.status-copy strong::before { content: "■ "; color: var(--text-muted); }
+.status-copy strong[data-state="connected"]::before { content: "✓ "; color: var(--green); }
+.status-copy strong[data-state="waiting"]::before { content: "… "; color: var(--amber); }
+.status-copy strong[data-state="error"]::before { content: "! "; color: var(--red); }
 .status-copy #statusDetail { display: block; overflow: hidden; margin-top: 3px; color: var(--text-secondary); font-size: 10px; text-overflow: ellipsis; white-space: nowrap; }
 
 .command-stat { padding-left: 14px; text-align: right; }
@@ -211,7 +215,7 @@ button { -webkit-appearance: none; }
 
 .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
 
-button:focus-visible { outline: 1px solid var(--violet); outline-offset: 2px; }
+button:focus-visible, input:focus-visible, #log:focus-visible { outline: 2px solid var(--violet-hover); outline-offset: 2px; }
 
 @media (max-width: 330px) {
   .panel-shell { padding-right: 10px; padding-left: 10px; }
@@ -224,4 +228,10 @@ button:focus-visible { outline: 1px solid var(--violet); outline-offset: 2px; }
 
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after { animation-duration: .01ms !important; animation-iteration-count: 1 !important; }
+}
+
+@media (forced-colors: active) {
+  .status-dot, .auto-start > span, .activity-state > span { forced-color-adjust: none; border: 1px solid CanvasText; }
+  .button, .path-field input, #log, .status-panel { border-color: CanvasText; }
+  .status-copy strong::before { color: CanvasText !important; }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ const args = process.argv.slice(2);
 
 if (args.includes("--help") || args.includes("-h")) {
   console.log(`
-premiere-pro-mcp — MCP server for Adobe Premiere Pro (269 tools)
+premiere-pro-mcp — MCP server for Adobe Premiere Pro (271 tools)
 
 Usage:
   premiere-pro-mcp              Start the MCP server (stdio transport)

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,6 +29,7 @@ import { getCaptionTools } from "./tools/captions.js";
 import { getPlaybackTools } from "./tools/playback.js";
 import { getProjectManagerTools } from "./tools/project-manager.js";
 import { getEditPlanTools } from "./tools/edit-plans.js";
+import { getRecoveryTools } from "./tools/recovery.js";
 import { guardToolHandler, resolveCapabilities } from "./security/index.js";
 import { EXTENDSCRIPT_REFERENCE } from "./resources/extendscript-reference.js";
 import { WORKFLOW_PROMPTS, WORKFLOW_RESOURCE } from "./workflows/catalog.js";
@@ -257,6 +258,7 @@ function collectTools(
     ...getPlaybackTools(bridgeOptions),
     ...getProjectManagerTools(bridgeOptions),
     ...getEditPlanTools(bridgeOptions, { capabilities }),
+    ...getRecoveryTools(bridgeOptions),
   };
   toolCatalogCache.set(cacheKey, tools);
   return tools;

--- a/src/tools/recovery.ts
+++ b/src/tools/recovery.ts
@@ -1,0 +1,215 @@
+import {
+  existsSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
+import { basename, dirname, extname, join, resolve } from "node:path";
+import { buildToolScript } from "../bridge/script-builder.js";
+import {
+  getTempDir,
+  sendCommand,
+  type BridgeOptions,
+  type CommandResult,
+} from "../bridge/file-bridge.js";
+
+const MAX_CANDIDATES = 50;
+const AUTOSAVE_DIR_NAMES = [
+  "Adobe Premiere Pro Auto-Save",
+  "Premiere Pro Auto-Save",
+];
+
+interface ProjectSnapshot {
+  name: string;
+  path: string;
+}
+
+export interface RecoveryCandidate {
+  path: string;
+  fileName: string;
+  modifiedAt: string;
+  modifiedMs: number;
+  sizeBytes: number;
+  newerThanProjectFile: boolean | null;
+}
+
+export function discoverAdjacentRecoveryCandidates(
+  projectPath: string,
+): RecoveryCandidate[] {
+  if (!projectPath || extname(projectPath).toLowerCase() !== ".prproj") return [];
+  const absoluteProjectPath = resolve(projectPath);
+  const projectDirectory = dirname(absoluteProjectPath);
+  const projectStem = basename(projectPath, extname(projectPath)).toLowerCase();
+  let projectModifiedMs: number | null = null;
+  try {
+    projectModifiedMs = statSync(absoluteProjectPath).mtimeMs;
+  } catch {
+    // An unsaved/new or inaccessible project may not exist on disk yet.
+  }
+
+  const roots = [
+    ...AUTOSAVE_DIR_NAMES.map((name) => join(projectDirectory, name)),
+    projectDirectory,
+  ];
+  const seen = new Set<string>();
+  const candidates: RecoveryCandidate[] = [];
+  for (const root of roots) {
+    if (!existsSync(root)) continue;
+    let names: string[] = [];
+    try {
+      names = readdirSync(root);
+    } catch {
+      continue;
+    }
+    for (const name of names) {
+      if (candidates.length >= MAX_CANDIDATES) break;
+      if (extname(name).toLowerCase() !== ".prproj") continue;
+      if (!name.toLowerCase().includes(projectStem)) continue;
+      const candidatePath = resolve(root, name);
+      if (candidatePath === absoluteProjectPath || seen.has(candidatePath)) continue;
+      seen.add(candidatePath);
+      try {
+        const stat = statSync(candidatePath);
+        if (!stat.isFile()) continue;
+        candidates.push({
+          path: candidatePath,
+          fileName: basename(candidatePath),
+          modifiedAt: stat.mtime.toISOString(),
+          modifiedMs: stat.mtimeMs,
+          sizeBytes: stat.size,
+          newerThanProjectFile:
+            projectModifiedMs === null ? null : stat.mtimeMs > projectModifiedMs,
+        });
+      } catch {
+        // A candidate can disappear during an autosave; omit unstable entries.
+      }
+    }
+  }
+  return candidates.sort((left, right) => right.modifiedMs - left.modifiedMs);
+}
+
+export function collectBridgeTelemetry(
+  bridgeOptions: BridgeOptions,
+  nowMs = Date.now(),
+) {
+  const directory = getTempDir(bridgeOptions);
+  const counts = { pendingCommands: 0, pendingResponses: 0, busyOperations: 0 };
+  let oldestPendingAgeMs: number | null = null;
+  let directoryAccessible = false;
+  try {
+    if (existsSync(directory)) {
+      directoryAccessible = true;
+      for (const name of readdirSync(directory)) {
+        let bucket: keyof typeof counts | null = null;
+        if (/^cmd_.+\.jsx$/.test(name)) bucket = "pendingCommands";
+        else if (/^res_.+\.json$/.test(name)) bucket = "pendingResponses";
+        else if (/^busy_.+\.json$/.test(name)) bucket = "busyOperations";
+        if (!bucket) continue;
+        counts[bucket]++;
+        try {
+          const age = Math.max(0, nowMs - statSync(join(directory, name)).mtimeMs);
+          oldestPendingAgeMs =
+            oldestPendingAgeMs === null ? age : Math.max(oldestPendingAgeMs, age);
+        } catch {
+          // Aggregate telemetry remains useful if one transient file disappears.
+        }
+      }
+    }
+  } catch {
+    directoryAccessible = false;
+  }
+  return {
+    schemaVersion: 1,
+    directoryAccessible,
+    ...counts,
+    oldestPendingAgeMs,
+    healthy:
+      directoryAccessible &&
+      counts.busyOperations === 0 &&
+      (oldestPendingAgeMs === null || oldestPendingAgeMs < 30_000),
+    privacy:
+      "Aggregate local bridge state only; no paths, filenames, script contents, project names, or media names are returned.",
+  };
+}
+
+function projectSnapshot(result: CommandResult): ProjectSnapshot | null {
+  if (!result.success || !result.data || typeof result.data !== "object") return null;
+  const value = result.data as Record<string, unknown>;
+  if (typeof value.name !== "string" || typeof value.path !== "string") return null;
+  return { name: value.name, path: value.path };
+}
+
+export function getRecoveryTools(bridgeOptions: BridgeOptions) {
+  return {
+    inspect_project_recovery: {
+      description:
+        "Read-only recovery inspection: diagnose the active project path and list adjacent Premiere Auto-Save project candidates without opening, copying, or restoring anything.",
+      parameters: {},
+      handler: async () => {
+        const result = await sendCommand(
+          buildToolScript(`
+            if (!app.project) return __error("No project is open");
+            return __result({
+              name: app.project.name || "",
+              path: app.project.path || ""
+            });
+          `),
+          bridgeOptions,
+        );
+        if (!result.success) return result;
+        const project = projectSnapshot(result);
+        if (!project) {
+          return {
+            success: false,
+            error: "Premiere returned an invalid project snapshot",
+          };
+        }
+        const hasSavedPath =
+          project.path.length > 0 &&
+          extname(project.path).toLowerCase() === ".prproj";
+        const candidates = hasSavedPath
+          ? discoverAdjacentRecoveryCandidates(project.path)
+          : [];
+        return {
+          success: true,
+          data: {
+            project: {
+              name: project.name,
+              path: project.path || null,
+              hasSavedPath,
+              fileExists: hasSavedPath ? existsSync(project.path) : false,
+            },
+            unsavedChanges: {
+              status: "not_exposed",
+              dirty: null,
+              reason:
+                "Premiere's documented scripting APIs do not expose the current dirty/unsaved flag.",
+            },
+            recovery: {
+              mode: "read_only_discovery",
+              candidateCount: candidates.length,
+              truncated: candidates.length >= MAX_CANDIDATES,
+              candidates,
+              automaticRestoreSupported: false,
+              guidance:
+                candidates.length > 0
+                  ? "Review modification times and file sizes, then use Premiere Pro's File > Open to inspect a chosen copy. Keep the current project open until you have confirmed the recovery."
+                  : hasSavedPath
+                    ? "No adjacent .prproj recovery candidates were found. Check Premiere Pro's configured Auto Save location and Creative Cloud recovery UI manually."
+                    : "Save the project to establish a project directory; then inspect Premiere's Auto Save location manually.",
+            },
+          },
+        };
+      },
+    },
+
+    get_bridge_telemetry: {
+      description:
+        "Inspect privacy-preserving aggregate bridge health: pending command/response counts, busy operations, and queue age without returning project or personal data.",
+      parameters: {},
+      handler: async () => ({
+        success: true,
+        data: collectBridgeTelemetry(bridgeOptions),
+      }),
+    },
+  };
+}

--- a/tests/mcp-modernization.test.ts
+++ b/tests/mcp-modernization.test.ts
@@ -64,7 +64,7 @@ describe("modern MCP surface", () => {
       const tools = await client.listTools();
       expect(tools.tools.find((tool) => tool.name === "get_project_info")?.annotations?.readOnlyHint).toBe(true);
       expect(tools.tools.map((tool) => tool.name)).toContain("get_capabilities");
-      expect(tools.tools).toHaveLength(269);
+      expect(tools.tools).toHaveLength(271);
     } finally {
       await client.close();
       await server.close();

--- a/tests/tools/recovery.test.ts
+++ b/tests/tools/recovery.test.ts
@@ -1,0 +1,147 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/bridge/file-bridge.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../src/bridge/file-bridge.js")>();
+  return { ...actual, sendCommand: vi.fn() };
+});
+
+import { sendCommand } from "../../src/bridge/file-bridge.js";
+import {
+  collectBridgeTelemetry,
+  discoverAdjacentRecoveryCandidates,
+  getRecoveryTools,
+} from "../../src/tools/recovery.js";
+
+const mockedSendCommand = vi.mocked(sendCommand);
+const temporaryDirectories: string[] = [];
+
+function temporaryDirectory() {
+  const directory = mkdtempSync(join(tmpdir(), "premiere-recovery-test-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("recovery candidate discovery", () => {
+  it("finds matching adjacent autosaves newest-first without modifying them", () => {
+    const directory = temporaryDirectory();
+    const project = join(directory, "Episode 01.prproj");
+    writeFileSync(project, "project");
+    const autosaveDirectory = join(directory, "Adobe Premiere Pro Auto-Save");
+    mkdirSync(autosaveDirectory);
+    const older = join(autosaveDirectory, "Episode 01-1.prproj");
+    const newer = join(autosaveDirectory, "Episode 01-2.prproj");
+    const unrelated = join(autosaveDirectory, "Other Project.prproj");
+    writeFileSync(older, "old");
+    writeFileSync(newer, "new");
+    writeFileSync(unrelated, "unrelated");
+    utimesSync(project, new Date(1_000), new Date(1_000));
+    utimesSync(older, new Date(2_000), new Date(2_000));
+    utimesSync(newer, new Date(3_000), new Date(3_000));
+
+    const candidates = discoverAdjacentRecoveryCandidates(project);
+    expect(candidates.map((item) => item.fileName)).toEqual([
+      "Episode 01-2.prproj",
+      "Episode 01-1.prproj",
+    ]);
+    expect(candidates.every((item) => item.newerThanProjectFile)).toBe(true);
+    expect(readFileSync(newer, "utf8")).toBe("new");
+  });
+
+  it("does not scan when no saved Premiere project path exists", () => {
+    expect(discoverAdjacentRecoveryCandidates("")).toEqual([]);
+    expect(discoverAdjacentRecoveryCandidates("/tmp/not-a-project.txt")).toEqual([]);
+  });
+});
+
+describe("privacy-preserving bridge telemetry", () => {
+  it("returns aggregate state without paths, filenames, or contents", () => {
+    const directory = temporaryDirectory();
+    writeFileSync(join(directory, "cmd_secret.jsx"), "private project script");
+    writeFileSync(join(directory, "res_secret.json"), '{"project":"Private"}');
+    writeFileSync(join(directory, "busy_secret.json"), "{}");
+    writeFileSync(join(directory, "helpers_ignored.jsx"), "helper");
+
+    const telemetry = collectBridgeTelemetry(
+      { tempDir: directory },
+      Date.now() + 100,
+    );
+    expect(telemetry).toMatchObject({
+      directoryAccessible: true,
+      pendingCommands: 1,
+      pendingResponses: 1,
+      busyOperations: 1,
+      healthy: false,
+    });
+    const serialized = JSON.stringify(telemetry);
+    expect(serialized).not.toContain(directory);
+    expect(serialized).not.toContain("secret");
+    expect(serialized).not.toContain("Private");
+  });
+});
+
+describe("recovery tools", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("reports the unavailable dirty flag and never emits restore code", async () => {
+    const directory = temporaryDirectory();
+    const project = join(directory, "Documentary.prproj");
+    writeFileSync(project, "project");
+    mockedSendCommand.mockResolvedValue({
+      success: true,
+      data: { name: "Documentary", path: project },
+    });
+    const tools = getRecoveryTools({ tempDir: join(directory, "bridge") });
+    const result = await tools.inspect_project_recovery.handler();
+    expect(result.success).toBe(true);
+    expect((result.data as any).unsavedChanges).toMatchObject({
+      status: "not_exposed",
+      dirty: null,
+    });
+    expect((result.data as any).recovery.automaticRestoreSupported).toBe(false);
+    const script = mockedSendCommand.mock.calls[0][0];
+    expect(script).not.toContain("openDocument");
+    expect(script).not.toContain("openProject");
+    expect(script).not.toContain(".save");
+  });
+});
+
+describe("bridge panel accessibility", () => {
+  it("uses semantic live regions, labels, keyboard focus, and forced-colors CSS", () => {
+    const cepHtml = readFileSync(
+      new URL("../../cep-plugin/index.html", import.meta.url),
+      "utf8",
+    );
+    const cepCss = readFileSync(
+      new URL("../../cep-plugin/styles.css", import.meta.url),
+      "utf8",
+    );
+    const uxpHtml = readFileSync(
+      new URL("../../uxp-plugin/index.html", import.meta.url),
+      "utf8",
+    );
+    expect(cepHtml).toContain('role="status"');
+    expect(cepHtml).toContain('aria-label="Bridge activity log"');
+    expect(cepHtml).toContain('tabindex="0"');
+    expect(cepCss).toContain("@media (forced-colors: active)");
+    expect(cepCss).toContain("focus-visible");
+    expect(uxpHtml).toContain('role="status"');
+    expect(uxpHtml).toContain('lang="en"');
+  });
+});

--- a/tests/tools/tool-modules.test.ts
+++ b/tests/tools/tool-modules.test.ts
@@ -46,6 +46,7 @@ import { getWorkspaceTools } from "../../src/tools/workspace.js";
 import { getCaptionTools } from "../../src/tools/captions.js";
 import { getPlaybackTools } from "../../src/tools/playback.js";
 import { getProjectManagerTools } from "../../src/tools/project-manager.js";
+import { getRecoveryTools } from "../../src/tools/recovery.js";
 
 interface ToolDef {
   description: string;
@@ -89,6 +90,7 @@ const ALL_MODULES: Array<{
   { name: "captions", getter: getCaptionTools, minTools: 1 },
   { name: "playback", getter: getPlaybackTools, minTools: 3 },
   { name: "project-manager", getter: getProjectManagerTools, minTools: 1 },
+  { name: "recovery", getter: getRecoveryTools, minTools: 2 },
 ];
 
 describe("Tool Module Structure", () => {
@@ -170,16 +172,16 @@ describe("Tool Module Structure", () => {
 });
 
 describe("Total Tool Count", () => {
-  it("all modules together have 267 tools", () => {
+  it("all modules together have 269 tools", () => {
     let total = 0;
     for (const mod of ALL_MODULES) {
       total += Object.keys(mod.getter(bridgeOptions)).length;
     }
-    expect(total).toBe(267);
+    expect(total).toBe(269);
   });
 
-  it("there are 28 modules", () => {
-    expect(ALL_MODULES.length).toBe(28);
+  it("there are 29 modules", () => {
+    expect(ALL_MODULES.length).toBe(29);
   });
 });
 

--- a/uxp-plugin/index.html
+++ b/uxp-plugin/index.html
@@ -1,10 +1,10 @@
 <!doctype html>
-<html><head><meta charset="utf-8"><style>
-body{font:12px system-ui;margin:14px;color:#ddd;background:#242424}button,input{margin:4px;padding:6px}button{background:#5b5bd6;color:white;border:0;border-radius:3px}pre{white-space:pre-wrap;background:#181818;padding:10px}label{display:block}
+<html lang="en"><head><meta charset="utf-8"><style>
+body{font:12px system-ui;margin:14px;color:#ddd;background:#242424}button,input{margin:4px;padding:6px}button{background:#5b5bd6;color:white;border:1px solid transparent;border-radius:3px}pre{white-space:pre-wrap;background:#181818;padding:10px}label{display:block}button:focus-visible,input:focus-visible{outline:2px solid #c7b8ff;outline-offset:2px}@media(forced-colors:active){button,input,pre{border:1px solid CanvasText}}
 </style></head><body>
 <h3>Premiere Pro MCP Bridge</h3>
-<label>Bridge URL <input id="bridge-url" value="ws://127.0.0.1:7777/uxp"></label>
-<button id="connect">Connect</button><button id="refresh">Refresh state</button>
-<pre id="status">Starting…</pre>
+<label for="bridge-url">Bridge URL</label><input id="bridge-url" value="ws://127.0.0.1:7777/uxp" spellcheck="false" autocomplete="off">
+<button id="connect" aria-controls="status">Connect</button><button id="refresh" aria-controls="status">Refresh state</button>
+<pre id="status" role="status" aria-live="polite" aria-atomic="true" tabindex="0">Starting…</pre>
 <script src="protocol.cjs"></script><script src="index.cjs"></script>
 </body></html>


### PR DESCRIPTION
## Summary

Adds two operational hardening tools and accessible status improvements:

- `inspect_project_recovery`
  - reads the active project's name/path through the supported CEP bridge
  - reports whether a saved `.prproj` path exists
  - searches only the project directory and adjacent `Adobe Premiere Pro Auto-Save` / `Premiere Pro Auto-Save` folders
  - filters candidates to project-name matches, caps results at 50, sorts newest-first, and reports timestamp/size/newer-than-project evidence
  - never opens, copies, overwrites, saves, or restores a project
  - truthfully reports the dirty/unsaved flag as unavailable because the documented API does not expose it
- `get_bridge_telemetry`
  - reports aggregate pending command/response/busy counts and oldest queue age
  - returns no bridge path, filenames, script/response contents, project names, or media names

CEP and UXP bridge panels gain:

- semantic atomic status live regions
- explicit labels and relationships for controls
- keyboard-focusable activity/status output
- stronger focus indicators
- text/symbol status cues in addition to color
- reduced-motion preservation and forced-colors support
- focus recovery when the bridge directory is missing

## Recovery safety boundary

Premiere's documented ExtendScript and UXP APIs do not provide a supported recovery/restore action or a direct current dirty-state query. This PR intentionally provides discovery and user guidance only. The user must review and open a selected autosave through Premiere's File > Open workflow.

Candidate discovery is local and bounded; it does not scan the home directory, Creative Cloud, arbitrary scratch disks, or recurse beyond the known adjacent folders. A custom Auto Save location must be reviewed manually.

## Verification

- recovery/accessibility + module tests: 241 passed
- full suite: 361 passed across 13 files
- `npm run build`: passed
- `git diff --check`: passed

## Live-host boundary

Filesystem discovery and generated bridge scripts are unit-tested. No live Premiere host was available, and no restore action was attempted or simulated.
