### PR TITLE
Add collaboration and AI feature support discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **Give AI full control over Adobe Premiere Pro.**
 
-269 tools across 29 modules, 3 resources, and 4 guided workflows.
+270 tools across 29 modules, 3 resources, and 4 guided workflows.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Node.js](https://img.shields.io/badge/Node.js-20.19%2B-green.svg)](https://nodejs.org)
@@ -25,7 +25,7 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 "Add the B-roll clips to V2, apply a cross dissolve between each, color correct them to match the A-roll, and export a 1080p ProRes."
 ```
 
-The AI handles the entire workflow through 269 tools spanning the supported ExtendScript, QE DOM, and safe edit-planning surfaces.
+The AI handles the entire workflow through 270 tools spanning the supported ExtendScript, QE DOM, and safe edit-planning surfaces.
 
 ### What's new in 1.3.1
 
@@ -228,6 +228,25 @@ The default bridge directory is derived from the operating system on both sides,
 
 `get_capabilities` reports the current operating system, temp directory, CEP/UXP coverage, enabled authority profile, and any live-host verification still required. It does not claim a Premiere operation succeeded; use `ping` and inspect each tool result for runtime evidence.
 
+### Collaboration and AI feature boundaries
+
+`get_advanced_feature_support` returns a machine-readable matrix for Productions,
+Team Projects, Frame.io, Media Intelligence, Generative Extend, Object Mask,
+caption translation, Speech-to-Text, Enhance Speech, and Remix. Pass an optional
+Premiere version, intended backend, confirmed entitlements, and network state to
+evaluate prerequisites without conflating them with API availability.
+
+- Productions exposes documented read-only state through UXP, but the production
+  MCP transport is still CEP.
+- Frame.io needs a separately authenticated Frame.io API integration; an account
+  entitlement alone does not make it callable through Premiere's DOM.
+- Transcript JSON import/export is documented in UXP. Starting Speech-to-Text is not.
+- The remaining AI operations are user-assisted or unsupported by documented
+  public APIs. The tool explains what can be inspected after a user completes
+  the operation and where artifact provenance cannot be established safely.
+- The server never uses menu automation, private APIs, clip-name heuristics, or
+  duration changes as proof that an AI operation occurred.
+
 ---
 
 ## Architecture
@@ -270,7 +289,7 @@ The file-based IPC bridge is simple, reliable, and works across macOS and Window
 
 ---
 
-## Tools (269)
+## Tools (270)
 
 ### Discovery & Inspection (10 + 10)
 
@@ -286,6 +305,7 @@ The file-based IPC bridge is simple, reliable, and works across macOS and Window
 | `search_project_items` | Filter by name, extension, offline status, color label |
 | `get_premiere_state` | Full snapshot: project, sequence, playhead, selection |
 | `inspect_dom_object` | Explore any Premiere Pro DOM object interactively |
+| `get_advanced_feature_support` | Collaboration/AI API support, prerequisites, entitlements, and user-assisted boundaries |
 
 ### Project Management (26)
 
@@ -495,7 +515,7 @@ premiere-pro-mcp/
 ├── src/
 │   ├── index.ts                 # Entry point — stdio transport setup
 │   ├── http-server.ts           # Entry point — HTTP/SSE transport (Fly.io / remote)
-│   ├── server.ts                # MCP server — registers 269 tools + 3 resources + 4 prompts
+│   ├── server.ts                # MCP server — registers 270 tools + 3 resources + 4 prompts
 │   ├── bridge/
 │   │   ├── file-bridge.ts       # File-based IPC (write .jsx, poll .json)
 │   │   └── script-builder.ts    # ExtendScript generator with ES3 helpers

--- a/README.md
+++ b/README.md
@@ -236,6 +236,12 @@ caption translation, Speech-to-Text, Enhance Speech, and Remix. Pass an optional
 Premiere version, intended backend, confirmed entitlements, and network state to
 evaluate prerequisites without conflating them with API availability.
 
+The report tool itself is local: it does not contact Premiere and is callable
+through the current MCP server. Each feature entry separately reports whether
+its operations are callable through the production CEP transport. Productions
+reports only static backend/version eligibility until a UXP host performs live
+capability negotiation.
+
 - Productions exposes documented read-only state through UXP, but the production
   MCP transport is still CEP.
 - Frame.io needs a separately authenticated Frame.io API integration; an account

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "premiere-pro-mcp",
   "version": "1.3.1",
-  "description": "Adobe Premiere Pro MCP server with 269 AI video editing tools for timeline automation, effects, media management, and export.",
+  "description": "Adobe Premiere Pro MCP server with 270 AI video editing tools for timeline automation, effects, media management, and export.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
   "type": "module",

--- a/src/advanced-feature-support.ts
+++ b/src/advanced-feature-support.ts
@@ -1,0 +1,150 @@
+export type AdvancedFeatureBackend = "cep" | "uxp";
+export type AdvancedFeatureStatus =
+  | "uxp-read-only"
+  | "external-api-required"
+  | "user-assisted"
+  | "unsupported-public-api";
+
+export interface AdvancedFeatureContext {
+  backend?: AdvancedFeatureBackend;
+  premiereVersion?: string;
+  frameIoEntitled?: boolean;
+  generativeAiEntitled?: boolean;
+  networkAvailable?: boolean;
+}
+
+function versionAtLeast(version: string | undefined, minimum: string): boolean | null {
+  if (!version) return null;
+  if (!/^\d+(?:\.\d+){0,3}$/.test(version)) throw new Error("premiere_version must contain only numeric version components");
+  const current = version.split(".").map(Number);
+  const required = minimum.split(".").map(Number);
+  for (let index = 0; index < Math.max(current.length, required.length); index += 1) {
+    const left = current[index] ?? 0;
+    const right = required[index] ?? 0;
+    if (left !== right) return left > right;
+  }
+  return true;
+}
+
+export function buildAdvancedFeatureSupport(context: AdvancedFeatureContext = {}) {
+  const backend = context.backend ?? "cep";
+  const productionsVersionEligible = versionAtLeast(context.premiereVersion, "25.6.0");
+
+  return {
+    schemaVersion: 1,
+    context: {
+      backend,
+      premiereVersion: context.premiereVersion ?? null,
+      frameIoEntitled: context.frameIoEntitled ?? null,
+      generativeAiEntitled: context.generativeAiEntitled ?? null,
+      networkAvailable: context.networkAvailable ?? null,
+    },
+    policy: {
+      publicApisOnly: true,
+      uiAutomation: false,
+      privateApis: false,
+      callableThroughCurrentMcpTransport: false,
+      note: "The production MCP transport is CEP. UXP-only entries require the separate UXP bridge and live capability negotiation.",
+    },
+    features: {
+      productions: {
+        status: "uxp-read-only" as AdvancedFeatureStatus,
+        availableInRequestedContext: backend === "uxp" ? productionsVersionEligible : false,
+        minPremiereVersion: "25.6.0",
+        entitlement: "local-project-feature",
+        documentedSurface: [
+          "PRProduction.getActiveProduction",
+          "PRProduction.getScratchDiskSettings",
+        ],
+        supportedOperations: ["inspect active Production", "inspect scratch-disk settings"],
+        unsupportedOperations: ["create Production", "add project", "lock project", "resolve conflicts"],
+        userAssistedWorkflow: "Open the Production in Premiere, then use a UXP-capable client to inspect its active state.",
+        docs: "https://developer.adobe.com/premiere-pro/uxp/ppro_reference/classes/prproduction/",
+      },
+      teamProjects: {
+        status: "unsupported-public-api" as AdvancedFeatureStatus,
+        availableInRequestedContext: false,
+        entitlement: "Creative Cloud Team Projects entitlement",
+        supportedOperations: [],
+        unsupportedOperations: ["create", "share", "sync", "publish changes", "resolve conflicts"],
+        userAssistedWorkflow: "Use Premiere's Team Projects panel for collaboration and conflict resolution.",
+        detection: "No safe documented project-state discriminator is exposed to this integration.",
+      },
+      frameIo: {
+        status: "external-api-required" as AdvancedFeatureStatus,
+        availableInRequestedContext: false,
+        entitlementSatisfied: context.frameIoEntitled ?? null,
+        prerequisites: ["Frame.io account and project access", "Frame.io API integration", "network access"],
+        networkSatisfied: context.networkAvailable ?? null,
+        supportedOperations: [],
+        unsupportedOperations: ["upload", "create review link", "read comments", "convert comments to markers"],
+        userAssistedWorkflow: "Use Premiere's Frame.io panel, or connect a separately authenticated Frame.io API client.",
+        detection: "Premiere DOM does not safely identify Frame.io review state.",
+      },
+      mediaIntelligence: {
+        status: "user-assisted" as AdvancedFeatureStatus,
+        availableInRequestedContext: false,
+        entitlement: "Premiere feature availability varies by build and locale",
+        supportedOperations: [],
+        unsupportedOperations: ["run semantic media analysis", "query Premiere's Media Intelligence index"],
+        userAssistedWorkflow: "Run Media Intelligence search in Premiere, then select or organize the resulting clips for ordinary MCP inspection.",
+        detection: "Search-index state and semantic matches are not exposed by a documented public API.",
+      },
+      generativeExtend: {
+        status: "user-assisted" as AdvancedFeatureStatus,
+        availableInRequestedContext: false,
+        entitlementSatisfied: context.generativeAiEntitled ?? null,
+        prerequisites: ["eligible Premiere build", "Adobe generative AI entitlement", "network access"],
+        networkSatisfied: context.networkAvailable ?? null,
+        supportedOperations: ["inspect a generated clip as an ordinary project/timeline item after Premiere creates it"],
+        unsupportedOperations: ["invoke Generative Extend", "inspect generation job or provenance"],
+        userAssistedWorkflow: "Run Generative Extend in Premiere, then re-query project and timeline items.",
+        detection: "No documented flag safely distinguishes a generated extension from an ordinary clip.",
+      },
+      objectMask: {
+        status: "user-assisted" as AdvancedFeatureStatus,
+        availableInRequestedContext: false,
+        supportedOperations: ["inspect ordinary effect components after a mask is created"],
+        unsupportedOperations: ["invoke object selection", "run tracking", "identify an Object Mask artifact reliably"],
+        userAssistedWorkflow: "Create and track the mask in Premiere, then use generic effect/property inspection where exposed.",
+        detection: "No documented stable Object Mask identifier is exposed.",
+      },
+      captionTranslation: {
+        status: "user-assisted" as AdvancedFeatureStatus,
+        availableInRequestedContext: false,
+        prerequisites: ["supported source/target language", "network access and service availability"],
+        networkSatisfied: context.networkAvailable ?? null,
+        supportedOperations: ["inspect resulting caption tracks through documented caption-track APIs"],
+        unsupportedOperations: ["invoke caption translation", "inspect translation job state"],
+        userAssistedWorkflow: "Translate captions in Premiere, then inspect the resulting caption track.",
+        detection: "No documented metadata identifies a caption track as machine-translated.",
+      },
+      speechToText: {
+        status: "user-assisted" as AdvancedFeatureStatus,
+        availableInRequestedContext: false,
+        minPremiereVersionForTranscriptIO: "25.6.0",
+        supportedOperations: ["UXP transcript JSON import", "UXP transcript JSON export"],
+        unsupportedOperations: ["start Speech-to-Text transcription", "monitor transcription progress"],
+        userAssistedWorkflow: "Transcribe the clip in Premiere; UXP clients can then import or export the transcript JSON.",
+        detection: "Transcript.hasTranscript is documented in Premiere 26.3+; export probing is available in 25.6+.",
+        docs: "https://developer.adobe.com/premiere-pro/uxp/ppro_reference/classes/transcript",
+      },
+      enhanceSpeech: {
+        status: "unsupported-public-api" as AdvancedFeatureStatus,
+        availableInRequestedContext: false,
+        supportedOperations: ["inspect generic audio effects if Premiere represents the result there"],
+        unsupportedOperations: ["invoke Enhance Speech", "set mix amount", "inspect analysis progress"],
+        userAssistedWorkflow: "Apply Enhance Speech in Premiere, then verify playback and generic audio state manually.",
+        detection: "No documented stable Enhance Speech artifact identifier or invocation API is exposed.",
+      },
+      remix: {
+        status: "unsupported-public-api" as AdvancedFeatureStatus,
+        availableInRequestedContext: false,
+        supportedOperations: ["inspect the resulting timeline clip duration after the user applies Remix"],
+        unsupportedOperations: ["invoke Remix", "set target duration through a dedicated API", "inspect analysis state"],
+        userAssistedWorkflow: "Apply Remix in Premiere, then inspect the resulting clip duration with timeline tools.",
+        detection: "A changed clip duration alone is not proof that Remix was applied.",
+      },
+    },
+  };
+}

--- a/src/advanced-feature-support.ts
+++ b/src/advanced-feature-support.ts
@@ -43,13 +43,34 @@ export function buildAdvancedFeatureSupport(context: AdvancedFeatureContext = {}
       publicApisOnly: true,
       uiAutomation: false,
       privateApis: false,
-      callableThroughCurrentMcpTransport: false,
-      note: "The production MCP transport is CEP. UXP-only entries require the separate UXP bridge and live capability negotiation.",
+      reportTool: {
+        transport: "local",
+        callableThroughCurrentMcpTransport: true,
+        contactsPremiereHost: false,
+        note: "This report is computed locally from documented support metadata and caller-supplied context.",
+      },
+      featureOperations: {
+        currentMcpTransport: "cep",
+        uxpOperationsRoutedByCurrentMcpTransport: false,
+        liveHostCapabilityNegotiationRequired: true,
+        note: "UXP-only feature operations require the separate UXP bridge and live capability negotiation.",
+      },
     },
     features: {
       productions: {
         status: "uxp-read-only" as AdvancedFeatureStatus,
-        availableInRequestedContext: backend === "uxp" ? productionsVersionEligible : false,
+        staticEligibility: {
+          backendEligible: backend === "uxp",
+          versionEligible: productionsVersionEligible,
+          eligible:
+            backend === "uxp" && productionsVersionEligible === true
+              ? true
+              : backend !== "uxp" || productionsVersionEligible === false
+                ? false
+                : null,
+        },
+        liveHostVerificationRequired: true,
+        callableThroughCurrentMcpTransport: false,
         minPremiereVersion: "25.6.0",
         entitlement: "local-project-feature",
         documentedSurface: [
@@ -63,7 +84,7 @@ export function buildAdvancedFeatureSupport(context: AdvancedFeatureContext = {}
       },
       teamProjects: {
         status: "unsupported-public-api" as AdvancedFeatureStatus,
-        availableInRequestedContext: false,
+        callableThroughCurrentMcpTransport: false,
         entitlement: "Creative Cloud Team Projects entitlement",
         supportedOperations: [],
         unsupportedOperations: ["create", "share", "sync", "publish changes", "resolve conflicts"],
@@ -72,7 +93,7 @@ export function buildAdvancedFeatureSupport(context: AdvancedFeatureContext = {}
       },
       frameIo: {
         status: "external-api-required" as AdvancedFeatureStatus,
-        availableInRequestedContext: false,
+        callableThroughCurrentMcpTransport: false,
         entitlementSatisfied: context.frameIoEntitled ?? null,
         prerequisites: ["Frame.io account and project access", "Frame.io API integration", "network access"],
         networkSatisfied: context.networkAvailable ?? null,
@@ -83,7 +104,7 @@ export function buildAdvancedFeatureSupport(context: AdvancedFeatureContext = {}
       },
       mediaIntelligence: {
         status: "user-assisted" as AdvancedFeatureStatus,
-        availableInRequestedContext: false,
+        callableThroughCurrentMcpTransport: false,
         entitlement: "Premiere feature availability varies by build and locale",
         supportedOperations: [],
         unsupportedOperations: ["run semantic media analysis", "query Premiere's Media Intelligence index"],
@@ -92,7 +113,7 @@ export function buildAdvancedFeatureSupport(context: AdvancedFeatureContext = {}
       },
       generativeExtend: {
         status: "user-assisted" as AdvancedFeatureStatus,
-        availableInRequestedContext: false,
+        callableThroughCurrentMcpTransport: false,
         entitlementSatisfied: context.generativeAiEntitled ?? null,
         prerequisites: ["eligible Premiere build", "Adobe generative AI entitlement", "network access"],
         networkSatisfied: context.networkAvailable ?? null,
@@ -103,7 +124,7 @@ export function buildAdvancedFeatureSupport(context: AdvancedFeatureContext = {}
       },
       objectMask: {
         status: "user-assisted" as AdvancedFeatureStatus,
-        availableInRequestedContext: false,
+        callableThroughCurrentMcpTransport: false,
         supportedOperations: ["inspect ordinary effect components after a mask is created"],
         unsupportedOperations: ["invoke object selection", "run tracking", "identify an Object Mask artifact reliably"],
         userAssistedWorkflow: "Create and track the mask in Premiere, then use generic effect/property inspection where exposed.",
@@ -111,7 +132,7 @@ export function buildAdvancedFeatureSupport(context: AdvancedFeatureContext = {}
       },
       captionTranslation: {
         status: "user-assisted" as AdvancedFeatureStatus,
-        availableInRequestedContext: false,
+        callableThroughCurrentMcpTransport: false,
         prerequisites: ["supported source/target language", "network access and service availability"],
         networkSatisfied: context.networkAvailable ?? null,
         supportedOperations: ["inspect resulting caption tracks through documented caption-track APIs"],
@@ -121,7 +142,7 @@ export function buildAdvancedFeatureSupport(context: AdvancedFeatureContext = {}
       },
       speechToText: {
         status: "user-assisted" as AdvancedFeatureStatus,
-        availableInRequestedContext: false,
+        callableThroughCurrentMcpTransport: false,
         minPremiereVersionForTranscriptIO: "25.6.0",
         supportedOperations: ["UXP transcript JSON import", "UXP transcript JSON export"],
         unsupportedOperations: ["start Speech-to-Text transcription", "monitor transcription progress"],
@@ -131,7 +152,7 @@ export function buildAdvancedFeatureSupport(context: AdvancedFeatureContext = {}
       },
       enhanceSpeech: {
         status: "unsupported-public-api" as AdvancedFeatureStatus,
-        availableInRequestedContext: false,
+        callableThroughCurrentMcpTransport: false,
         supportedOperations: ["inspect generic audio effects if Premiere represents the result there"],
         unsupportedOperations: ["invoke Enhance Speech", "set mix amount", "inspect analysis progress"],
         userAssistedWorkflow: "Apply Enhance Speech in Premiere, then verify playback and generic audio state manually.",
@@ -139,7 +160,7 @@ export function buildAdvancedFeatureSupport(context: AdvancedFeatureContext = {}
       },
       remix: {
         status: "unsupported-public-api" as AdvancedFeatureStatus,
-        availableInRequestedContext: false,
+        callableThroughCurrentMcpTransport: false,
         supportedOperations: ["inspect the resulting timeline clip duration after the user applies Remix"],
         unsupportedOperations: ["invoke Remix", "set target duration through a dedicated API", "inspect analysis state"],
         userAssistedWorkflow: "Apply Remix in Premiere, then inspect the resulting clip duration with timeline tools.",

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ const args = process.argv.slice(2);
 
 if (args.includes("--help") || args.includes("-h")) {
   console.log(`
-premiere-pro-mcp — MCP server for Adobe Premiere Pro (269 tools)
+premiere-pro-mcp — MCP server for Adobe Premiere Pro (270 tools)
 
 Usage:
   premiere-pro-mcp              Start the MCP server (stdio transport)

--- a/src/tools/health.ts
+++ b/src/tools/health.ts
@@ -2,12 +2,65 @@ import { buildToolScript } from "../bridge/script-builder.js";
 import { getTempDir, sendCommand, BridgeOptions } from "../bridge/file-bridge.js";
 import { resolveCapabilities, type CapabilityConfig } from "../security/capabilities.js";
 import { buildPlatformCapabilityReport } from "../platform-capabilities.js";
+import { buildAdvancedFeatureSupport, type AdvancedFeatureBackend } from "../advanced-feature-support.js";
 
 export function getHealthTools(
   bridgeOptions: BridgeOptions,
   capabilities: CapabilityConfig = resolveCapabilities(),
 ) {
   return {
+    get_advanced_feature_support: {
+      description:
+        "Report public-API support, prerequisites, entitlements, and user-assisted boundaries for Premiere collaboration and AI features",
+      parameters: {
+        type: "object" as const,
+        properties: {
+          backend: {
+            type: "string",
+            enum: ["cep", "uxp"],
+            description: "Backend being evaluated (default: cep, the current production MCP transport)",
+          },
+          premiere_version: {
+            type: "string",
+            description: "Optional Premiere version such as 26.3.0 for version-specific eligibility",
+          },
+          frameio_entitled: {
+            type: "boolean",
+            description: "Whether the operator has confirmed Frame.io account/project access",
+          },
+          generative_ai_entitled: {
+            type: "boolean",
+            description: "Whether the operator has confirmed Adobe generative AI entitlement",
+          },
+          network_available: {
+            type: "boolean",
+            description: "Whether required Adobe/cloud services are reachable",
+          },
+        },
+      },
+      handler: async (args: {
+        backend?: AdvancedFeatureBackend;
+        premiere_version?: string;
+        frameio_entitled?: boolean;
+        generative_ai_entitled?: boolean;
+        network_available?: boolean;
+      }) => {
+        try {
+          return {
+            success: true,
+            data: buildAdvancedFeatureSupport({
+              backend: args.backend,
+              premiereVersion: args.premiere_version,
+              frameIoEntitled: args.frameio_entitled,
+              generativeAiEntitled: args.generative_ai_entitled,
+              networkAvailable: args.network_available,
+            }),
+          };
+        } catch (error) {
+          return { success: false, error: error instanceof Error ? error.message : String(error) };
+        }
+      },
+    },
     get_capabilities: {
       description: "Report Windows/macOS support, Premiere Pro backend coverage, enabled authority, and whether live host verification is still required.",
       parameters: {},

--- a/tests/advanced-feature-support.test.ts
+++ b/tests/advanced-feature-support.test.ts
@@ -10,18 +10,32 @@ describe("advanced collaboration and AI feature support", () => {
       publicApisOnly: true,
       uiAutomation: false,
       privateApis: false,
-      callableThroughCurrentMcpTransport: false,
+      reportTool: {
+        transport: "local",
+        callableThroughCurrentMcpTransport: true,
+        contactsPremiereHost: false,
+      },
+      featureOperations: {
+        currentMcpTransport: "cep",
+        uxpOperationsRoutedByCurrentMcpTransport: false,
+        liveHostCapabilityNegotiationRequired: true,
+      },
     });
     expect(report.features.productions).toMatchObject({
       status: "uxp-read-only",
-      availableInRequestedContext: false,
+      staticEligibility: {
+        backendEligible: false,
+        eligible: false,
+      },
+      liveHostVerificationRequired: true,
+      callableThroughCurrentMcpTransport: false,
     });
   });
 
   it("marks documented Productions inspection available only for eligible UXP hosts", () => {
-    expect(buildAdvancedFeatureSupport({ backend: "uxp", premiereVersion: "25.6.0" }).features.productions.availableInRequestedContext).toBe(true);
-    expect(buildAdvancedFeatureSupport({ backend: "uxp", premiereVersion: "25.5.9" }).features.productions.availableInRequestedContext).toBe(false);
-    expect(buildAdvancedFeatureSupport({ backend: "uxp" }).features.productions.availableInRequestedContext).toBeNull();
+    expect(buildAdvancedFeatureSupport({ backend: "uxp", premiereVersion: "25.6.0" }).features.productions.staticEligibility.eligible).toBe(true);
+    expect(buildAdvancedFeatureSupport({ backend: "uxp", premiereVersion: "25.5.9" }).features.productions.staticEligibility.eligible).toBe(false);
+    expect(buildAdvancedFeatureSupport({ backend: "uxp" }).features.productions.staticEligibility.eligible).toBeNull();
   });
 
   it("keeps entitlements separate from API availability", () => {
@@ -35,12 +49,12 @@ describe("advanced collaboration and AI feature support", () => {
     expect(report.features.frameIo).toMatchObject({
       status: "external-api-required",
       entitlementSatisfied: true,
-      availableInRequestedContext: false,
+      callableThroughCurrentMcpTransport: false,
     });
     expect(report.features.generativeExtend).toMatchObject({
       status: "user-assisted",
       entitlementSatisfied: true,
-      availableInRequestedContext: false,
+      callableThroughCurrentMcpTransport: false,
     });
   });
 

--- a/tests/advanced-feature-support.test.ts
+++ b/tests/advanced-feature-support.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { buildAdvancedFeatureSupport } from "../src/advanced-feature-support.js";
+import { getHealthTools } from "../src/tools/health.js";
+
+describe("advanced collaboration and AI feature support", () => {
+  it("defaults to the production CEP transport and fails closed", () => {
+    const report = buildAdvancedFeatureSupport();
+    expect(report.context.backend).toBe("cep");
+    expect(report.policy).toMatchObject({
+      publicApisOnly: true,
+      uiAutomation: false,
+      privateApis: false,
+      callableThroughCurrentMcpTransport: false,
+    });
+    expect(report.features.productions).toMatchObject({
+      status: "uxp-read-only",
+      availableInRequestedContext: false,
+    });
+  });
+
+  it("marks documented Productions inspection available only for eligible UXP hosts", () => {
+    expect(buildAdvancedFeatureSupport({ backend: "uxp", premiereVersion: "25.6.0" }).features.productions.availableInRequestedContext).toBe(true);
+    expect(buildAdvancedFeatureSupport({ backend: "uxp", premiereVersion: "25.5.9" }).features.productions.availableInRequestedContext).toBe(false);
+    expect(buildAdvancedFeatureSupport({ backend: "uxp" }).features.productions.availableInRequestedContext).toBeNull();
+  });
+
+  it("keeps entitlements separate from API availability", () => {
+    const report = buildAdvancedFeatureSupport({
+      backend: "uxp",
+      premiereVersion: "26.3",
+      frameIoEntitled: true,
+      generativeAiEntitled: true,
+      networkAvailable: true,
+    });
+    expect(report.features.frameIo).toMatchObject({
+      status: "external-api-required",
+      entitlementSatisfied: true,
+      availableInRequestedContext: false,
+    });
+    expect(report.features.generativeExtend).toMatchObject({
+      status: "user-assisted",
+      entitlementSatisfied: true,
+      availableInRequestedContext: false,
+    });
+  });
+
+  it("documents artifact detection boundaries instead of inferring provenance", () => {
+    const features = buildAdvancedFeatureSupport().features;
+    expect(features.generativeExtend.detection).toContain("No documented flag");
+    expect(features.objectMask.detection).toContain("No documented stable");
+    expect(features.captionTranslation.detection).toContain("No documented metadata");
+    expect(features.remix.detection).toContain("not proof");
+  });
+
+  it("rejects non-numeric host versions", () => {
+    expect(() => buildAdvancedFeatureSupport({ premiereVersion: "26.3-beta" })).toThrow("numeric version");
+  });
+
+  it("exposes the report through the health tool without contacting Premiere", async () => {
+    const tool = getHealthTools({}).get_advanced_feature_support;
+    const result = await tool.handler({ backend: "uxp", premiere_version: "26.3.0" });
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        context: { backend: "uxp", premiereVersion: "26.3.0" },
+        features: {
+          speechToText: {
+            status: "user-assisted",
+          },
+        },
+      },
+    });
+  });
+});

--- a/tests/mcp-modernization.test.ts
+++ b/tests/mcp-modernization.test.ts
@@ -64,7 +64,7 @@ describe("modern MCP surface", () => {
       const tools = await client.listTools();
       expect(tools.tools.find((tool) => tool.name === "get_project_info")?.annotations?.readOnlyHint).toBe(true);
       expect(tools.tools.map((tool) => tool.name)).toContain("get_capabilities");
-      expect(tools.tools).toHaveLength(269);
+      expect(tools.tools).toHaveLength(270);
     } finally {
       await client.close();
       await server.close();

--- a/tests/tools/tool-modules.test.ts
+++ b/tests/tools/tool-modules.test.ts
@@ -84,7 +84,7 @@ const ALL_MODULES: Array<{
   { name: "source-monitor", getter: getSourceMonitorTools, minTools: 5 },
   { name: "track-targeting", getter: getTrackTargetingTools, minTools: 20 },
   { name: "utility", getter: getUtilityTools, minTools: 15 },
-  { name: "health", getter: getHealthTools, minTools: 2 },
+  { name: "health", getter: getHealthTools, minTools: 3 },
   { name: "workspace", getter: getWorkspaceTools, minTools: 2 },
   { name: "captions", getter: getCaptionTools, minTools: 1 },
   { name: "playback", getter: getPlaybackTools, minTools: 3 },
@@ -170,12 +170,12 @@ describe("Tool Module Structure", () => {
 });
 
 describe("Total Tool Count", () => {
-  it("all modules together have 267 tools", () => {
+  it("all modules together have 268 tools", () => {
     let total = 0;
     for (const mod of ALL_MODULES) {
       total += Object.keys(mod.getter(bridgeOptions)).length;
     }
-    expect(total).toBe(267);
+    expect(total).toBe(268);
   });
 
   it("there are 28 modules", () => {


### PR DESCRIPTION
## What changed

- add `get_advanced_feature_support`, a machine-readable support/prerequisite matrix
- cover Productions, Team Projects, Frame.io, Media Intelligence, Generative Extend, Object Mask, caption translation, Speech-to-Text, Enhance Speech, and Remix
- distinguish documented UXP read-only access, external API requirements, user-assisted workflows, and unsupported public APIs
- evaluate optional Premiere version, backend, network state, and confirmed entitlements without treating prerequisites as callable support
- document safe post-operation inspection and explicit artifact-provenance boundaries
- update the registered MCP surface to 270 tools

## Why

These Premiere features are easy for an AI client to overclaim because product UI availability, cloud entitlement, and public automation support are different things. This report gives clients a fail-closed contract and a safe user-assisted next step for each feature.

## Validation

- `npm run build`
- `npm test` — 13 files / 355 tests passed
- `git diff --check`

## Exact boundaries

- Productions: documented UXP read-only active Production and scratch-disk inspection; not callable through the current CEP MCP transport; no create/add/lock/conflict automation.
- Team Projects: no safe documented public automation or project-state discriminator in this integration.
- Frame.io: requires a separately authenticated Frame.io API integration; Premiere entitlement alone is insufficient.
- Speech-to-Text: UXP transcript JSON import/export is documented; starting or monitoring transcription is not.
- Generative Extend, Object Mask, caption translation, Media Intelligence, Enhance Speech, and Remix: no documented invocation API is claimed. Generic clips, tracks, effects, or durations may be inspected after user action, but are never treated as proof of provenance.
- No menu automation, private APIs, or heuristic artifact detection is introduced.