### PR TITLE
feat: add authenticated server-to-UXP transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,18 @@ The default bridge directory is derived from the operating system on both sides,
 
 `get_capabilities` reports the current operating system, temp directory, CEP/UXP coverage, enabled authority profile, and any live-host verification still required. It does not claim a Premiere operation succeeded; use `ping` and inspect each tool result for runtime evidence.
 
+### Authenticated UXP connection
+
+The MCP server can accept a local UXP panel connection and invoke the UXP commands that are currently implemented:
+
+```bash
+PREMIERE_UXP_TOKEN="replace-with-a-long-random-secret" premiere-pro-mcp
+```
+
+Enter the same token in the UXP panel. The listener binds only to `127.0.0.1:7777`, authenticates the WebSocket upgrade, requires a versioned capability handshake, correlates concurrent requests, and fails pending work on timeout or disconnect. Set `PREMIERE_UXP_PORT` to use another loopback port.
+
+When enabled, MCP discovery includes `get_uxp_capabilities`, `get_uxp_state`, and `export_frame_uxp`. A failed UXP command is never silently retried through CEP because the first operation may have partially succeeded.
+
 ---
 
 ## Architecture

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "ws": "^8.21.1",
         "zod": "^4.4.3"
       },
       "bin": {
@@ -17,6 +18,7 @@
       },
       "devDependencies": {
         "@types/node": "^26.1.1",
+        "@types/ws": "^8.18.1",
         "typescript": "^7.0.2",
         "vitest": "^4.1.10"
       },
@@ -433,6 +435,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
@@ -2704,6 +2716,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/zod": {
       "version": "4.4.3",

--- a/package.json
+++ b/package.json
@@ -75,10 +75,12 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "ws": "^8.21.1",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",
+    "@types/ws": "^8.18.1",
     "typescript": "^7.0.2",
     "vitest": "^4.1.10"
   },

--- a/src/bridge/uxp-websocket-bridge.ts
+++ b/src/bridge/uxp-websocket-bridge.ts
@@ -1,0 +1,306 @@
+import { randomUUID, timingSafeEqual } from "node:crypto";
+import { EventEmitter } from "node:events";
+import { createServer, type Server } from "node:http";
+import { WebSocket, WebSocketServer } from "ws";
+
+const LOOPBACK_HOST = "127.0.0.1";
+const SUPPORTED_PROTOCOLS = new Set([1, 2]);
+
+export interface UxpBridgeOptions {
+  token: string;
+  port?: number;
+  path?: string;
+  requestTimeoutMs?: number;
+  handshakeTimeoutMs?: number;
+}
+
+export interface UxpCapability {
+  supported: boolean;
+  [key: string]: unknown;
+}
+
+export interface UxpHello {
+  backend: "uxp";
+  protocolVersion: number;
+  commands: Record<string, UxpCapability>;
+  [key: string]: unknown;
+}
+
+export type UxpConnectionState =
+  | { status: "stopped" | "listening"; connected: false }
+  | {
+      status: "connected";
+      connected: true;
+      protocolVersion: number;
+      capabilities: UxpHello;
+      connectedAt: string;
+    };
+
+interface PendingRequest {
+  command: string;
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timer: NodeJS.Timeout;
+}
+
+export class UxpBridgeError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "UxpBridgeError";
+  }
+}
+
+function secureTokenEqual(actual: string, expected: string): boolean {
+  const left = Buffer.from(actual);
+  const right = Buffer.from(expected);
+  return left.length === right.length && timingSafeEqual(left, right);
+}
+
+function validPort(value: number): number {
+  if (!Number.isInteger(value) || value < 0 || value > 65535) {
+    throw new Error("UXP bridge port must be an integer between 0 and 65535");
+  }
+  return value;
+}
+
+/**
+ * Authenticated loopback WebSocket server used only by the local Premiere UXP
+ * panel. It never binds a LAN/WAN interface and does not silently fall back to
+ * CEP after a UXP command has been sent.
+ */
+export class UxpWebSocketBridge extends EventEmitter {
+  private readonly options: Required<UxpBridgeOptions>;
+  private httpServer: Server | null = null;
+  private wsServer: WebSocketServer | null = null;
+  private socket: WebSocket | null = null;
+  private hello: UxpHello | null = null;
+  private connectedAt: string | null = null;
+  private handshakeTimer: NodeJS.Timeout | null = null;
+  private readonly pending = new Map<string, PendingRequest>();
+
+  constructor(options: UxpBridgeOptions) {
+    super();
+    if (!options.token || options.token.length < 16) {
+      throw new Error("PREMIERE_UXP_TOKEN must contain at least 16 characters");
+    }
+    this.options = {
+      token: options.token,
+      port: validPort(options.port ?? 7777),
+      path: options.path ?? "/uxp",
+      requestTimeoutMs: options.requestTimeoutMs ?? 30_000,
+      handshakeTimeoutMs: options.handshakeTimeoutMs ?? 5_000,
+    };
+    if (!this.options.path.startsWith("/")) {
+      throw new Error("UXP bridge path must begin with '/'");
+    }
+  }
+
+  async start(): Promise<void> {
+    if (this.httpServer) return;
+    const httpServer = createServer((_req, res) => {
+      res.writeHead(404, { "Content-Type": "text/plain" });
+      res.end("Not found");
+    });
+    const wsServer = new WebSocketServer({ noServer: true, maxPayload: 1_048_576 });
+
+    httpServer.on("upgrade", (request, socket, head) => {
+      const url = new URL(request.url ?? "/", `http://${LOOPBACK_HOST}`);
+      const authorized =
+        url.pathname === this.options.path &&
+        secureTokenEqual(url.searchParams.get("token") ?? "", this.options.token);
+      if (!authorized) {
+        socket.write("HTTP/1.1 401 Unauthorized\r\nConnection: close\r\n\r\n");
+        socket.destroy();
+        return;
+      }
+      wsServer.handleUpgrade(request, socket, head, (client) => {
+        wsServer.emit("connection", client, request);
+      });
+    });
+    wsServer.on("connection", (client) => this.acceptConnection(client));
+
+    await new Promise<void>((resolve, reject) => {
+      httpServer.once("error", reject);
+      httpServer.listen(this.options.port, LOOPBACK_HOST, () => {
+        httpServer.off("error", reject);
+        resolve();
+      });
+    });
+    this.httpServer = httpServer;
+    this.wsServer = wsServer;
+    this.emit("listening", this.address());
+  }
+
+  address(): { host: string; port: number; path: string } {
+    const address = this.httpServer?.address();
+    return {
+      host: LOOPBACK_HOST,
+      port: typeof address === "object" && address ? address.port : this.options.port,
+      path: this.options.path,
+    };
+  }
+
+  getState(): UxpConnectionState {
+    if (this.socket?.readyState === WebSocket.OPEN && this.hello && this.connectedAt) {
+      return {
+        status: "connected",
+        connected: true,
+        protocolVersion: this.hello.protocolVersion,
+        capabilities: this.hello,
+        connectedAt: this.connectedAt,
+      };
+    }
+    return {
+      status: this.httpServer ? "listening" : "stopped",
+      connected: false,
+    };
+  }
+
+  async request(command: string, args: Record<string, unknown> = {}): Promise<unknown> {
+    const socket = this.socket;
+    const hello = this.hello;
+    if (!socket || socket.readyState !== WebSocket.OPEN || !hello) {
+      throw new UxpBridgeError("UXP_NOT_CONNECTED", "Premiere UXP bridge is not connected");
+    }
+    if (hello.commands[command]?.supported !== true) {
+      throw new UxpBridgeError(
+        "UXP_COMMAND_UNSUPPORTED",
+        `Connected Premiere host does not support UXP command '${command}'`,
+      );
+    }
+
+    const requestId = randomUUID();
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(requestId);
+        reject(new UxpBridgeError("UXP_TIMEOUT", `UXP command '${command}' timed out`));
+      }, this.options.requestTimeoutMs);
+      this.pending.set(requestId, { command, resolve, reject, timer });
+      socket.send(JSON.stringify({
+        protocolVersion: hello.protocolVersion,
+        type: "command",
+        requestId,
+        command,
+        args,
+      }), (error) => {
+        if (!error) return;
+        const pending = this.pending.get(requestId);
+        if (!pending) return;
+        clearTimeout(pending.timer);
+        this.pending.delete(requestId);
+        pending.reject(new UxpBridgeError("UXP_SEND_FAILED", error.message));
+      });
+    });
+  }
+
+  async stop(): Promise<void> {
+    this.clearConnection(new UxpBridgeError("UXP_STOPPED", "UXP bridge stopped"));
+    const wsServer = this.wsServer;
+    const httpServer = this.httpServer;
+    this.wsServer = null;
+    this.httpServer = null;
+    if (wsServer) {
+      for (const client of wsServer.clients) client.terminate();
+      wsServer.close();
+    }
+    if (httpServer) {
+      await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+    }
+  }
+
+  private acceptConnection(client: WebSocket): void {
+    if (this.socket) {
+      this.clearConnection(
+        new UxpBridgeError("UXP_RECONNECTED", "Premiere UXP bridge reconnected"),
+      );
+    }
+    this.socket = client;
+    this.hello = null;
+    this.connectedAt = null;
+    this.handshakeTimer = setTimeout(() => {
+      client.close(1008, "Versioned hello required");
+    }, this.options.handshakeTimeoutMs);
+    client.on("message", (data) => this.handleMessage(client, data.toString()));
+    client.on("close", () => {
+      if (client !== this.socket) return;
+      this.clearConnection(
+        new UxpBridgeError("UXP_DISCONNECTED", "Premiere UXP bridge disconnected"),
+      );
+      this.emit("disconnected");
+    });
+    client.on("error", (error) => this.emit("clientError", error));
+  }
+
+  private handleMessage(client: WebSocket, raw: string): void {
+    let message: any;
+    try {
+      message = JSON.parse(raw);
+    } catch {
+      client.close(1007, "Invalid JSON");
+      return;
+    }
+
+    if (!this.hello) {
+      const hello = message?.type === "hello" ? message.payload : null;
+      if (
+        !hello ||
+        hello.backend !== "uxp" ||
+        !SUPPORTED_PROTOCOLS.has(message.protocolVersion) ||
+        hello.protocolVersion !== message.protocolVersion ||
+        !hello.commands ||
+        typeof hello.commands !== "object" ||
+        Array.isArray(hello.commands)
+      ) {
+        client.close(1008, "Unsupported UXP handshake");
+        return;
+      }
+      if (this.handshakeTimer) clearTimeout(this.handshakeTimer);
+      this.handshakeTimer = null;
+      this.hello = hello as UxpHello;
+      this.connectedAt = new Date().toISOString();
+      this.emit("connected", this.getState());
+      return;
+    }
+
+    if (message?.protocolVersion !== this.hello.protocolVersion) {
+      client.close(1008, "Protocol version changed");
+      return;
+    }
+    if (message?.type === "event") {
+      this.emit("event", message.payload);
+      return;
+    }
+    if (message?.type !== "result" || typeof message.requestId !== "string") return;
+    const pending = this.pending.get(message.requestId);
+    if (!pending) return;
+    clearTimeout(pending.timer);
+    this.pending.delete(message.requestId);
+    if (message.payload?.ok === true) {
+      pending.resolve(message.payload.result);
+    } else {
+      const error = message.payload?.error;
+      pending.reject(new UxpBridgeError(
+        error?.code ?? "UXP_COMMAND_FAILED",
+        error?.message ?? `UXP command '${pending.command}' failed`,
+      ));
+    }
+  }
+
+  private clearConnection(error: Error): void {
+    if (this.handshakeTimer) clearTimeout(this.handshakeTimer);
+    this.handshakeTimer = null;
+    const socket = this.socket;
+    this.socket = null;
+    this.hello = null;
+    this.connectedAt = null;
+    if (socket?.readyState === WebSocket.OPEN) socket.close();
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { cleanupTempDir, getTempDir } from "./bridge/file-bridge.js";
 import { execFileSync } from "child_process";
 import { fileURLToPath } from "url";
 import path from "path";
+import { UxpWebSocketBridge } from "./bridge/uxp-websocket-bridge.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -39,6 +40,8 @@ Environment variables:
   PREMIERE_TIMEOUT_MS   Command timeout in ms (default: 30000)
   PREMIERE_MCP_CAPABILITIES  Comma-separated authority profile
   PREMIERE_MCP_DEBUG    Set to 1/true to enable verbose stderr diagnostics
+  PREMIERE_UXP_TOKEN    Enable the authenticated local UXP bridge (minimum 16 characters)
+  PREMIERE_UXP_PORT     UXP loopback WebSocket port (default: 7777)
 
 More info: https://github.com/leancoderkavy/premiere-pro-mcp
 `);
@@ -111,11 +114,31 @@ async function main() {
   // Clean up any stale files from previous sessions
   cleanupTempDir(bridgeOptions);
 
-  const server = createServer(bridgeOptions);
+  let uxpBridge: UxpWebSocketBridge | undefined;
+  if (process.env.PREMIERE_UXP_TOKEN) {
+    uxpBridge = new UxpWebSocketBridge({
+      token: process.env.PREMIERE_UXP_TOKEN,
+      port: process.env.PREMIERE_UXP_PORT
+        ? parseInt(process.env.PREMIERE_UXP_PORT, 10)
+        : undefined,
+    });
+    await uxpBridge.start();
+    const address = uxpBridge.address();
+    debugLog(`UXP bridge listening on ws://${address.host}:${address.port}${address.path}`);
+  }
+
+  const server = createServer(bridgeOptions, { uxpBridge });
   const transport = new StdioServerTransport();
 
   await server.connect(transport);
   debugLog("Server connected and ready");
+
+  const shutdown = async () => {
+    if (uxpBridge) await uxpBridge.stop();
+    await server.close();
+  };
+  process.once("SIGINT", () => void shutdown().finally(() => process.exit(0)));
+  process.once("SIGTERM", () => void shutdown().finally(() => process.exit(0)));
 }
 
 main().catch((err) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,6 +29,8 @@ import { getCaptionTools } from "./tools/captions.js";
 import { getPlaybackTools } from "./tools/playback.js";
 import { getProjectManagerTools } from "./tools/project-manager.js";
 import { getEditPlanTools } from "./tools/edit-plans.js";
+import { getUxpTools } from "./tools/uxp.js";
+import type { UxpWebSocketBridge } from "./bridge/uxp-websocket-bridge.js";
 import { guardToolHandler, resolveCapabilities } from "./security/index.js";
 import { EXTENDSCRIPT_REFERENCE } from "./resources/extendscript-reference.js";
 import { WORKFLOW_PROMPTS, WORKFLOW_RESOURCE } from "./workflows/catalog.js";
@@ -217,6 +219,7 @@ function jsonSchemaToZodShape(
 function collectTools(
   bridgeOptions: BridgeOptions,
   capabilities: ReturnType<typeof resolveCapabilities>,
+  uxpBridge?: UxpWebSocketBridge,
 ): Record<string, ToolDef> {
   const cacheKey = JSON.stringify({
     tempDir: bridgeOptions.tempDir ?? process.env.PREMIERE_TEMP_DIR ?? null,
@@ -224,7 +227,7 @@ function collectTools(
       bridgeOptions.timeoutMs ?? process.env.PREMIERE_TIMEOUT_MS ?? null,
     capabilities: [...capabilities.capabilities].sort(),
   });
-  const cached = toolCatalogCache.get(cacheKey);
+  const cached = uxpBridge ? undefined : toolCatalogCache.get(cacheKey);
   if (cached) return cached;
 
   const tools: Record<string, ToolDef> = {
@@ -257,12 +260,20 @@ function collectTools(
     ...getPlaybackTools(bridgeOptions),
     ...getProjectManagerTools(bridgeOptions),
     ...getEditPlanTools(bridgeOptions, { capabilities }),
+    ...(uxpBridge ? getUxpTools(uxpBridge) : {}),
   };
-  toolCatalogCache.set(cacheKey, tools);
+  if (!uxpBridge) toolCatalogCache.set(cacheKey, tools);
   return tools;
 }
 
-export function createServer(bridgeOptions: BridgeOptions): McpServer {
+export interface ServerOptions {
+  uxpBridge?: UxpWebSocketBridge;
+}
+
+export function createServer(
+  bridgeOptions: BridgeOptions,
+  serverOptions: ServerOptions = {},
+): McpServer {
   const server = new McpServer({
     name: "premiere-pro-mcp",
     version: "1.2.0",
@@ -271,7 +282,11 @@ export function createServer(bridgeOptions: BridgeOptions): McpServer {
   const capabilities = resolveCapabilities();
 
   // Collect all tools from each module
-  const toolModules = collectTools(bridgeOptions, capabilities);
+  const toolModules = collectTools(
+    bridgeOptions,
+    capabilities,
+    serverOptions.uxpBridge,
+  );
 
   // Register each tool with the MCP server
   for (const [name, tool] of Object.entries(toolModules)) {

--- a/src/tools/uxp.ts
+++ b/src/tools/uxp.ts
@@ -1,0 +1,65 @@
+import type { UxpWebSocketBridge } from "../bridge/uxp-websocket-bridge.js";
+
+function invoke(
+  bridge: UxpWebSocketBridge,
+  command: string,
+  args: Record<string, unknown> = {},
+) {
+  return bridge.request(command, args)
+    .then((result) => ({ success: true, data: { backend: "uxp", result } }))
+    .catch((error: unknown) => ({
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    }));
+}
+
+export function getUxpTools(bridge: UxpWebSocketBridge) {
+  return {
+    get_uxp_capabilities: {
+      description: "Report the authenticated local UXP bridge connection and the capabilities advertised by the connected Premiere host.",
+      parameters: {},
+      handler: async () => ({ success: true, data: bridge.getState() }),
+    },
+    get_uxp_state: {
+      description: "Read the active project, sequence, and playhead state through the connected Premiere UXP bridge.",
+      parameters: {},
+      handler: async () => invoke(bridge, "state.get"),
+    },
+    export_frame_uxp: {
+      description: "Export a sequence frame through Premiere's supported UXP Exporter and verify the output file in the host panel.",
+      parameters: {
+        type: "object" as const,
+        properties: {
+          output_directory: {
+            type: "string",
+            description: "Existing local directory available to the Premiere UXP plugin.",
+          },
+          filename: {
+            type: "string",
+            description: "Simple PNG filename without directory components.",
+          },
+          seconds: {
+            type: "number",
+            description: "Sequence time in seconds; omit to use the playhead.",
+          },
+          width: { type: "number", description: "Optional positive output width." },
+          height: { type: "number", description: "Optional positive output height." },
+        },
+        required: ["output_directory", "filename"],
+      },
+      handler: async (args: {
+        output_directory: string;
+        filename: string;
+        seconds?: number;
+        width?: number;
+        height?: number;
+      }) => invoke(bridge, "frame.export", {
+        outputDirectory: args.output_directory,
+        filename: args.filename,
+        ...(args.seconds === undefined ? {} : { seconds: args.seconds }),
+        ...(args.width === undefined ? {} : { width: args.width }),
+        ...(args.height === undefined ? {} : { height: args.height }),
+      }),
+    },
+  };
+}

--- a/tests/tools/uxp-tools.test.ts
+++ b/tests/tools/uxp-tools.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import { getUxpTools } from "../../src/tools/uxp.js";
+import type { UxpWebSocketBridge } from "../../src/bridge/uxp-websocket-bridge.js";
+import { createServer } from "../../src/server.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+
+describe("UXP MCP tools", () => {
+  it("maps MCP arguments to the supported frame export command", async () => {
+    const request = vi.fn().mockResolvedValue({ path: "/tmp/frame.png" });
+    const bridge = {
+      request,
+      getState: vi.fn(),
+    } as unknown as UxpWebSocketBridge;
+    const tools = getUxpTools(bridge);
+    const result = await tools.export_frame_uxp.handler({
+      output_directory: "/tmp",
+      filename: "frame.png",
+      seconds: 2.5,
+      width: 1920,
+      height: 1080,
+    });
+    expect(request).toHaveBeenCalledWith("frame.export", {
+      outputDirectory: "/tmp",
+      filename: "frame.png",
+      seconds: 2.5,
+      width: 1920,
+      height: 1080,
+    });
+    expect(result).toEqual({
+      success: true,
+      data: { backend: "uxp", result: { path: "/tmp/frame.png" } },
+    });
+  });
+
+  it("exposes connection discovery without requiring a host request", async () => {
+    const state = { status: "listening", connected: false } as const;
+    const bridge = {
+      request: vi.fn(),
+      getState: vi.fn(() => state),
+    } as unknown as UxpWebSocketBridge;
+    const result = await getUxpTools(bridge).get_uxp_capabilities.handler();
+    expect(result).toEqual({ success: true, data: state });
+    expect(bridge.request).not.toHaveBeenCalled();
+  });
+
+  it("returns transport errors through the normal tool envelope", async () => {
+    const bridge = {
+      request: vi.fn().mockRejectedValue(new Error("UXP bridge is not connected")),
+      getState: vi.fn(),
+    } as unknown as UxpWebSocketBridge;
+    const result = await getUxpTools(bridge).get_uxp_state.handler();
+    expect(result).toEqual({
+      success: false,
+      error: "UXP bridge is not connected",
+    });
+  });
+
+  it("registers UXP tools only when an adapter is supplied", async () => {
+    const bridge = {
+      request: vi.fn(),
+      getState: vi.fn(() => ({ status: "listening", connected: false })),
+    } as unknown as UxpWebSocketBridge;
+    const server = createServer({}, { uxpBridge: bridge });
+    const client = new Client({ name: "uxp-tool-test", version: "1.0.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    try {
+      const tools = await client.listTools();
+      expect(tools.tools.map((tool) => tool.name)).toEqual(
+        expect.arrayContaining([
+          "get_uxp_capabilities",
+          "get_uxp_state",
+          "export_frame_uxp",
+        ]),
+      );
+      expect(tools.tools).toHaveLength(272);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});

--- a/tests/uxp/transport.test.ts
+++ b/tests/uxp/transport.test.ts
@@ -1,0 +1,147 @@
+import { once } from "node:events";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocket } from "ws";
+import {
+  UxpBridgeError,
+  UxpWebSocketBridge,
+} from "../../src/bridge/uxp-websocket-bridge.js";
+
+const TOKEN = "test-token-at-least-16-characters";
+const bridges: UxpWebSocketBridge[] = [];
+
+async function createBridge(options: {
+  requestTimeoutMs?: number;
+  handshakeTimeoutMs?: number;
+} = {}) {
+  const bridge = new UxpWebSocketBridge({
+    token: TOKEN,
+    port: 0,
+    ...options,
+  });
+  bridges.push(bridge);
+  await bridge.start();
+  return bridge;
+}
+
+function bridgeUrl(bridge: UxpWebSocketBridge, token = TOKEN): string {
+  const address = bridge.address();
+  return `ws://${address.host}:${address.port}${address.path}?token=${encodeURIComponent(token)}`;
+}
+
+async function connectHost(
+  bridge: UxpWebSocketBridge,
+  commands: Record<string, { supported: boolean }> = {
+    "state.get": { supported: true },
+    "frame.export": { supported: true },
+  },
+) {
+  const client = new WebSocket(bridgeUrl(bridge));
+  await once(client, "open");
+  const connected = once(bridge, "connected");
+  client.send(JSON.stringify({
+    protocolVersion: 1,
+    type: "hello",
+    payload: {
+      backend: "uxp",
+      protocolVersion: 1,
+      commands,
+    },
+  }));
+  await connected;
+  return client;
+}
+
+afterEach(async () => {
+  await Promise.all(bridges.splice(0).map((bridge) => bridge.stop()));
+});
+
+describe("UXP WebSocket bridge", () => {
+  it("binds only to IPv4 loopback and requires the configured token", async () => {
+    const bridge = await createBridge();
+    expect(bridge.address()).toMatchObject({ host: "127.0.0.1", path: "/uxp" });
+
+    const unauthorized = new WebSocket(bridgeUrl(bridge, "wrong-token"));
+    unauthorized.on("error", () => {});
+    const [, response] = await once(unauthorized, "unexpected-response");
+    expect(response.statusCode).toBe(401);
+    response.resume();
+    expect(bridge.getState()).toEqual({ status: "listening", connected: false });
+  });
+
+  it("validates the versioned hello before reporting capabilities", async () => {
+    const bridge = await createBridge();
+    const client = await connectHost(bridge);
+    expect(bridge.getState()).toMatchObject({
+      status: "connected",
+      connected: true,
+      protocolVersion: 1,
+      capabilities: {
+        backend: "uxp",
+        commands: { "state.get": { supported: true } },
+      },
+    });
+    client.close();
+  });
+
+  it("correlates concurrent command results by request id", async () => {
+    const bridge = await createBridge();
+    const client = await connectHost(bridge);
+    const commands: any[] = [];
+    client.on("message", (data) => {
+      const message = JSON.parse(data.toString());
+      commands.push(message);
+      if (commands.length !== 2) return;
+      for (const command of [...commands].reverse()) {
+        client.send(JSON.stringify({
+          protocolVersion: 1,
+          type: "result",
+          requestId: command.requestId,
+          payload: { ok: true, result: { command: command.command } },
+        }));
+      }
+    });
+
+    const [state, frame] = await Promise.all([
+      bridge.request("state.get"),
+      bridge.request("frame.export", { filename: "frame.png" }),
+    ]);
+    expect(state).toEqual({ command: "state.get" });
+    expect(frame).toEqual({ command: "frame.export" });
+    client.close();
+  });
+
+  it("rejects unsupported commands before sending them", async () => {
+    const bridge = await createBridge();
+    const client = await connectHost(bridge, { "state.get": { supported: true } });
+    await expect(bridge.request("frame.export")).rejects.toMatchObject({
+      code: "UXP_COMMAND_UNSUPPORTED",
+    });
+    client.close();
+  });
+
+  it("times out requests and rejects in-flight work on disconnect", async () => {
+    const bridge = await createBridge({ requestTimeoutMs: 30 });
+    const client = await connectHost(bridge);
+    await expect(bridge.request("state.get")).rejects.toMatchObject({
+      code: "UXP_TIMEOUT",
+    });
+
+    const pending = bridge.request("state.get");
+    client.close();
+    await expect(pending).rejects.toMatchObject({ code: "UXP_DISCONNECTED" });
+  });
+
+  it("rejects invalid configuration without opening a listener", () => {
+    expect(() => new UxpWebSocketBridge({ token: "short" })).toThrow(
+      "at least 16 characters",
+    );
+    expect(() => new UxpWebSocketBridge({
+      token: TOKEN,
+      port: 70_000,
+    })).toThrow("between 0 and 65535");
+    expect(new UxpBridgeError("CODE", "message")).toMatchObject({
+      code: "CODE",
+      message: "message",
+    });
+  });
+});

--- a/uxp-plugin/README.md
+++ b/uxp-plugin/README.md
@@ -1,6 +1,6 @@
 # Premiere Pro MCP UXP bridge
 
-Production-oriented UXP transport for Premiere Pro 25.6+. Side-load `manifest.json` with UXP Developer Tool, open **Window → UXP Plugins → MCP Bridge**, then point it at the MCP-side WebSocket endpoint (default `ws://127.0.0.1:7777/uxp`).
+Production-oriented UXP transport for Premiere Pro 25.6+. Set `PREMIERE_UXP_TOKEN` to a secret of at least 16 characters before starting the MCP server. Side-load `manifest.json` with UXP Developer Tool, open **Window → UXP Plugins → MCP Bridge**, enter the same secret in **Bridge token**, then connect to the MCP-side WebSocket endpoint (default `ws://127.0.0.1:7777/uxp`).
 
 The bridge sends a versioned `hello`, emits `premiere.state.changed` events, and accepts `capabilities.get`, `state.get`, and `frame.export` commands. `frame.export` uses Adobe's supported `Exporter.exportSequenceFrame()` and verifies the file exists before reporting success. Example:
 
@@ -13,3 +13,19 @@ The bridge sends a versioned `hello`, emits `premiere.state.changed` events, and
 Capability discovery is authoritative per host session. Route a command to CEP only when the UXP capability is absent or explicitly `supported: false`. Never replay a failed UXP mutation through CEP automatically: the first attempt may have partially succeeded. CEP/QE results must identify `backend: "cep"`, and callers should treat QE-only behavior as compatibility mode rather than equivalent proof. UXP remains authoritative for supported frame export.
 
 Loopback WebSocket support must still be verified on each supported OS/Premiere combination. Until that evidence exists, keep the existing file bridge available as the transport fallback; transport fallback does not change command-backend selection.
+
+## MCP-side transport
+
+The server listener binds only to `127.0.0.1`, requires the token during the WebSocket upgrade, limits messages to 1 MiB, and requires a versioned UXP `hello` before accepting results. Requests are correlated by random IDs and fail on timeout or disconnect.
+
+When `PREMIERE_UXP_TOKEN` is configured, the MCP server registers only the commands currently implemented by this panel:
+
+- `get_uxp_capabilities`
+- `get_uxp_state`
+- `export_frame_uxp`
+
+These tools never silently replay a failed UXP request through CEP. `PREMIERE_UXP_PORT` changes the loopback port when `7777` is unavailable.
+
+### Related UXP lifecycle work
+
+This transport accepts protocol versions 1 and 2. PR #47 upgrades the panel protocol to version 2 with event-driven state and operation lifecycle semantics. Merge this transport first, then rebase PR #47; its panel-side `index.cjs` changes should retain the authenticated URL construction added here. The server adapter itself already accepts both versions.

--- a/uxp-plugin/index.cjs
+++ b/uxp-plugin/index.cjs
@@ -79,7 +79,16 @@ async function dispatch(raw) {
 function connect() {
   if (reconnectTimer) clearTimeout(reconnectTimer);
   if (socket) try { socket.close(); } catch (_) {}
-  const url = document.getElementById("bridge-url").value;
+  const configuredUrl = document.getElementById("bridge-url").value;
+  const token = document.getElementById("bridge-token").value;
+  let url;
+  try {
+    url = new URL(configuredUrl);
+    if (token) url.searchParams.set("token", token);
+    url = url.toString();
+  } catch (_) {
+    return scheduleReconnect("Invalid bridge URL");
+  }
   setStatus("Connecting to " + url);
   try { socket = new WebSocket(url); } catch (e) { return scheduleReconnect(e.message); }
   socket.onopen = async () => { setStatus("Connected"); send(Protocol.envelope("hello", await capabilities())); publishState("connected"); };

--- a/uxp-plugin/index.html
+++ b/uxp-plugin/index.html
@@ -4,6 +4,7 @@ body{font:12px system-ui;margin:14px;color:#ddd;background:#242424}button,input{
 </style></head><body>
 <h3>Premiere Pro MCP Bridge</h3>
 <label>Bridge URL <input id="bridge-url" value="ws://127.0.0.1:7777/uxp"></label>
+<label>Bridge token <input id="bridge-token" type="password" autocomplete="off"></label>
 <button id="connect">Connect</button><button id="refresh">Refresh state</button>
 <pre id="status">Starting…</pre>
 <script src="protocol.cjs"></script><script src="index.cjs"></script>


### PR DESCRIPTION
## Summary
- add an authenticated WebSocket adapter bound exclusively to 127.0.0.1
- validate protocol v1/v2 hello messages and advertised command capabilities
- correlate concurrent requests and reject work on timeout, send failure, reconnect, or disconnect
- conditionally register get_uxp_capabilities, get_uxp_state, and export_frame_uxp when PREMIERE_UXP_TOKEN enables the adapter
- add panel token entry without logging or persisting the secret
- preserve the no-silent-CEP-retry boundary

## Security
- loopback-only binding
- minimum 16-character shared secret checked during WebSocket upgrade
- timing-safe token comparison for equal-length values
- 1 MiB message limit
- unsupported/unadvertised commands fail before transmission

## Verification
- node --check uxp-plugin/index.cjs
- npm run build
- npm test (14 files, 359 tests)
- git diff --check

## Dependency ordering
This adapter accepts both protocol v1 and v2. Merge this PR before #47, then rebase #47 and retain this PR's authenticated URL construction in uxp-plugin/index.cjs. PR #47 supplies protocol-v2 lifecycle events; it is not required for request/response transport.

## Live-host boundary
Automated tests use a real loopback WebSocket client/server pair. Premiere Pro 25.6+ validation on macOS and Windows is still required.