### PR TITLE
Add Claude Code and Desktop distributions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "premiere-pro-mcp",
+  "owner": {
+    "name": "Premiere Pro MCP contributors"
+  },
+  "metadata": {
+    "description": "Claude Code integrations for Adobe Premiere Pro."
+  },
+  "plugins": [
+    {
+      "name": "premiere-pro",
+      "source": "./claude-plugins/premiere-pro",
+      "description": "Inspect, edit, verify, and export local Premiere Pro projects through MCP.",
+      "version": "1.3.1",
+      "category": "creative",
+      "tags": ["premiere-pro", "video-editing", "mcp"]
+    }
+  ]
+}

--- a/.github/workflows/claude-desktop-bundle.yml
+++ b/.github/workflows/claude-desktop-bundle.yml
@@ -1,0 +1,36 @@
+name: Build Claude Desktop bundle
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  bundle:
+    name: Build MCPB and legacy DXT
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          package-manager-cache: false
+      - run: npm ci
+      - run: npm run build:claude
+      - uses: actions/upload-artifact@v6
+        with:
+          name: premiere-pro-mcp-claude-desktop
+          path: |
+            artifacts/*.mcpb
+            artifacts/*.dxt
+          if-no-files-found: error
+      - name: Attach bundles to release
+        if: ${{ github.event_name == 'release' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          gh release upload "${{ github.event.release.tag_name }}"
+          artifacts/*.mcpb artifacts/*.dxt --clobber

--- a/README.md
+++ b/README.md
@@ -239,6 +239,36 @@ The plugin source lives in [`plugins/premiere-pro`](plugins/premiere-pro), and t
 repository marketplace manifest lives in
 [`.agents/plugins/marketplace.json`](.agents/plugins/marketplace.json).
 
+### Claude
+
+For Claude Code, add this repository as a marketplace and install the plugin:
+
+```text
+/plugin marketplace add leancoderkavy/premiere-pro-mcp
+/plugin install premiere-pro@premiere-pro-mcp
+```
+
+Then install the Premiere bridge and start a new Claude Code session:
+
+```bash
+npx -y premiere-pro-mcp@1.3.1 --install-cep
+```
+
+The Claude Code package lives in
+[`claude-plugins/premiere-pro`](claude-plugins/premiere-pro), with its marketplace
+at [`.claude-plugin/marketplace.json`](.claude-plugin/marketplace.json).
+
+Claude Desktop uses the self-contained MCP Bundle format, formerly called Desktop
+Extensions. Build both the current `.mcpb` artifact and a legacy `.dxt` copy with:
+
+```bash
+npm run build:claude
+```
+
+Install the resulting file from `artifacts/` through **Settings > Extensions >
+Advanced settings > Install Extension**. The Premiere CEP bridge must still be
+installed separately.
+
 ### Windows and macOS capability coverage
 
 | Surface | Windows | macOS | Verification boundary |

--- a/claude-desktop/manifest.json
+++ b/claude-desktop/manifest.json
@@ -1,0 +1,37 @@
+{
+  "manifest_version": "0.3",
+  "name": "premiere-pro-mcp",
+  "display_name": "Premiere Pro MCP",
+  "version": "1.3.1",
+  "description": "Control a local Adobe Premiere Pro project through MCP.",
+  "long_description": "Inspect projects, assemble and modify timelines, manage media, effects, audio and captions, and export deliverables through a local bridge to Adobe Premiere Pro.",
+  "author": {
+    "name": "Premiere Pro MCP contributors",
+    "url": "https://github.com/leancoderkavy/premiere-pro-mcp"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/leancoderkavy/premiere-pro-mcp.git"
+  },
+  "homepage": "https://premiere-pro-mcp.com/",
+  "documentation": "https://premiere-pro-mcp.com/docs/",
+  "support": "https://github.com/leancoderkavy/premiere-pro-mcp/issues",
+  "server": {
+    "type": "node",
+    "entry_point": "server/dist/index.js",
+    "mcp_config": {
+      "command": "node",
+      "args": ["${__dirname}/server/dist/index.js"]
+    }
+  },
+  "tools_generated": true,
+  "prompts_generated": true,
+  "keywords": ["premiere-pro", "video-editing", "timeline", "captions", "export"],
+  "license": "MIT",
+  "compatibility": {
+    "platforms": ["darwin", "win32"],
+    "runtimes": {
+      "node": ">=20.19.0"
+    }
+  }
+}

--- a/claude-plugins/premiere-pro/.claude-plugin/plugin.json
+++ b/claude-plugins/premiere-pro/.claude-plugin/plugin.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "premiere-pro",
+  "displayName": "Premiere Pro MCP",
+  "version": "1.3.1",
+  "description": "Inspect, edit, verify, and export local Adobe Premiere Pro projects through MCP.",
+  "author": {
+    "name": "Premiere Pro MCP contributors",
+    "url": "https://github.com/leancoderkavy/premiere-pro-mcp"
+  },
+  "homepage": "https://premiere-pro-mcp.com/",
+  "repository": "https://github.com/leancoderkavy/premiere-pro-mcp",
+  "license": "MIT",
+  "keywords": ["premiere-pro", "video-editing", "mcp", "timeline", "export"],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json"
+}

--- a/claude-plugins/premiere-pro/.mcp.json
+++ b/claude-plugins/premiere-pro/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "premiere-pro": {
+      "command": "npx",
+      "args": ["-y", "premiere-pro-mcp@1.3.1"]
+    }
+  }
+}

--- a/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: edit-premiere-project
+description: Inspect, edit, verify, save, and export an open Adobe Premiere Pro project through the premiere-pro MCP server. Use for rough cuts, timeline assembly or cleanup, clip and track changes, transitions and effects, dialogue or audio adjustments, captions, project organization, frame inspection, and delivery exports.
+---
+
+# Edit Premiere Project
+
+Operate Premiere through the `premiere-pro` MCP tools. Preserve the user's current
+project state, make only requested changes, and verify the timeline after mutations.
+
+## Establish a live session
+
+1. Call `get_capabilities` to inspect platform coverage and enabled authority.
+2. Call `ping` before any other Premiere operation.
+3. If `ping` fails, stop editing and tell the user to:
+   - Open or restart Premiere Pro.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.3.1 --install-cep` if needed.
+   - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
+4. Call `get_premiere_state` and inspect the active sequence before planning changes.
+5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.
+
+## Plan the edit
+
+- Clarify only missing choices that materially change the edit, such as target sequence,
+  source media, timing, track placement, or export preset.
+- Prefer the server's `premiere-rough-cut`, `premiere-dialogue-cleanup`,
+  `premiere-caption-and-style`, or `premiere-delivery` prompt when it matches the request.
+- Inspect project items and sequence structure before referring to item, clip, track, or
+  sequence identifiers.
+- Re-query identifiers after timeline mutations; do not reuse stale node IDs.
+- Keep existing tracks, effects, timing, and project organization unless the request
+  requires changing them.
+
+## Apply changes safely
+
+For compound insert or removal operations:
+
+1. Construct one exact edit plan.
+2. Call `preview_edit_plan`.
+3. Present the preview when it contains destructive operations or the user's intent is
+   ambiguous.
+4. Call `apply_edit_plan` only with the unchanged plan and exact confirmation token.
+5. Preview again after any plan change.
+
+For other mutations:
+
+- Validate the active project, sequence, tracks, media paths, and relevant identifiers
+  immediately before the call.
+- Ask before deleting media, sequences, tracks, or clips unless the user explicitly
+  requested that exact deletion.
+- Ask before overwriting a project or export destination.
+- Never enable `unsafe-script`, call `execute_extendscript`, `send_raw_script`, or
+  `evaluate_expression` unless the user explicitly requests raw scripting and accepts
+  the expanded authority.
+- Stop after an error that makes later steps depend on unknown state. Re-inspect before
+  retrying.
+
+## Verify and finish
+
+1. Inspect the affected sequence with `get_sequence_structure`,
+   `get_timeline_summary`, or the narrowest relevant inspection tool.
+2. Compare the result against the requested timing, ordering, tracks, effects, audio,
+   and captions.
+3. Save only after successful verification when the user requested persistent changes.
+4. For exports, validate the active sequence, destination, filename, and preset before
+   calling `export_sequence`; then verify and report the returned artifact path.
+5. Report completed, skipped, and failed work separately. Include any remaining
+   verification that requires playback or human visual judgment.
+
+## Editing judgment
+
+- Prefer reversible operations and conservative parameter values.
+- Do not invent creative choices the user did not request when those choices affect
+  pacing, story, color, mix, typography, or delivery requirements.
+- Use frame capture or playback inspection when useful, while clearly separating
+  machine verification from subjective editorial approval.
+- Treat file paths as local to the Premiere host. Never expose unrelated files or
+  secrets from the machine in the response.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "build:claude": "npm run build && node scripts/build-claude-desktop.mjs",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "start:http": "node dist/http-server.js",

--- a/scripts/build-claude-desktop.mjs
+++ b/scripts/build-claude-desktop.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+
+import { cp, copyFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const stage = path.join(root, "build", "claude-desktop");
+const artifacts = path.join(root, "artifacts");
+const manifestSource = path.join(root, "claude-desktop", "manifest.json");
+const packageSource = path.join(root, "package.json");
+const lockSource = path.join(root, "package-lock.json");
+
+const run = (command, args, cwd) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(command, args, { cwd, stdio: "inherit", shell: false });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${command} exited with code ${code}`));
+    });
+  });
+
+await rm(stage, { recursive: true, force: true });
+await mkdir(path.join(stage, "server"), { recursive: true });
+await mkdir(artifacts, { recursive: true });
+
+await copyFile(manifestSource, path.join(stage, "manifest.json"));
+await cp(path.join(root, "dist"), path.join(stage, "server", "dist"), {
+  recursive: true,
+});
+await copyFile(lockSource, path.join(stage, "package-lock.json"));
+
+const packageJson = JSON.parse(await readFile(packageSource, "utf8"));
+await writeFile(
+  path.join(stage, "package.json"),
+  `${JSON.stringify(
+    {
+      name: `${packageJson.name}-claude-desktop`,
+      version: packageJson.version,
+      private: true,
+      type: packageJson.type,
+      dependencies: packageJson.dependencies,
+      overrides: packageJson.overrides,
+    },
+    null,
+    2,
+  )}\n`,
+);
+
+await run("npm", ["ci", "--omit=dev", "--ignore-scripts"], stage);
+
+const mcpbPath = path.join(
+  artifacts,
+  `premiere-pro-mcp-${packageJson.version}.mcpb`,
+);
+const dxtPath = path.join(
+  artifacts,
+  `premiere-pro-mcp-${packageJson.version}.dxt`,
+);
+
+await run(
+  "npx",
+  ["-y", "@anthropic-ai/mcpb@2.1.2", "pack", stage, mcpbPath],
+  root,
+);
+await copyFile(mcpbPath, dxtPath);
+
+console.log(`Built ${path.relative(root, mcpbPath)}`);
+console.log(`Built ${path.relative(root, dxtPath)} (legacy extension)`);

--- a/tests/codex-plugin.test.ts
+++ b/tests/codex-plugin.test.ts
@@ -55,3 +55,74 @@ describe("Codex plugin package", () => {
     expect(skill).not.toContain("TODO");
   });
 });
+
+describe("Claude distributions", () => {
+  it("keeps Claude Code metadata aligned with the npm package", () => {
+    const pkg = readJson("package.json");
+    const marketplace = readJson(".claude-plugin/marketplace.json");
+    const plugin = readJson(
+      "claude-plugins/premiere-pro/.claude-plugin/plugin.json",
+    );
+    const mcp = readJson("claude-plugins/premiere-pro/.mcp.json");
+
+    expect(marketplace.name).toBe("premiere-pro-mcp");
+    expect(marketplace.plugins[0]).toMatchObject({
+      name: "premiere-pro",
+      source: "./claude-plugins/premiere-pro",
+      version: pkg.version,
+    });
+    expect(plugin.version).toBe(pkg.version);
+    expect(plugin.mcpServers).toBe("./.mcp.json");
+    expect(mcp.mcpServers["premiere-pro"].args).toContain(
+      `premiere-pro-mcp@${pkg.version}`,
+    );
+  });
+
+  it("keeps the Claude and Codex editing skills identical", () => {
+    const codexSkill = readFileSync(
+      join(
+        root,
+        "plugins",
+        "premiere-pro",
+        "skills",
+        "edit-premiere-project",
+        "SKILL.md",
+      ),
+      "utf8",
+    );
+    const claudeSkill = readFileSync(
+      join(
+        root,
+        "claude-plugins",
+        "premiere-pro",
+        "skills",
+        "edit-premiere-project",
+        "SKILL.md",
+      ),
+      "utf8",
+    );
+
+    expect(claudeSkill).toBe(codexSkill);
+  });
+
+  it("defines a self-contained Claude Desktop MCP bundle", () => {
+    const pkg = readJson("package.json");
+    const manifest = readJson("claude-desktop/manifest.json");
+
+    expect(manifest).toMatchObject({
+      manifest_version: "0.3",
+      name: "premiere-pro-mcp",
+      version: pkg.version,
+      server: {
+        type: "node",
+        entry_point: "server/dist/index.js",
+      },
+      compatibility: {
+        platforms: ["darwin", "win32"],
+      },
+    });
+    expect(manifest.server.mcp_config.args).toContain(
+      "${__dirname}/server/dist/index.js",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add a validated Claude Code marketplace and `premiere-pro` plugin
- bundle the same safety-oriented editing skill used by the Codex package
- add a self-contained Claude Desktop MCP Bundle manifest
- add a reproducible build that emits the current `.mcpb` format and a legacy `.dxt` copy
- build and upload both formats in CI, and attach them to published GitHub releases
- document Claude Code and Claude Desktop installation
- add regression coverage for version alignment, marketplace wiring, skill parity, and Desktop manifest configuration

## Why

The existing MCP works with Claude through manual configuration, but it did not provide installable Claude Code or Claude Desktop packages. Premiere is a local desktop application, so a self-contained local MCP Bundle preserves the correct Claude Desktop → MCP → CEP bridge → Premiere architecture.

## User impact

Claude Code users can add this repository as a marketplace and install `premiere-pro@premiere-pro-mcp`. Claude Desktop users can install a generated `.mcpb` or transitional `.dxt` file through the Extensions settings.

The Premiere CEP bridge remains a separate installation because it runs inside Adobe Premiere Pro.

## Validation

- `claude plugin validate .` passed for the marketplace
- Claude plugin manifest validation passed
- MCPB manifest schema validation passed
- generated a 3.3 MB self-contained MCPB and legacy DXT
- packaged-server smoke test discovered 271 tools, 4 prompts, and `ping`
- 14 test files passed, 360 tests total
- workflow YAML parsed successfully

## Dependency

This is a stacked PR based on #48, which introduces the shared Codex plugin and editing skill used for parity checks. Merge #48 first, then retarget or merge this PR.