### PR TITLE
Add Premiere connector update flow

### DIFF
--- a/.github/workflows/cep-release.yml
+++ b/.github/workflows/cep-release.yml
@@ -1,0 +1,22 @@
+name: Attach Premiere connector
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  attach-connector:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Build and verify signed connector
+        shell: pwsh
+        run: ./scripts/build-signed-cep.ps1
+      - name: Attach connector to release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "${{ github.event.release.tag_name }}" "artifacts/MCPBridgeCEP.zxp" --clobber

--- a/cep-plugin/index.html
+++ b/cep-plugin/index.html
@@ -62,6 +62,17 @@
       </button>
     </div>
 
+    <section class="update-section" aria-live="polite">
+      <div class="update-copy">
+        <span class="section-label">Connector updates</span>
+        <strong id="updateTitle">Version 1.3.1</strong>
+        <span id="updateDetail">Checking for updates…</span>
+      </div>
+      <button id="btnUpdate" class="button button-update" onclick="handleUpdateClick()" type="button" disabled>
+        Check again
+      </button>
+    </section>
+
     <section class="activity-section">
       <div class="section-heading activity-heading">
         <div>
@@ -75,6 +86,7 @@
   </main>
 
   <script src="CSInterface.js"></script>
+  <script src="updater.cjs"></script>
   <script src="main.js"></script>
 </body>
 </html>

--- a/cep-plugin/main.js
+++ b/cep-plugin/main.js
@@ -55,7 +55,9 @@ function nodeRequire(moduleName) {
 var fs = nodeRequire("fs");
 var path = nodeRequire("path");
 var os = nodeRequire("os");
+var https = nodeRequire("https");
 tempDir = path.join(os.tmpdir(), "premiere-mcp-bridge");
+var latestUpdate = null;
 
 function ensureDir(dir) {
   try {
@@ -250,6 +252,124 @@ function saveTempDir() {
   } catch (e) {}
 }
 
+// ---- Connector Updates ----
+function setUpdateUI(title, detail, buttonText, disabled) {
+  document.getElementById("updateTitle").textContent = title;
+  document.getElementById("updateDetail").textContent = detail;
+  var button = document.getElementById("btnUpdate");
+  button.textContent = buttonText;
+  button.disabled = !!disabled;
+}
+
+function checkForUpdates() {
+  latestUpdate = null;
+  setUpdateUI(
+    "Version " + MCPBridgeUpdater.CURRENT_VERSION,
+    "Checking for updates…",
+    "Checking…",
+    true
+  );
+
+  var request = https.get(
+    MCPBridgeUpdater.LATEST_RELEASE_API,
+    {
+      headers: {
+        Accept: "application/vnd.github+json",
+        "User-Agent": "premiere-pro-mcp-connector/" + MCPBridgeUpdater.CURRENT_VERSION,
+      },
+    },
+    function (response) {
+      var body = "";
+      response.setEncoding("utf8");
+      response.on("data", function (chunk) {
+        if (body.length < 1024 * 1024) body += chunk;
+      });
+      response.on("end", function () {
+        if (response.statusCode !== 200) {
+          showUpdateCheckError("Could not check GitHub (HTTP " + response.statusCode + ").");
+          return;
+        }
+        try {
+          var release = JSON.parse(body);
+          var latestVersion = MCPBridgeUpdater.normalizeVersion(
+            release.tag_name || release.name
+          );
+          if (!latestVersion) throw new Error("Release has no version");
+
+          if (
+            MCPBridgeUpdater.compareVersions(
+              latestVersion,
+              MCPBridgeUpdater.CURRENT_VERSION
+            ) > 0
+          ) {
+            latestUpdate = {
+              version: latestVersion,
+              url: MCPBridgeUpdater.chooseDownloadUrl(release),
+            };
+            setUpdateUI(
+              "Version " + latestVersion + " is available",
+              "Download it, then close Premiere and run the installer.",
+              "Download update",
+              false
+            );
+          } else {
+            setUpdateUI(
+              "Version " + MCPBridgeUpdater.CURRENT_VERSION,
+              "You have the latest connector.",
+              "Check again",
+              false
+            );
+          }
+        } catch (e) {
+          showUpdateCheckError("GitHub returned an unreadable release.");
+        }
+      });
+    }
+  );
+  request.setTimeout(10000, function () {
+    request.destroy(new Error("Update check timed out"));
+  });
+  request.on("error", function () {
+    showUpdateCheckError("Unable to check while offline.");
+  });
+}
+
+function showUpdateCheckError(message) {
+  setUpdateUI(
+    "Version " + MCPBridgeUpdater.CURRENT_VERSION,
+    message,
+    "Check again",
+    false
+  );
+}
+
+function handleUpdateClick() {
+  if (!latestUpdate) {
+    checkForUpdates();
+    return;
+  }
+  if (!MCPBridgeUpdater.isTrustedDownloadUrl(latestUpdate.url)) {
+    showUpdateCheckError("The update link was not trusted.");
+    return;
+  }
+  try {
+    var childProcess = nodeRequire("child_process");
+    var command =
+      os.platform() === "win32"
+        ? ["cmd.exe", ["/d", "/s", "/c", "start", "", latestUpdate.url]]
+        : ["open", [latestUpdate.url]];
+    var child = childProcess.spawn(command[0], command[1], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+    document.getElementById("updateDetail").textContent =
+      "Download opened. Close Premiere before installing.";
+  } catch (e) {
+    showUpdateCheckError("Could not open the download. Try again.");
+  }
+}
+
 // ---- Init ----
 (function init() {
   // Set the default temp dir in the input field
@@ -273,4 +393,5 @@ function saveTempDir() {
   ensureDir(tempDir);
   log("Auto-starting bridge...");
   setTimeout(startBridge, 500);
+  setTimeout(checkForUpdates, 1200);
 })();

--- a/cep-plugin/styles.css
+++ b/cep-plugin/styles.css
@@ -183,6 +183,32 @@ button { -webkit-appearance: none; }
 .button-stop:hover { border-color: var(--red); background: rgba(255, 101, 101, .08); }
 .button:disabled { border-color: var(--border); background: var(--surface); color: #5f5e65; cursor: default; }
 
+.update-section {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 14px;
+  padding: 11px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--surface);
+}
+.update-copy { min-width: 0; flex: 1; }
+.update-copy strong, .update-copy > span:last-child { display: block; }
+.update-copy strong { font-size: 11px; font-weight: 600; }
+.update-copy > span:last-child { margin-top: 3px; color: var(--text-muted); font-size: 9px; line-height: 1.4; }
+.button-update {
+  width: auto;
+  min-width: 92px;
+  height: 30px;
+  padding: 0 10px;
+  border-color: var(--border-strong);
+  background: var(--surface-raised);
+  color: var(--violet-hover);
+  white-space: nowrap;
+}
+.button-update:hover { border-color: var(--violet); background: var(--violet-soft); }
+
 .activity-section { display: flex; flex: 1; min-height: 120px; flex-direction: column; }
 .activity-heading { align-items: center; margin: 2px 0 8px; }
 .activity-state { display: flex; align-items: center; gap: 6px; color: var(--text-muted); font-size: 9px; }

--- a/cep-plugin/updater.cjs
+++ b/cep-plugin/updater.cjs
@@ -1,0 +1,74 @@
+/* MCP Bridge update helpers. Kept dependency-free for the older Chromium
+ * runtime embedded in CEP. */
+(function (root, factory) {
+  var api = factory();
+  if (typeof module === "object" && module.exports) module.exports = api;
+  root.MCPBridgeUpdater = api;
+})(this, function () {
+  "use strict";
+
+  var CURRENT_VERSION = "1.3.1";
+  var LATEST_RELEASE_API =
+    "https://api.github.com/repos/leancoderkavy/premiere-pro-mcp/releases/latest";
+  var RELEASES_URL =
+    "https://github.com/leancoderkavy/premiere-pro-mcp/releases/latest";
+
+  function normalizeVersion(value) {
+    return String(value || "")
+      .trim()
+      .replace(/^v/i, "")
+      .split("-")[0];
+  }
+
+  function compareVersions(left, right) {
+    var a = normalizeVersion(left).split(".");
+    var b = normalizeVersion(right).split(".");
+    var length = Math.max(a.length, b.length);
+    for (var i = 0; i < length; i++) {
+      var aPart = parseInt(a[i] || "0", 10);
+      var bPart = parseInt(b[i] || "0", 10);
+      if (aPart > bPart) return 1;
+      if (aPart < bPart) return -1;
+    }
+    return 0;
+  }
+
+  function chooseDownloadUrl(release) {
+    var assets = release && release.assets ? release.assets : [];
+    var preferredNames = [
+      /^MCPBridgeCEP(?:-[\w.-]+)?\.zxp$/i,
+      /premiere.*(?:connector|bridge).*\.zxp$/i,
+      /\.zxp$/i,
+      /premiere.*(?:connector|bridge).*\.(?:zip|dmg|exe)$/i,
+    ];
+    for (var p = 0; p < preferredNames.length; p++) {
+      for (var i = 0; i < assets.length; i++) {
+        if (
+          preferredNames[p].test(assets[i].name || "") &&
+          isTrustedDownloadUrl(assets[i].browser_download_url)
+        ) {
+          return assets[i].browser_download_url;
+        }
+      }
+    }
+    return isTrustedDownloadUrl(release && release.html_url)
+      ? release.html_url
+      : RELEASES_URL;
+  }
+
+  function isTrustedDownloadUrl(value) {
+    return /^https:\/\/(?:github\.com|api\.github\.com|objects\.githubusercontent\.com)\//i.test(
+      String(value || "")
+    );
+  }
+
+  return {
+    CURRENT_VERSION: CURRENT_VERSION,
+    LATEST_RELEASE_API: LATEST_RELEASE_API,
+    RELEASES_URL: RELEASES_URL,
+    normalizeVersion: normalizeVersion,
+    compareVersions: compareVersions,
+    chooseDownloadUrl: chooseDownloadUrl,
+    isTrustedDownloadUrl: isTrustedDownloadUrl,
+  };
+});

--- a/tests/cep-install.test.ts
+++ b/tests/cep-install.test.ts
@@ -8,9 +8,11 @@ describe("CEP installation metadata", () => {
   it("keeps the CEP bundle and extension versions aligned with package.json", () => {
     const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
     const manifest = readFileSync(join(root, "cep-plugin", "CSXS", "manifest.xml"), "utf8");
+    const updater = readFileSync(join(root, "cep-plugin", "updater.cjs"), "utf8");
 
     expect(manifest).toContain(`ExtensionBundleVersion="${pkg.version}"`);
     expect(manifest.match(new RegExp(`Version="${pkg.version.replaceAll(".", "\\.")}"`, "g"))).toHaveLength(3);
+    expect(updater).toContain(`CURRENT_VERSION = "${pkg.version}"`);
   });
 
   it("documents the Windows unsigned-extension value as REG_SZ", () => {
@@ -34,6 +36,17 @@ describe("CEP installation metadata", () => {
     expect(signer).toContain("-verify");
     expect(workflow).toContain("build-signed-cep");
     expect(workflow).toContain("signed-cep");
+  });
+
+  it("publishes connector updates and exposes the updater in the panel", () => {
+    const workflow = readFileSync(join(root, ".github", "workflows", "cep-release.yml"), "utf8");
+    const panel = readFileSync(join(root, "cep-plugin", "index.html"), "utf8");
+    const panelLogic = readFileSync(join(root, "cep-plugin", "main.js"), "utf8");
+
+    expect(workflow).toContain("release:");
+    expect(workflow).toContain("artifacts/MCPBridgeCEP.zxp");
+    expect(panel).toContain('src="updater.cjs"');
+    expect(panelLogic).toContain("Download update");
   });
 
   it("copies the macOS plugin for npm installs and supports diagnostics", () => {

--- a/tests/cep-updater.test.ts
+++ b/tests/cep-updater.test.ts
@@ -1,0 +1,38 @@
+import { createRequire } from "node:module";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const require = createRequire(import.meta.url);
+const updater = require(join(process.cwd(), "cep-plugin", "updater.cjs"));
+
+describe("CEP connector updater", () => {
+  it("compares release versions numerically", () => {
+    expect(updater.compareVersions("v1.10.0", "1.9.9")).toBe(1);
+    expect(updater.compareVersions("1.3.1", "1.3.1")).toBe(0);
+    expect(updater.compareVersions("1.3.0", "1.3.1")).toBe(-1);
+  });
+
+  it("prefers the signed connector package", () => {
+    const release = {
+      html_url: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.4.0",
+      assets: [
+        {
+          name: "source.zip",
+          browser_download_url: "https://github.com/example/source.zip",
+        },
+        {
+          name: "MCPBridgeCEP.zxp",
+          browser_download_url:
+            "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.4.0/MCPBridgeCEP.zxp",
+        },
+      ],
+    };
+
+    expect(updater.chooseDownloadUrl(release)).toContain("MCPBridgeCEP.zxp");
+  });
+
+  it("rejects untrusted download hosts", () => {
+    expect(updater.isTrustedDownloadUrl("https://github.com/example/file.zxp")).toBe(true);
+    expect(updater.isTrustedDownloadUrl("https://evil.example/file.zxp")).toBe(false);
+  });
+});


### PR DESCRIPTION
## What changed

- added an automatic GitHub Releases update check to the Premiere Pro MCP Bridge panel
- added a one-click download action that prefers the signed `MCPBridgeCEP.zxp` release asset
- added trusted-host validation, offline handling, and numerical version comparison
- added a release workflow that builds, verifies, and attaches the signed connector package
- added updater and distribution tests

## Why

Installed connector users previously had no in-product way to discover or retrieve newer versions. This gives them a visible, safe update path without disrupting the running bridge.

## Validation

- `npm run build`
- `npm test` — 359 tests passed
- `git diff --check`