### PR TITLE
Add search and analytics configuration

### DIFF
--- a/landing/app/docs/page.tsx
+++ b/landing/app/docs/page.tsx
@@ -22,9 +22,50 @@ const categories = [
   ["Inspection and workflows", "Use 269 tools, three resources, four prompts, edit-plan previews, capability profiles, and audit events."],
 ]
 
+const structuredData = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "TechArticle",
+      "@id": "https://premiere-pro-mcp.com/docs/#article",
+      headline: "Premiere Pro MCP setup, tools, compatibility, and security",
+      description:
+        "Installation and technical reference for connecting AI assistants to Adobe Premiere Pro with Premiere Pro MCP.",
+      url: "https://premiere-pro-mcp.com/docs/",
+      dateModified: "2026-07-26",
+      inLanguage: "en-US",
+      about: { "@id": "https://premiere-pro-mcp.com/#software" },
+      isPartOf: { "@id": "https://premiere-pro-mcp.com/#website" },
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": "https://premiere-pro-mcp.com/docs/#breadcrumb",
+      itemListElement: [
+        {
+          "@type": "ListItem",
+          position: 1,
+          name: "Premiere Pro MCP",
+          item: "https://premiere-pro-mcp.com/",
+        },
+        {
+          "@type": "ListItem",
+          position: 2,
+          name: "Documentation",
+          item: "https://premiere-pro-mcp.com/docs/",
+        },
+      ],
+    },
+  ],
+}
+
 export default function DocsPage() {
   return (
-    <main className="min-h-screen bg-black px-5 py-16 text-zinc-100">
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+      <main className="min-h-screen bg-black px-5 py-16 text-zinc-100">
       <article className="mx-auto max-w-4xl">
         <nav aria-label="Breadcrumb" className="text-sm text-zinc-500">
           <Link href="/" className="hover:text-purple-300">Premiere Pro MCP</Link> <span aria-hidden="true">/</span> Documentation
@@ -41,7 +82,7 @@ export default function DocsPage() {
         <section className="py-12" aria-labelledby="install-heading">
           <h2 id="install-heading" className="text-3xl font-semibold">How to install Premiere Pro MCP</h2>
           <ol className="mt-6 list-decimal space-y-3 pl-6 leading-7 text-zinc-300">
-            <li>Install Node.js 18 or newer on Windows or macOS.</li>
+            <li>Install Node.js 20.19 or newer on Windows or macOS.</li>
             <li>Run <code className="rounded bg-zinc-900 px-2 py-1 text-purple-200">npm install -g premiere-pro-mcp</code>.</li>
             <li>Run <code className="rounded bg-zinc-900 px-2 py-1 text-purple-200">premiere-pro-mcp --install-cep</code>.</li>
             <li>Configure Claude Desktop, Cursor, Windsurf, or another MCP client to launch <code className="rounded bg-zinc-900 px-2 py-1 text-purple-200">premiere-pro-mcp</code>.</li>
@@ -85,6 +126,7 @@ export default function DocsPage() {
           </ul>
         </section>
       </article>
-    </main>
+      </main>
+    </>
   )
 }

--- a/landing/app/layout.tsx
+++ b/landing/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import Script from "next/script";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -16,6 +17,8 @@ const siteUrl = "https://premiere-pro-mcp.com";
 const title = "Premiere Pro MCP Server – AI Video Editing Tools";
 const description =
   "Connect AI assistants to Adobe Premiere Pro with 269 local-first MCP tools for timeline editing, effects, color, media management, automation, and export.";
+const googleAnalyticsId =
+  process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID ?? "G-XSH74T16E4";
 
 export const metadata: Metadata = {
   title: {
@@ -28,6 +31,9 @@ export const metadata: Metadata = {
   category: "developer tools",
   creator: "Premiere Pro MCP contributors",
   publisher: "Premiere Pro MCP",
+  verification: {
+    google: "DYKtInlwQzKguGVKyDbZY55-7gKySyg3N9yl9fERiho",
+  },
   keywords: [
     "Premiere Pro MCP",
     "Adobe Premiere Pro AI",
@@ -93,6 +99,25 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
+        {googleAnalyticsId ? (
+          <>
+            <Script
+              src={`https://www.googletagmanager.com/gtag/js?id=${googleAnalyticsId}`}
+              strategy="afterInteractive"
+            />
+            <Script id="google-analytics" strategy="afterInteractive">
+              {`
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+                gtag('config', '${googleAnalyticsId}', {
+                  anonymize_ip: true,
+                  send_page_view: true
+                });
+              `}
+            </Script>
+          </>
+        ) : null}
       </body>
     </html>
   );

--- a/landing/app/page.tsx
+++ b/landing/app/page.tsx
@@ -9,12 +9,29 @@ const structuredData = {
   "@context": "https://schema.org",
   "@graph": [
     {
+      "@type": "Organization",
+      "@id": "https://premiere-pro-mcp.com/#organization",
+      name: "Premiere Pro MCP contributors",
+      url: "https://premiere-pro-mcp.com/",
+      logo: {
+        "@type": "ImageObject",
+        url: "https://premiere-pro-mcp.com/og-image.png",
+        width: 1200,
+        height: 630,
+      },
+      sameAs: [
+        "https://github.com/leancoderkavy/premiere-pro-mcp",
+        "https://www.npmjs.com/package/premiere-pro-mcp",
+      ],
+    },
+    {
       "@type": "WebSite",
       "@id": "https://premiere-pro-mcp.com/#website",
       name: "Premiere Pro MCP",
       url: "https://premiere-pro-mcp.com/",
       description: "Open-source AI control and automation for Adobe Premiere Pro through the Model Context Protocol.",
       inLanguage: "en-US",
+      publisher: { "@id": "https://premiere-pro-mcp.com/#organization" },
     },
     {
       "@type": "SoftwareApplication",
@@ -22,7 +39,7 @@ const structuredData = {
       name: "Premiere Pro MCP",
       applicationCategory: "DeveloperApplication",
       operatingSystem: "macOS, Windows",
-      softwareVersion: "1.2.1",
+      softwareVersion: "1.3.1",
       description:
         "Open-source Model Context Protocol server with 269 tools for AI-assisted editing and automation in Adobe Premiere Pro.",
       url: "https://premiere-pro-mcp.com/",
@@ -33,7 +50,11 @@ const structuredData = {
         "https://www.npmjs.com/package/premiere-pro-mcp",
       ],
       releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases",
-      softwareRequirements: "Node.js 18 or newer and Adobe Premiere Pro 2020–2026",
+      softwareRequirements: "Node.js 20.19 or newer and Adobe Premiere Pro 2020–2026",
+      author: { "@id": "https://premiere-pro-mcp.com/#organization" },
+      publisher: { "@id": "https://premiere-pro-mcp.com/#organization" },
+      image: "https://premiere-pro-mcp.com/og-image.png",
+      dateModified: "2026-07-26",
       featureList: [
         "Timeline editing",
         "Effects and Lumetri color control",

--- a/landing/app/robots.ts
+++ b/landing/app/robots.ts
@@ -11,7 +11,13 @@ export default function robots(): MetadataRoute.Robots {
         disallow: ["/mcp", "/health"],
       },
       {
-        userAgent: "OAI-SearchBot",
+        userAgent: [
+          "OAI-SearchBot",
+          "ChatGPT-User",
+          "ClaudeBot",
+          "Claude-SearchBot",
+          "PerplexityBot",
+        ],
         allow: "/",
         disallow: ["/mcp", "/health"],
       },

--- a/landing/app/sitemap.ts
+++ b/landing/app/sitemap.ts
@@ -2,17 +2,19 @@ import type { MetadataRoute } from "next"
 
 export const dynamic = "force-static"
 
+const lastModified = new Date("2026-07-26")
+
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
       url: "https://premiere-pro-mcp.com/",
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: "weekly",
       priority: 1,
     },
     {
       url: "https://premiere-pro-mcp.com/docs/",
-      lastModified: new Date(),
+      lastModified,
       changeFrequency: "weekly",
       priority: 0.8,
     },

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -7,7 +7,7 @@ Documentation: https://premiere-pro-mcp.com/docs/
 Source: https://github.com/leancoderkavy/premiere-pro-mcp
 npm: https://www.npmjs.com/package/premiere-pro-mcp
 License: MIT
-Current release: 1.2.1
+Current release: 1.3.1
 
 ## What it does
 
@@ -20,7 +20,7 @@ The recommended configuration is local. An MCP client starts the Node.js server 
 ## Compatibility
 
 - Operating systems: Windows and macOS, including Apple Silicon and Intel Macs.
-- Node.js: 18 or newer.
+- Node.js: 20.19 or newer.
 - CEP target: Premiere Pro 2020 through 2026.
 - UXP preview target: Premiere Pro 25.6 or newer.
 - AI clients: Claude Desktop, Cursor, Windsurf, and other clients that support local stdio MCP servers.

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -15,7 +15,7 @@ Premiere Pro MCP exposes 269 structured tools for timeline editing, effects, Lum
 
 ## Recommended local installation
 
-1. Install Node.js 18 or newer.
+1. Install Node.js 20.19 or newer.
 2. Run `npm install -g premiere-pro-mcp`.
 3. Run `premiere-pro-mcp --install-cep`.
 4. Add `premiere-pro-mcp` as a local stdio server in an MCP-compatible client.
@@ -24,7 +24,7 @@ The recommended setup runs the MCP server and CEP bridge locally. Project media 
 
 ## Verified facts
 
-- Current project release: 1.2.1.
+- Current project release: 1.3.1.
 - Tool surface: 269 structured MCP tools, 3 resources, and 4 prompts.
 - Supported desktop platforms: Windows and macOS.
 - Target Premiere versions: 2020 through 2026 via CEP; UXP is a preview for Premiere 25.6 and newer.


### PR DESCRIPTION
## What changed

- added GA4 measurement for the Premiere Pro MCP production site
- added the Google Search Console verification token
- expanded SoftwareApplication, Organization, TechArticle, FAQ, and breadcrumb structured data
- made sitemap modification dates stable and added explicit AI-search crawler rules
- refreshed machine-readable release and runtime facts for AI/GEO discovery

## Why

The landing site had strong baseline metadata but no Google measurement, no Search Console ownership verification, and stale version/runtime facts in structured and AI-readable content.

## Validation

- `npm run lint`
- `npm run build`
- inspected the generated static HTML, robots.txt, and sitemap.xml for emitted analytics, verification, canonical, schema, and crawler directives
