### PR TITLE
Release version 1.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "premiere-pro",
       "source": "./claude-plugins/premiere-pro",
       "description": "Inspect, edit, verify, and export local Premiere Pro projects through MCP.",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "category": "creative",
       "tags": ["premiere-pro", "video-editing", "mcp"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-07-26
+
+### Added
+
+- Added in-panel connector update discovery and trusted downloads from GitHub Releases.
+- Added authenticated MCP-to-UXP WebSocket transport, transcript and caption inspection, event-driven
+  state reporting, operation semantics, and supported video-transition workflows.
+- Added recovery diagnostics, export verification, AV inspection, capability reporting, and
+  collaboration/AI feature eligibility discovery.
+- Added installable Codex, Claude Code, and Claude Desktop distributions.
+
+### Changed
+
+- Expanded the MCP surface to 278 tools and aligned documentation, plugin metadata, and distribution
+  manifests with the new release.
+- Added automated signed CEP connector assets and Claude Desktop bundles to GitHub releases.
+
 ## [1.3.1] - 2026-07-25
 
 ### Fixed

--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.3.1" ExtensionBundleName="MCP Bridge">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.4.0" ExtensionBundleName="MCP Bridge">
   <ExtensionList>
-    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.3.1"/>
-    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.3.1"/>
+    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.4.0"/>
+    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.4.0"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/cep-plugin/index.html
+++ b/cep-plugin/index.html
@@ -65,7 +65,7 @@
     <section class="update-section" aria-live="polite">
       <div class="update-copy">
         <span class="section-label">Connector updates</span>
-        <strong id="updateTitle">Version 1.3.1</strong>
+        <strong id="updateTitle">Version 1.4.0</strong>
         <span id="updateDetail">Checking for updates…</span>
       </div>
       <button id="btnUpdate" class="button button-update" onclick="handleUpdateClick()" type="button" disabled>

--- a/cep-plugin/updater.cjs
+++ b/cep-plugin/updater.cjs
@@ -7,7 +7,7 @@
 })(this, function () {
   "use strict";
 
-  var CURRENT_VERSION = "1.3.1";
+  var CURRENT_VERSION = "1.4.0";
   var LATEST_RELEASE_API =
     "https://api.github.com/repos/leancoderkavy/premiere-pro-mcp/releases/latest";
   var RELEASES_URL =

--- a/claude-desktop/manifest.json
+++ b/claude-desktop/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "premiere-pro-mcp",
   "display_name": "Premiere Pro MCP",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Control a local Adobe Premiere Pro project through MCP.",
   "long_description": "Inspect projects, assemble and modify timelines, manage media, effects, audio and captions, and export deliverables through a local bridge to Adobe Premiere Pro.",
   "author": {

--- a/claude-plugins/premiere-pro/.claude-plugin/plugin.json
+++ b/claude-plugins/premiere-pro/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "premiere-pro",
   "displayName": "Premiere Pro MCP",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Inspect, edit, verify, and export local Adobe Premiere Pro projects through MCP.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/claude-plugins/premiere-pro/.mcp.json
+++ b/claude-plugins/premiere-pro/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "premiere-pro": {
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.3.1"]
+      "args": ["-y", "premiere-pro-mcp@1.4.0"]
     }
   }
 }

--- a/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.3.1 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.4.0 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/landing/app/page.tsx
+++ b/landing/app/page.tsx
@@ -39,7 +39,7 @@ const structuredData = {
       name: "Premiere Pro MCP",
       applicationCategory: "DeveloperApplication",
       operatingSystem: "macOS, Windows",
-      softwareVersion: "1.3.1",
+      softwareVersion: "1.4.0",
       description:
         "Open-source Model Context Protocol server with 269 tools for AI-assisted editing and automation in Adobe Premiere Pro.",
       url: "https://premiere-pro-mcp.com/",

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -7,7 +7,7 @@ Documentation: https://premiere-pro-mcp.com/docs/
 Source: https://github.com/leancoderkavy/premiere-pro-mcp
 npm: https://www.npmjs.com/package/premiere-pro-mcp
 License: MIT
-Current release: 1.3.1
+Current release: 1.4.0
 
 ## What it does
 

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -24,7 +24,7 @@ The recommended setup runs the MCP server and CEP bridge locally. Project media 
 
 ## Verified facts
 
-- Current project release: 1.3.1.
+- Current project release: 1.4.0.
 - Tool surface: 269 structured MCP tools, 3 resources, and 4 prompts.
 - Supported desktop platforms: Windows and macOS.
 - Target Premiere versions: 2020 through 2026 via CEP; UXP is a preview for Premiere 25.6 and newer.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "premiere-pro-mcp",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Adobe Premiere Pro MCP server with 278 AI video editing tools for timeline automation, effects, media management, and export.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/premiere-pro/.codex-plugin/plugin.json
+++ b/plugins/premiere-pro/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Plan, execute, verify, and export video edits in Adobe Premiere Pro through the Premiere Pro MCP server.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/plugins/premiere-pro/.mcp.json
+++ b/plugins/premiere-pro/.mcp.json
@@ -4,7 +4,7 @@
       "title": "Premiere Pro MCP",
       "description": "Inspect and edit a local Adobe Premiere Pro project through the Premiere Pro MCP bridge.",
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.3.1"]
+      "args": ["-y", "premiere-pro-mcp@1.4.0"]
     }
   }
 }

--- a/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.3.1 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.4.0 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/uxp-plugin/manifest.json
+++ b/uxp-plugin/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.ppmcp.premiere.uxp",
   "name": "Premiere Pro MCP Bridge",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "main": "index.html",
   "host": { "app": "premierepro", "minVersion": "25.6.0" },
   "entrypoints": [


### PR DESCRIPTION
## Release

- bumps npm, CEP, UXP, Codex, Claude Code, and Claude Desktop metadata to 1.4.0
- updates the connector updater and website release metadata
- documents the combined feature release in the changelog

## Validation

- 431 tests passed
- TypeScript build passed
- npm publish dry run passed
- Next.js production build passed
- package audit found no vulnerabilities