### PR TITLE
Serve demo video with MP4 content type

### DIFF
--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -40,6 +40,7 @@ const MIME: Record<string, string> = {
   ".css":  "text/css; charset=utf-8",
   ".json": "application/json",
   ".png":  "image/png",
+  ".mp4":  "video/mp4",
   ".svg":  "image/svg+xml",
   ".ico":  "image/x-icon",
   ".woff2":"font/woff2",


### PR DESCRIPTION
Ensures the landing-page demo is delivered as `video/mp4` for reliable browser playback.\n\nValidated with `npm run build` and all 431 tests.