### PR TITLE
Add immersive editorial hero motion

### DIFF
--- a/landing/app/globals.css
+++ b/landing/app/globals.css
@@ -143,6 +143,19 @@
   filter: blur(60px);
 }
 
+.hero-depth-scene {
+  mask-image: linear-gradient(to bottom, black 0%, black 58%, transparent 88%);
+  opacity: 0;
+  animation: scene-reveal 1.4s 350ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+.hero-depth-vignette {
+  background:
+    radial-gradient(circle at 50% 24%, transparent 0%, rgb(0 0 0 / 0.2) 43%, rgb(0 0 0 / 0.76) 82%),
+    linear-gradient(to bottom, rgb(0 0 0 / 0.18), transparent 38%, rgb(0 0 0 / 0.45));
+  pointer-events: none;
+}
+
 .accent-text {
   background: linear-gradient(100deg, #a99cff 10%, #ee78ba 90%);
   background-clip: text;
@@ -190,6 +203,17 @@ section[id] {
   50% { box-shadow: 0 0 0 5px rgb(16 185 129 / 0.12); }
 }
 
+@keyframes scene-reveal {
+  from {
+    opacity: 0;
+    transform: scale(1.04);
+  }
+  to {
+    opacity: 0.48;
+    transform: scale(1);
+  }
+}
+
 .hero-enter {
   opacity: 0;
   animation: hero-enter 700ms cubic-bezier(0.22, 1, 0.36, 1) forwards;
@@ -223,6 +247,15 @@ section[id] {
     animation: hero-enter linear both;
     animation-timeline: view();
     animation-range: entry 8% cover 24%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-enter,
+  .terminal-float,
+  .status-pulse {
+    animation: none;
+    opacity: 1;
   }
 }
 

--- a/landing/components/sections/hero-depth-loader.tsx
+++ b/landing/components/sections/hero-depth-loader.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import dynamic from "next/dynamic"
+import { useEffect, useState } from "react"
+
+const HeroDepthScene = dynamic(
+  () => import("@/components/sections/hero-depth-scene").then((module) => module.HeroDepthScene),
+  { ssr: false },
+)
+
+export function HeroDepthLoader() {
+  const [canRender, setCanRender] = useState(false)
+
+  useEffect(() => {
+    const query = window.matchMedia("(min-width: 768px) and (prefers-reduced-motion: no-preference)")
+    let timer = 0
+
+    const sync = () => {
+      window.clearTimeout(timer)
+      if (!query.matches) {
+        setCanRender(false)
+        return
+      }
+
+      timer = window.setTimeout(() => setCanRender(true), 450)
+    }
+
+    sync()
+    query.addEventListener("change", sync)
+    return () => {
+      window.clearTimeout(timer)
+      query.removeEventListener("change", sync)
+    }
+  }, [])
+
+  return canRender ? <HeroDepthScene /> : null
+}

--- a/landing/components/sections/hero-depth-scene.tsx
+++ b/landing/components/sections/hero-depth-scene.tsx
@@ -1,0 +1,95 @@
+"use client"
+
+import { useRef } from "react"
+import { Canvas, useFrame } from "@react-three/fiber"
+import type { Group, Mesh } from "three"
+
+const clips = [
+  { position: [-3.6, 1.15, -1.1], scale: [2.1, 0.34, 0.1], color: "#8b7cff" },
+  { position: [-1.25, 1.15, -0.75], scale: [1.25, 0.34, 0.1], color: "#a99cff" },
+  { position: [0.25, 1.15, -0.4], scale: [1.45, 0.34, 0.1], color: "#ef76b9" },
+  { position: [2.05, 1.15, -0.05], scale: [1.75, 0.34, 0.1], color: "#8b7cff" },
+  { position: [-3.05, 0.25, -0.65], scale: [2.75, 0.34, 0.1], color: "#6d5dd3" },
+  { position: [0.05, 0.25, -0.3], scale: [1.8, 0.34, 0.1], color: "#ef76b9" },
+  { position: [2.25, 0.25, 0.05], scale: [2.1, 0.34, 0.1], color: "#806fdc" },
+  { position: [-3.7, -0.65, -0.2], scale: [1.9, 0.28, 0.1], color: "#2da886" },
+  { position: [-1.5, -0.65, 0.15], scale: [1.65, 0.28, 0.1], color: "#249879" },
+  { position: [0.45, -0.65, 0.5], scale: [1.95, 0.28, 0.1], color: "#2da886" },
+  { position: [2.7, -0.65, 0.85], scale: [1.85, 0.28, 0.1], color: "#249879" },
+] as const
+
+function SequenceScene() {
+  const group = useRef<Group>(null)
+  const playhead = useRef<Mesh>(null)
+
+  useFrame(({ clock, pointer }, delta) => {
+    if (group.current) {
+      const targetX = -0.12 + pointer.y * 0.05
+      const targetY = -0.18 + pointer.x * 0.09
+      group.current.rotation.x += (targetX - group.current.rotation.x) * Math.min(1, delta * 2.2)
+      group.current.rotation.y += (targetY - group.current.rotation.y) * Math.min(1, delta * 2.2)
+      group.current.position.y = Math.sin(clock.elapsedTime * 0.35) * 0.08
+    }
+
+    if (playhead.current) {
+      playhead.current.position.x = -4.8 + ((clock.elapsedTime * 0.62) % 1) * 9.6
+    }
+  })
+
+  return (
+    <>
+      <fog attach="fog" args={["#030304", 7, 14]} />
+      <group ref={group} position={[0.7, -0.45, -1.4]} rotation={[-0.12, -0.18, 0]}>
+        {[-1.35, -0.45, 0.45].map((y) => (
+          <mesh key={y} position={[0, y, -0.35]}>
+            <boxGeometry args={[10.5, 0.015, 0.015]} />
+            <meshBasicMaterial color="#4b455f" transparent opacity={0.35} />
+          </mesh>
+        ))}
+
+        {clips.map((clip, index) => (
+          <mesh key={index} position={clip.position} scale={clip.scale}>
+            <boxGeometry args={[1, 1, 1]} />
+            <meshStandardMaterial
+              color={clip.color}
+              emissive={clip.color}
+              emissiveIntensity={0.28}
+              metalness={0.15}
+              roughness={0.45}
+              transparent
+              opacity={0.82}
+            />
+          </mesh>
+        ))}
+
+        <mesh ref={playhead} position={[-4.8, -0.1, 1.05]}>
+          <boxGeometry args={[0.025, 3.8, 0.025]} />
+          <meshBasicMaterial color="#f7d7ef" transparent opacity={0.85} />
+        </mesh>
+
+        <mesh position={[0, -1.6, -0.55]}>
+          <planeGeometry args={[10.5, 0.8]} />
+          <meshBasicMaterial color="#08070d" transparent opacity={0.7} />
+        </mesh>
+      </group>
+
+      <ambientLight intensity={0.7} />
+      <pointLight position={[-4, 4, 5]} color="#9a86ff" intensity={32} distance={13} />
+      <pointLight position={[5, -2, 4]} color="#ef76b9" intensity={20} distance={12} />
+    </>
+  )
+}
+
+export function HeroDepthScene() {
+  return (
+    <div className="hero-depth-scene absolute inset-0" aria-hidden="true">
+      <Canvas
+        dpr={[1, 1.5]}
+        camera={{ position: [0, 0, 8], fov: 40 }}
+        gl={{ alpha: true, antialias: false, powerPreference: "high-performance" }}
+      >
+        <SequenceScene />
+      </Canvas>
+    </div>
+  )
+}

--- a/landing/components/sections/hero.tsx
+++ b/landing/components/sections/hero.tsx
@@ -1,5 +1,6 @@
 import { Github, Monitor, Package, ShieldCheck, Sparkles } from "lucide-react"
 import { EditingTimeline } from "@/components/sections/editing-timeline"
+import { HeroDepthLoader } from "@/components/sections/hero-depth-loader"
 import { MobileNav } from "@/components/sections/mobile-nav"
 
 const navItems = [
@@ -56,6 +57,8 @@ export function HeroSection() {
       <section id="top" className="relative overflow-hidden px-5 pb-16 pt-28 md:pb-28 md:pt-44">
         <div className="hero-grid absolute inset-0" aria-hidden="true" />
         <div className="hero-glow absolute left-1/2 top-0 h-[36rem] w-[52rem] -translate-x-1/2" aria-hidden="true" />
+        <HeroDepthLoader />
+        <div className="hero-depth-vignette absolute inset-0" aria-hidden="true" />
 
         <div className="relative mx-auto max-w-6xl">
           <div className="mx-auto max-w-4xl text-center">

--- a/landing/package-lock.json
+++ b/landing/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-slot": "^1.2.4",
+        "@react-three/fiber": "^9.6.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.575.0",
@@ -17,13 +18,15 @@
         "radix-ui": "^1.4.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
-        "tailwind-merge": "^3.5.0"
+        "tailwind-merge": "^3.5.0",
+        "three": "^0.180.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/three": "^0.180.0",
         "babel-plugin-react-compiler": "1.0.0",
         "eslint": "^9.39.0",
         "eslint-config-next": "^16.2.12",
@@ -440,6 +443,15 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -484,6 +496,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.52.0",
@@ -3634,6 +3653,54 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@react-three/fiber": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.1.tgz",
+      "integrity": "sha512-zF0rsKcVYpcJwbFEnv2HkHX9cvOEgsfQo/X8lwmR2dn13S4qEQJXir9fxf5js2LQFoXqxOY7MDkOkYx2uZ4gSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^2.0.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.27.0",
+        "suspend-react": "^0.1.3",
+        "use-sync-external-store": "^1.4.0",
+        "zustand": "^5.0.3"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=19 <19.3",
+        "react-dom": ">=19 <19.3",
+        "react-native": ">=0.78",
+        "three": ">=0.156"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -4046,6 +4113,13 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -4088,7 +4162,6 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -4104,6 +4177,22 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/statuses": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
@@ -4111,11 +4200,33 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-ykFtgCqNnY0IPvDro7h+9ZeLY+qjgUWv+qEvUt84grhenO60Hqd4hScHE7VTB9nOQ/3QM8lkbNE+4vKjEpUxKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.22.0"
+      }
+    },
     "node_modules/@types/validate-npm-package-name": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/validate-npm-package-name/-/validate-npm-package-name-4.0.2.tgz",
       "integrity": "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4652,6 +4763,13 @@
         "win32"
       ]
     },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.71",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.71.tgz",
+      "integrity": "sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -5061,6 +5179,26 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
@@ -5167,6 +5305,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/bundle-name": {
@@ -5605,7 +5767,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -6902,6 +7063,13 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/figures": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
@@ -7558,6 +7726,26 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -8254,6 +8442,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
+    },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -8866,6 +9066,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
+      "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -10106,6 +10313,21 @@
         }
       }
     },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/recast": {
       "version": "0.23.11",
       "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
@@ -11109,6 +11331,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
@@ -11152,6 +11383,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==",
+      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
@@ -12106,6 +12343,35 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/landing/package.json
+++ b/landing/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.4",
+    "@react-three/fiber": "^9.6.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.575.0",
@@ -19,13 +20,15 @@
     "radix-ui": "^1.4.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "tailwind-merge": "^3.5.0"
+    "tailwind-merge": "^3.5.0",
+    "three": "^0.180.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/three": "^0.180.0",
     "babel-plugin-react-compiler": "1.0.0",
     "eslint": "^9.39.0",
     "eslint-config-next": "^16.2.12",


### PR DESCRIPTION
## Summary

- add a dimensional Premiere timeline scene behind the landing-page hero
- use React Three Fiber with a compatible Three.js release for the WebGL layer
- defer the 3D runtime behind a desktop-only dynamic import
- preserve the existing Motion-driven UI, mobile composition, and semantic content
- disable the scene for reduced-motion users and add reduced-motion fallbacks for existing hero animation

## Design intent

The scene turns the existing Premiere timeline language into a spatial editorial environment: clips sit across video and audio tracks while a playhead moves through the sequence. It remains atmospheric so the headline, setup action, and product demonstration stay dominant.

## Performance and accessibility

- the 3D engine is isolated in a deferred chunk and mounts after primary content
- mobile viewports and reduced-motion users do not render or request the scene component
- device pixel ratio is capped at 1.5
- the canvas is decorative and hidden from assistive technology
- production dependencies report zero known vulnerabilities

## Validation

- `npm run lint`
- `npm run build`
- `npm audit --omit=dev`
- `git diff --check`
- desktop rendered QA at 1440×1000
- mobile rendered QA at 390×844
- verified desktop canvas mounting, zero mobile canvases, CTA navigation, mobile navigation, no overflow, and clean console output
