### PR TITLE
fix: report package version in serverInfo instead of stale literal

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -42,6 +42,25 @@ import {
 } from "./workflows/tool-metadata.js";
 import { getTelemetry, type Telemetry } from "./telemetry.js";
 import { z } from "zod";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+/**
+ * Read the version from package.json rather than hardcoding it. A literal here
+ * silently drifts from the published package every release, which makes the
+ * version reported over MCP useless for triaging bug reports.
+ */
+export const SERVER_VERSION = ((): string => {
+  try {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const raw = readFileSync(path.resolve(here, "../package.json"), "utf8");
+    const version: unknown = JSON.parse(raw).version;
+    return typeof version === "string" && version ? version : "unknown";
+  } catch {
+    return "unknown";
+  }
+})();
 
 const PREMIERE_INSTRUCTIONS = `You are controlling Adobe Premiere Pro through MCP tools. Follow these best practices:
 
@@ -285,7 +304,7 @@ export function createServer(
 ): McpServer {
   const server = new McpServer({
     name: "premiere-pro-mcp",
-    version: "1.2.0",
+    version: SERVER_VERSION,
   });
 
   const capabilities = resolveCapabilities();

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createServer } from "../src/server.js";
+import { createServer, SERVER_VERSION } from "../src/server.js";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { z } from "zod";
 
 // Mock all tool modules to return simple tool definitions
@@ -103,5 +105,18 @@ describe("jsonSchemaToZodShape (tested via createServer)", () => {
   it("handles tools with no parameters", () => {
     // Many tools (health ping, etc.) have empty parameters.
     expect(() => createServer({})).not.toThrow();
+  });
+});
+
+describe("SERVER_VERSION", () => {
+  it("matches the version in package.json", () => {
+    const pkg = JSON.parse(
+      readFileSync(join(process.cwd(), "package.json"), "utf-8"),
+    );
+    expect(SERVER_VERSION).toBe(pkg.version);
+  });
+
+  it("is a concrete semver, never the 'unknown' fallback", () => {
+    expect(SERVER_VERSION).toMatch(/^\d+\.\d+\.\d+/);
   });
 });


### PR DESCRIPTION
`createServer()` hardcodes `version: "1.2.0"`, but `package.json` is at `1.4.0`. Every MCP client has been seeing a version two releases behind in `serverInfo`, which makes the version reported over the wire useless for triaging bug reports.

The version is now read from `package.json` at module load, with an `"unknown"` fallback if the read fails. It resolves correctly from both `src/` (vitest) and `dist/` (published package), since `rootDir` maps 1:1 onto `outDir`.

There is already a test asserting the **CLI** `--version` matches `package.json`, which is why this went unnoticed — that path reads the manifest dynamically, while the MCP handshake used the literal. Added a matching regression test for `SERVER_VERSION` so the two cannot diverge again.

Verified against the built server:

```
serverInfo -> {"name":"premiere-pro-mcp","version":"1.4.0"}
package.json -> 1.4.0
```

Full suite green.
