### PR TITLE
feat: withhold tools the active capability profile will always refuse

### DIFF
--- a/src/security/capabilities.ts
+++ b/src/security/capabilities.ts
@@ -70,6 +70,29 @@ export function capabilityForTool(toolName: string): Capability {
   return "edit";
 }
 
+/**
+ * Tools that stay advertised under every profile, because they are how an
+ * operator diagnoses a profile that is too narrow: get_capabilities reports the
+ * active authority, and ping proves the bridge is alive. Withholding them makes
+ * a misconfigured server look broken with no supported way to ask why.
+ */
+export const ALWAYS_LISTED_TOOL_NAMES = new Set(["ping", "get_capabilities"]);
+
+/**
+ * Whether a tool should appear in tools/list under the given profile.
+ *
+ * This is an advertising decision, not an enforcement one — guardToolHandler
+ * remains the authority check at call time. Keeping the two separate means a
+ * listing bug can never widen what a profile is actually allowed to do.
+ */
+export function isToolPermitted(
+  toolName: string,
+  config: CapabilityConfig,
+): boolean {
+  if (ALWAYS_LISTED_TOOL_NAMES.has(toolName)) return true;
+  return config.capabilities.has(capabilityForTool(toolName));
+}
+
 export function guardToolHandler<TArgs, TResult>(
   toolName: string,
   handler: (args: TArgs) => Promise<TResult>,

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,7 +33,11 @@ import { getAvSettingsTools } from "./tools/av-settings.js";
 import { getRecoveryTools } from "./tools/recovery.js";
 import { getUxpTools } from "./tools/uxp.js";
 import type { UxpWebSocketBridge } from "./bridge/uxp-websocket-bridge.js";
-import { guardToolHandler, resolveCapabilities } from "./security/index.js";
+import {
+  guardToolHandler,
+  isToolPermitted,
+  resolveCapabilities,
+} from "./security/index.js";
 import { EXTENDSCRIPT_REFERENCE } from "./resources/extendscript-reference.js";
 import { WORKFLOW_PROMPTS, WORKFLOW_RESOURCE } from "./workflows/catalog.js";
 import {
@@ -299,7 +303,17 @@ export function createServer(
   );
 
   // Register each tool with the MCP server
+  let withheld = 0;
   for (const [name, tool] of Object.entries(toolModules)) {
+    // Don't advertise tools the active authority profile will always refuse.
+    // guardToolHandler still rejects them at call time, but listing an
+    // unusable tool spends client context and invites the model to attempt a
+    // call that cannot succeed.
+    if (!isToolPermitted(name, capabilities)) {
+      withheld++;
+      continue;
+    }
+
     const zodShape = jsonSchemaToZodShape(tool.parameters);
     const guardedHandler = guardToolHandler(name, tool.handler, capabilities);
 
@@ -392,6 +406,14 @@ export function createServer(
           };
         }
       },
+    );
+  }
+
+  if (withheld > 0) {
+    debugLog(
+      `Withheld ${withheld} tool(s) from tools/list — not permitted by the ` +
+        `active capability profile (${[...capabilities.capabilities].sort().join(", ")}). ` +
+        `Call get_capabilities to see the enabled authority.`,
     );
   }
 

--- a/tests/mcp-modernization.test.ts
+++ b/tests/mcp-modernization.test.ts
@@ -65,7 +65,11 @@ describe("modern MCP surface", () => {
       const tools = await client.listTools();
       expect(tools.tools.find((tool) => tool.name === "get_project_info")?.annotations?.readOnlyHint).toBe(true);
       expect(tools.tools.map((tool) => tool.name)).toContain("get_capabilities");
-      expect(tools.tools).toHaveLength(278);
+      // The default profile grants inspect/edit/export/filesystem but not
+      // unsafe-script, so the two scripting tools are not advertised.
+      expect(tools.tools.map((tool) => tool.name)).not.toContain("execute_extendscript");
+      expect(tools.tools.map((tool) => tool.name)).not.toContain("evaluate_expression");
+      expect(tools.tools).toHaveLength(276);
 
       const capabilities = await client.callTool({
         name: "get_capabilities",
@@ -73,10 +77,17 @@ describe("modern MCP surface", () => {
       });
       const capabilityData = (capabilities.structuredContent as any).data;
       expect(capabilityData.tools.generatedFrom).toBe("registered-tool-catalog");
-      expect(capabilityData.tools.total).toBe(tools.tools.length);
+      // The catalog intentionally reports every tool that exists — including
+      // ones this profile disables, each flagged with its authority state — so
+      // it is a superset of what tools/list advertises.
+      expect(capabilityData.tools.total).toBeGreaterThanOrEqual(tools.tools.length);
       expect(capabilityData.tools.tools.map((tool: any) => tool.name)).toEqual(
         expect.arrayContaining(tools.tools.map((tool) => tool.name)),
       );
+      expect(
+        capabilityData.tools.tools.find((tool: any) => tool.name === "execute_extendscript")
+          ?.authority,
+      ).toMatchObject({ required: "unsafe-script", enabled: false });
     } finally {
       await client.close();
       await server.close();

--- a/tests/security-capabilities.test.ts
+++ b/tests/security-capabilities.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { capabilityForTool, guardToolHandler, resolveCapabilities } from "../src/security/capabilities.js";
+import { capabilityForTool, guardToolHandler, isToolPermitted, resolveCapabilities } from "../src/security/capabilities.js";
 import { buildPlatformCapabilityReport } from "../src/platform-capabilities.js";
 import {
   buildToolCapabilityReport,
@@ -203,5 +203,50 @@ describe("capability profiles", () => {
       verificationBoundary: "local_and_host_response",
       notes: ["Explicit registration metadata."],
     });
+  });
+});
+
+describe("isToolPermitted", () => {
+  it("withholds unsafe-script tools under the default profile", () => {
+    const config = resolveCapabilities(undefined);
+    expect(isToolPermitted("execute_extendscript", config)).toBe(false);
+    expect(isToolPermitted("evaluate_expression", config)).toBe(false);
+    expect(isToolPermitted("send_raw_script", config)).toBe(false);
+  });
+
+  it("permits unsafe-script tools once the authority is named", () => {
+    const config = resolveCapabilities("inspect,edit,export,filesystem,unsafe-script");
+    expect(isToolPermitted("execute_extendscript", config)).toBe(true);
+    expect(isToolPermitted("evaluate_expression", config)).toBe(true);
+  });
+
+  it("permits ordinary edit tools under the default profile", () => {
+    const config = resolveCapabilities(undefined);
+    expect(isToolPermitted("trim_clip", config)).toBe(true);
+    expect(isToolPermitted("get_project_info", config)).toBe(true);
+    expect(isToolPermitted("export_sequence", config)).toBe(true);
+  });
+
+  it("withholds edit and export tools under an inspect-only profile", () => {
+    const config = resolveCapabilities("inspect");
+    expect(isToolPermitted("trim_clip", config)).toBe(false);
+    expect(isToolPermitted("export_sequence", config)).toBe(false);
+    expect(isToolPermitted("import_media", config)).toBe(false);
+    expect(isToolPermitted("get_project_info", config)).toBe(true);
+  });
+
+  it("always advertises the diagnostic tools, even under a profile that excludes inspect", () => {
+    // Without this, a too-narrow profile leaves no supported way to ask the
+    // server which authority it actually has.
+    const config = resolveCapabilities("export");
+    expect(isToolPermitted("get_capabilities", config)).toBe(true);
+    expect(isToolPermitted("ping", config)).toBe(true);
+    expect(isToolPermitted("get_project_info", config)).toBe(false);
+  });
+
+  it("agrees with capabilityForTool for every capability in the profile", () => {
+    const config = resolveCapabilities("edit");
+    expect(capabilityForTool("trim_clip")).toBe("edit");
+    expect(isToolPermitted("trim_clip", config)).toBe(true);
   });
 });

--- a/tests/tools/uxp-tools.test.ts
+++ b/tests/tools/uxp-tools.test.ts
@@ -74,7 +74,9 @@ describe("UXP MCP tools", () => {
           "export_frame_uxp",
         ]),
       );
-      expect(tools.tools).toHaveLength(281);
+      // 281 collected minus the 2 unsafe-script tools the default profile
+      // withholds from tools/list.
+      expect(tools.tools).toHaveLength(279);
     } finally {
       await client.close();
       await server.close();


### PR DESCRIPTION
`tools/list` advertises all 278 tools regardless of the resolved authority profile. Under the default profile, `execute_extendscript` and `evaluate_expression` are listed but rejected at call time with `CAPABILITY_DENIED` — so every client pays context for two tools that can never succeed, and models are invited to attempt them.

Registration now skips tools whose required capability is absent.

**Enforcement is unchanged.** `guardToolHandler` remains the authority check at call time; this only decides what gets advertised. Keeping the two separate means a listing bug can never widen what a profile is actually allowed to do. The new `isToolPermitted()` lives next to `capabilityForTool()` in `src/security/capabilities.ts`.

### One deliberate carve-out

`ping` and `get_capabilities` stay advertised under **every** profile. They are how an operator diagnoses a profile that is too narrow — `get_capabilities` reports the enabled authority — and withholding them makes a misconfigured server look broken with no supported way to ask why.

This is the one opinionated call in the PR, so it is easy to drop if you would rather the filter be uniform. Observed behaviour:

| profile | advertised | unsafe tools | diagnostics |
|---|---|---|---|
| default | 276 | withheld | `ping`, `get_capabilities` |
| `…,unsafe-script` | 278 | listed | `ping`, `get_capabilities` |
| `export` only | 13 | withheld | `ping`, `get_capabilities` |

### Notes

- `get_capabilities` still reports the **full** catalog with each tool's authority state, so disabled tools remain discoverable there — it is now a superset of `tools/list` rather than equal to it. The assertion in `mcp-modernization.test.ts` was tightened to express that relationship instead of strict equality.
- Count assertions updated: 278 → 276, and 281 → 279 in the UXP test.
- When tools are withheld, a `PREMIERE_MCP_DEBUG` line reports how many and points at `get_capabilities`.

Full suite green (438).
