### PR TITLE
Add a capability-aware UXP foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,13 @@ Enter the same token in the UXP panel. The listener binds only to `127.0.0.1:777
 
 When enabled, MCP discovery includes `get_uxp_capabilities`, `get_uxp_state`, and `export_frame_uxp`. A failed UXP command is never silently retried through CEP because the first operation may have partially succeeded.
 
+Premiere 26.2-26.3 hosts also expose documented UXP workflows for revisioned project
+inspection, verified project saves, preset-based sequence creation, OTIO/FCP XML
+interchange, transcript-language discovery, Object Mask detection, and Adobe Media
+Encoder control. Mutations accept optional idempotency keys and return explicit
+verification outcomes. See [the UXP capability foundation](docs/uxp-capability-foundation.md)
+for the command matrix and live-host validation boundary.
+
 ---
 
 ## Architecture

--- a/docs/uxp-capability-foundation.md
+++ b/docs/uxp-capability-foundation.md
@@ -1,0 +1,46 @@
+# UXP capability foundation
+
+The UXP bridge prefers documented Premiere APIs and never silently retries a failed
+mutation through CEP or QE. `capabilities.get` reports support from the APIs present
+in the connected host rather than from the package version alone.
+
+## Supported command groups
+
+| Command | Premiere | Read only | Undoable | Verification |
+|---|---:|---:|---:|---|
+| `project.snapshot` | 25.6+ | yes | n/a | revisioned host snapshot |
+| `project.save` | 25.6+ | no | no | Premiere return value |
+| `sequence.createPreset` | 26.3+ | no | no | created GUID found in project |
+| `interchange.export` | 26.2+ | no | no | Premiere return value |
+| `transcript.languages` | 26.3+ | yes | n/a | host response |
+| `objectMask.has` | 26.3+ | yes | n/a | host response |
+| `encoder.configure` | 26.3+ | no | no | mixed; outcome identifies limits |
+| `frame.export` | 25.6+ | no | no | exporter result and panel file check |
+| `transition.video.*` | 25.6+ | mixed | mutations only | committed transaction |
+
+Mutation commands accept an optional `operationId`. The bridge retains the 256 most
+recent completed operations and returns the saved result with `replayed: true` when
+the same identifier is received again. This prevents a reconnect or client retry
+from repeating a completed edit during one panel session.
+
+## Outcome vocabulary
+
+- `verified`: a documented host result or postcondition confirmed the requested state.
+- `committed_unverified`: Premiere accepted the operation but exposes no complete
+  read-back API for every affected setting.
+- `partially_applied`: reserved for a future batch where only some actions committed.
+- `not_applied`: represented as a structured command error, never as success.
+
+Capability support and an operation outcome are separate. A command can be supported
+by the connected build and still fail because no project or sequence is active.
+
+## Compatibility policy
+
+CEP remains available for Premiere 2020-2025 compatibility. QE-backed tools are
+experimental because QE is undocumented. New UXP mutations must use documented
+actions inside `Project.lockedAccess()` and `Project.executeTransaction()` whenever
+the corresponding Premiere API offers an Action.
+
+Live host validation is still required before broad release claims. The automated
+tests use a contract host and prove routing, validation, idempotency, and envelopes;
+they do not prove behavior in a particular Premiere build.

--- a/src/tools/uxp.ts
+++ b/src/tools/uxp.ts
@@ -14,6 +14,10 @@ function invoke(
 }
 
 export function getUxpTools(bridge: UxpWebSocketBridge) {
+  const operationId = {
+    type: "string" as const,
+    description: "Optional idempotency key (1-128 letters, numbers, dot, underscore, colon, or dash).",
+  };
   return {
     get_uxp_capabilities: {
       description: "Report the authenticated local UXP bridge connection and the capabilities advertised by the connected Premiere host.",
@@ -24,6 +28,90 @@ export function getUxpTools(bridge: UxpWebSocketBridge) {
       description: "Read the active project, sequence, and playhead state through the connected Premiere UXP bridge.",
       parameters: {},
       handler: async () => invoke(bridge, "state.get"),
+    },
+    inspect_project_uxp: {
+      description: "Read a compact, revisioned project and sequence snapshot through documented Premiere UXP APIs.",
+      parameters: {},
+      handler: async () => invoke(bridge, "project.snapshot"),
+    },
+    save_project_uxp: {
+      description: "Save the active project through UXP and require Premiere to confirm success.",
+      parameters: {
+        type: "object" as const,
+        properties: { operation_id: operationId },
+      },
+      handler: async (args: { operation_id?: string }) => invoke(bridge, "project.save", {
+        ...(args.operation_id ? { operationId: args.operation_id } : {}),
+      }),
+    },
+    create_sequence_with_preset_uxp: {
+      description: "Create and verify a sequence from a preset path using the documented Premiere 26.3+ UXP API.",
+      parameters: {
+        type: "object" as const,
+        properties: {
+          name: { type: "string", description: "New sequence name." },
+          preset_path: { type: "string", description: "Local Premiere sequence preset path." },
+          operation_id: operationId,
+        },
+        required: ["name", "preset_path"],
+      },
+      handler: async (args: { name: string; preset_path: string; operation_id?: string }) => invoke(bridge, "sequence.createPreset", {
+        name: args.name, presetPath: args.preset_path,
+        ...(args.operation_id ? { operationId: args.operation_id } : {}),
+      }),
+    },
+    export_interchange_uxp: {
+      description: "Export the active sequence as OpenTimelineIO or Final Cut Pro XML with explicit verification.",
+      parameters: {
+        type: "object" as const,
+        properties: {
+          format: { type: "string", enum: ["otio", "fcpxml"], description: "Interchange format." },
+          output_file_path: { type: "string", description: "Absolute output file path." },
+          suppress_ui: { type: "boolean", description: "Suppress Premiere export UI; defaults to true." },
+          operation_id: operationId,
+        },
+        required: ["format", "output_file_path"],
+      },
+      handler: async (args: { format: "otio" | "fcpxml"; output_file_path: string; suppress_ui?: boolean; operation_id?: string }) =>
+        invoke(bridge, "interchange.export", {
+          format: args.format, outputFilePath: args.output_file_path,
+          ...(args.suppress_ui === undefined ? {} : { suppressUI: args.suppress_ui }),
+          ...(args.operation_id ? { operationId: args.operation_id } : {}),
+        }),
+    },
+    get_transcript_languages_uxp: {
+      description: "List transcription languages supported by the connected Premiere 26.3+ host.",
+      parameters: {},
+      handler: async () => invoke(bridge, "transcript.languages"),
+    },
+    detect_object_masks_uxp: {
+      description: "Detect whether the active project or sequence contains an Object Mask using Premiere 26.3+.",
+      parameters: {
+        type: "object" as const,
+        properties: { scope: { type: "string", enum: ["sequence", "project"], description: "Inspection scope; defaults to sequence." } },
+      },
+      handler: async (args: { scope?: "sequence" | "project" }) => invoke(bridge, "objectMask.has", args.scope ? { scope: args.scope } : {}),
+    },
+    configure_encoder_uxp: {
+      description: "Launch or configure Adobe Media Encoder and optionally start its queued batch using Premiere 26.3+.",
+      parameters: {
+        type: "object" as const,
+        properties: {
+          launch: { type: "boolean", description: "Launch AME if needed." },
+          embedded_xmp: { type: "boolean", description: "Enable or disable embedded XMP." },
+          sidecar_xmp: { type: "boolean", description: "Enable or disable sidecar XMP." },
+          start_batch: { type: "boolean", description: "Start queued AME encodes." },
+          operation_id: operationId,
+        },
+      },
+      handler: async (args: { launch?: boolean; embedded_xmp?: boolean; sidecar_xmp?: boolean; start_batch?: boolean; operation_id?: string }) =>
+        invoke(bridge, "encoder.configure", {
+          ...(args.launch === undefined ? {} : { launch: args.launch }),
+          ...(args.embedded_xmp === undefined ? {} : { embeddedXmp: args.embedded_xmp }),
+          ...(args.sidecar_xmp === undefined ? {} : { sidecarXmp: args.sidecar_xmp }),
+          ...(args.start_batch === undefined ? {} : { startBatch: args.start_batch }),
+          ...(args.operation_id ? { operationId: args.operation_id } : {}),
+        }),
     },
     export_frame_uxp: {
       description: "Export a sequence frame through Premiere's supported UXP Exporter and verify the output file in the host panel.",

--- a/tests/tools/uxp-tools.test.ts
+++ b/tests/tools/uxp-tools.test.ts
@@ -44,6 +44,28 @@ describe("UXP MCP tools", () => {
     expect(bridge.request).not.toHaveBeenCalled();
   });
 
+  it("maps verified project and interchange workflows to versioned UXP commands", async () => {
+    const request = vi.fn().mockResolvedValue({ outcome: "verified" });
+    const bridge = { request, getState: vi.fn() } as unknown as UxpWebSocketBridge;
+    const tools = getUxpTools(bridge);
+    await tools.create_sequence_with_preset_uxp.handler({
+      name: "Delivery",
+      preset_path: "/presets/hd.sqpreset",
+      operation_id: "sequence-1",
+    });
+    await tools.export_interchange_uxp.handler({
+      format: "otio",
+      output_file_path: "/exports/edit.otio",
+      operation_id: "export-1",
+    });
+    expect(request).toHaveBeenNthCalledWith(1, "sequence.createPreset", {
+      name: "Delivery", presetPath: "/presets/hd.sqpreset", operationId: "sequence-1",
+    });
+    expect(request).toHaveBeenNthCalledWith(2, "interchange.export", {
+      format: "otio", outputFilePath: "/exports/edit.otio", operationId: "export-1",
+    });
+  });
+
   it("returns transport errors through the normal tool envelope", async () => {
     const bridge = {
       request: vi.fn().mockRejectedValue(new Error("UXP bridge is not connected")),
@@ -71,12 +93,19 @@ describe("UXP MCP tools", () => {
         expect.arrayContaining([
           "get_uxp_capabilities",
           "get_uxp_state",
+          "inspect_project_uxp",
+          "save_project_uxp",
+          "create_sequence_with_preset_uxp",
+          "export_interchange_uxp",
+          "get_transcript_languages_uxp",
+          "detect_object_masks_uxp",
+          "configure_encoder_uxp",
           "export_frame_uxp",
         ]),
       );
       // 282 collected minus the 2 unsafe-script tools the default profile
       // withholds from tools/list.
-      expect(tools.tools).toHaveLength(280);
+      expect(tools.tools).toHaveLength(287);
     } finally {
       await client.close();
       await server.close();

--- a/tests/uxp/commands.test.ts
+++ b/tests/uxp/commands.test.ts
@@ -11,12 +11,20 @@ function host(options: { transitions?: boolean; commit?: boolean } = {}) {
   const clip = { createAddVideoTransitionAction: add, createRemoveVideoTransitionAction: remove };
   const track = { getTrackItems: vi.fn(async () => [clip]) };
   const sequence = {
+    guid: "sequence-1",
+    name: "Timeline",
     getVideoTrackCount: vi.fn(async () => 1),
     getVideoTrack: vi.fn(async () => track),
     getPlayerPosition: vi.fn(async () => ({ seconds: 3 }))
   };
   const project = {
+    guid: "project-1",
+    name: "Example",
+    path: "/projects/example.prproj",
     getActiveSequence: vi.fn(async () => sequence),
+    getSequences: vi.fn(async () => [sequence]),
+    save: vi.fn(async () => true),
+    createSequenceWithPresetPath: vi.fn(async (name: string) => ({ guid: "sequence-2", name })),
     lockedAccess: vi.fn((callback: () => void) => callback()),
     executeTransaction: vi.fn((callback: (compound: unknown) => void) => {
       callback({ addAction });
@@ -40,6 +48,18 @@ function host(options: { transitions?: boolean; commit?: boolean } = {}) {
     Project: { getActiveProject: vi.fn(async () => project) },
     TickTime: { createWithSeconds: vi.fn((seconds: number) => ({ seconds })) },
     Constants: { TrackItemType: { CLIP: 1 }, TransitionPosition: { START: 0, END: 1 } },
+    ProjectConverter: {
+      exportAsOpenTimelineIO: vi.fn(async () => true),
+      exportAsFinalCutProXML: vi.fn(async () => true),
+    },
+    Transcript: { querySupportedLanguages: vi.fn(async () => [{ languageCode: "en-US" }]) },
+    ObjectMaskUtils: { hasObjectMask: vi.fn(() => true) },
+    EncoderManager: {
+      launchEncoder: vi.fn(async () => true),
+      setEmbeddedXMPEnabled: vi.fn(async () => true),
+      setSidecarXMPEnabled: vi.fn(async () => true),
+      startBatchEncode: vi.fn(async () => true),
+    },
     ...transitionApis
   };
   return { registry: Commands.createCommandRegistry({ ppro, fs: {}, Protocol }), ppro, project, sequence, track, clip, add, remove, addAction, optionValues };
@@ -56,6 +76,41 @@ describe("UXP command registry", () => {
   it("lists installed video transition match names", async () => {
     await expect(host().registry.dispatch("transition.video.list", {})).resolves.toEqual({
       matchNames: ["CrossDissolve", "DipToBlack"], count: 2
+    });
+  });
+
+  it("returns a stable compact project snapshot", async () => {
+    await expect(host().registry.dispatch("project.snapshot", {})).resolves.toMatchObject({
+      revision: expect.stringMatching(/^uxp-/),
+      project: { guid: "project-1", name: "Example" },
+      activeSequenceGuid: "sequence-1",
+      sequences: [{ guid: "sequence-1", name: "Timeline" }],
+    });
+  });
+
+  it("deduplicates completed mutations by operation id", async () => {
+    const value = host();
+    const args = { operationId: "save-123" };
+    await expect(value.registry.dispatch("project.save", args)).resolves.toMatchObject({
+      saved: true, outcome: "verified", operationId: "save-123",
+    });
+    await expect(value.registry.dispatch("project.save", args)).resolves.toMatchObject({
+      saved: true, replayed: true,
+    });
+    expect(value.project.save).toHaveBeenCalledOnce();
+  });
+
+  it("exports supported interchange formats and configures AME", async () => {
+    const value = host();
+    await expect(value.registry.dispatch("interchange.export", {
+      format: "otio", outputFilePath: "/tmp/edit.otio",
+    })).resolves.toMatchObject({ exported: true, format: "otio", outcome: "verified" });
+    await expect(value.registry.dispatch("encoder.configure", {
+      launch: true, embeddedXmp: true, startBatch: true,
+    })).resolves.toMatchObject({
+      configured: true,
+      outcome: "committed_unverified",
+      performed: ["launch", "embeddedXmp", "startBatch"],
     });
   });
 

--- a/uxp-plugin/commands.cjs
+++ b/uxp-plugin/commands.cjs
@@ -7,10 +7,18 @@
 
   function createCommandRegistry(deps) {
     const ppro = deps.ppro, Protocol = deps.Protocol;
+    const completedOperations = new Map();
     const definitions = {
       "capabilities.get": { readOnly: true, handler: capabilities },
       "state.get": { readOnly: true, handler: stateSnapshot },
-      "frame.export": { probe: canExportFrame, handler: exportFrame },
+      "project.snapshot": { readOnly: true, minHostVersion: "25.6.0", probe: canInspectProject, handler: projectSnapshot },
+      "project.save": { idempotent: true, minHostVersion: "25.6.0", probe: canSaveProject, handler: saveProject },
+      "sequence.createPreset": { destructive: true, undoable: false, minHostVersion: "26.3.0", probe: canCreatePresetSequence, handler: createPresetSequence },
+      "interchange.export": { minHostVersion: "26.2.0", probe: canExportInterchange, handler: exportInterchange },
+      "transcript.languages": { readOnly: true, minHostVersion: "26.3.0", probe: canQueryTranscriptLanguages, handler: transcriptLanguages },
+      "objectMask.has": { readOnly: true, minHostVersion: "26.3.0", probe: canInspectObjectMasks, handler: hasObjectMask },
+      "encoder.configure": { minHostVersion: "26.3.0", probe: canConfigureEncoder, handler: configureEncoder },
+      "frame.export": { minHostVersion: "25.6.0", probe: canExportFrame, handler: exportFrame },
       "transition.video.list": { readOnly: true, minHostVersion: "25.6.0", probe: canListTransitions, handler: listTransitions },
       "transition.video.add": { destructive: true, undoable: true, minHostVersion: "25.6.0", probe: canMutateTransitions, handler: addTransition },
       "transition.video.remove": { destructive: true, undoable: true, minHostVersion: "25.6.0", probe: canMutateTransitions, handler: removeTransition }
@@ -19,19 +27,39 @@
     async function dispatch(command, args) {
       const definition = definitions[command];
       if (!definition) throw commandError("UXP_UNSUPPORTED_COMMAND", "Unsupported UXP command: " + command);
-      if (definition.probe && !definition.probe()) throw commandError("UXP_COMMAND_UNAVAILABLE", command + " is not supported by this Premiere build");
-      return definition.handler(args || {});
+      if (definition.probe && !await definition.probe()) throw commandError("UXP_COMMAND_UNAVAILABLE", command + " is not supported by this Premiere build");
+      const input = args || {};
+      const operationId = validateOperationId(input.operationId);
+      const operationKey = operationId ? command + ":" + operationId : null;
+      if (!definition.readOnly && operationKey && completedOperations.has(operationKey)) {
+        return { ...completedOperations.get(operationKey), replayed: true };
+      }
+      const result = await definition.handler(input);
+      const envelope = definition.readOnly ? result : {
+        operationId: operationId || null,
+        outcome: result && result.outcome ? result.outcome : "verified",
+        ...result
+      };
+      if (!definition.readOnly && operationKey) {
+        completedOperations.set(operationKey, envelope);
+        if (completedOperations.size > 256) completedOperations.delete(completedOperations.keys().next().value);
+      }
+      return envelope;
     }
     async function capabilities() {
       let project = null, sequence = null;
       try { project = await ppro.Project.getActiveProject(); sequence = project && await project.getActiveSequence(); } catch (_) {}
       const commands = {};
-      Object.keys(definitions).forEach((name) => {
-        const definition = definitions[name], supported = !definition.probe || definition.probe();
-        commands[name] = { supported, readOnly: !!definition.readOnly, destructive: !!definition.destructive, undoable: !!definition.undoable };
+      for (const name of Object.keys(definitions)) {
+        const definition = definitions[name], supported = !definition.probe || await definition.probe();
+        commands[name] = {
+          supported, backend: "uxp", documented: true,
+          readOnly: !!definition.readOnly, destructive: !!definition.destructive,
+          undoable: !!definition.undoable, idempotent: !!definition.idempotent
+        };
         if (definition.minHostVersion) commands[name].minHostVersion = definition.minHostVersion;
         if (!supported) commands[name].reason = "Required Premiere UXP API is unavailable in this host";
-      });
+      }
       return {
         backend: "uxp", protocolVersion: Protocol.PROTOCOL_VERSION, hostMinVersion: "25.6.0",
         activeProject: !!project, activeSequence: !!sequence, commands,
@@ -43,6 +71,73 @@
       const sequence = project && await project.getActiveSequence();
       const position = sequence && await sequence.getPlayerPosition();
       return { projectOpen: !!project, sequenceOpen: !!sequence, playheadSeconds: position ? position.seconds : null };
+    }
+    async function projectSnapshot() {
+      const project = await ppro.Project.getActiveProject();
+      if (!project) return { revision: "no-project", project: null, sequences: [] };
+      const sequences = Array.from(await project.getSequences() || []).map((sequence) => ({
+        guid: String(sequence.guid || ""), name: String(sequence.name || "")
+      }));
+      const active = await project.getActiveSequence();
+      const revision = simpleRevision([project.guid, project.name, project.path, active && active.guid, sequences.map((item) => item.guid).join(",")].join("|"));
+      return {
+        revision,
+        project: { guid: String(project.guid || ""), name: String(project.name || ""), path: String(project.path || "") },
+        activeSequenceGuid: active ? String(active.guid || "") : null,
+        sequences
+      };
+    }
+    async function saveProject() {
+      const project = await ppro.Project.getActiveProject();
+      if (!project) throw commandError("UXP_NO_ACTIVE_PROJECT", "No active project");
+      const saved = await project.save();
+      if (!saved) throw commandError("UXP_VERIFICATION_FAILED", "Premiere did not confirm the project save");
+      return { saved: true, outcome: "verified", projectGuid: String(project.guid || "") };
+    }
+    async function createPresetSequence(args) {
+      assertOnlyKeys(args, ["name", "presetPath", "operationId"]);
+      const name = requiredString(args.name, "name"), presetPath = requiredString(args.presetPath, "presetPath");
+      const project = await ppro.Project.getActiveProject();
+      if (!project) throw commandError("UXP_NO_ACTIVE_PROJECT", "No active project");
+      const sequence = await project.createSequenceWithPresetPath(name, presetPath);
+      if (!sequence) throw commandError("UXP_VERIFICATION_FAILED", "Premiere did not return the created sequence");
+      const verified = Array.from(await project.getSequences() || []).some((item) => String(item.guid || "") === String(sequence.guid || ""));
+      if (!verified) throw commandError("UXP_VERIFICATION_FAILED", "Created sequence was not present in the project");
+      return { created: true, outcome: "verified", sequence: { guid: String(sequence.guid || ""), name: String(sequence.name || name) } };
+    }
+    async function exportInterchange(args) {
+      assertOnlyKeys(args, ["format", "outputFilePath", "suppressUI", "operationId"]);
+      const format = requiredString(args.format, "format"), outputFilePath = requiredString(args.outputFilePath, "outputFilePath");
+      if (format !== "otio" && format !== "fcpxml") throw commandError("UXP_INVALID_ARGUMENT", "format must be otio or fcpxml");
+      const context = await activeContext(false);
+      const method = format === "otio" ? "exportAsOpenTimelineIO" : "exportAsFinalCutProXML";
+      const exported = await ppro.ProjectConverter[method](context.sequence, outputFilePath, args.suppressUI !== false);
+      if (!exported) throw commandError("UXP_VERIFICATION_FAILED", "Premiere did not confirm the interchange export");
+      return { exported: true, outcome: "verified", format, outputFilePath };
+    }
+    async function transcriptLanguages() {
+      const languages = Array.from(await ppro.Transcript.querySupportedLanguages() || []);
+      return { languages, count: languages.length };
+    }
+    async function hasObjectMask(args) {
+      assertOnlyKeys(args, ["scope"]);
+      const scope = args.scope == null ? "sequence" : args.scope;
+      if (scope !== "sequence" && scope !== "project") throw commandError("UXP_INVALID_ARGUMENT", "scope must be sequence or project");
+      const project = await ppro.Project.getActiveProject();
+      if (!project) throw commandError("UXP_NO_ACTIVE_PROJECT", "No active project");
+      const target = scope === "project" ? project : await project.getActiveSequence();
+      if (!target) throw commandError("UXP_NO_ACTIVE_SEQUENCE", "No active sequence");
+      return { scope, hasObjectMask: !!ppro.ObjectMaskUtils.hasObjectMask(target) };
+    }
+    async function configureEncoder(args) {
+      assertOnlyKeys(args, ["launch", "embeddedXmp", "sidecarXmp", "startBatch", "operationId"]);
+      const performed = [];
+      if (args.launch) { if (!await ppro.EncoderManager.launchEncoder()) throw commandError("UXP_VERIFICATION_FAILED", "AME did not launch"); performed.push("launch"); }
+      if (args.embeddedXmp != null) { await ppro.EncoderManager.setEmbeddedXMPEnabled(!!args.embeddedXmp); performed.push("embeddedXmp"); }
+      if (args.sidecarXmp != null) { await ppro.EncoderManager.setSidecarXMPEnabled(!!args.sidecarXmp); performed.push("sidecarXmp"); }
+      if (args.startBatch) { if (!await ppro.EncoderManager.startBatchEncode()) throw commandError("UXP_VERIFICATION_FAILED", "AME batch queue did not start"); performed.push("startBatch"); }
+      if (!performed.length) throw commandError("UXP_INVALID_ARGUMENT", "At least one encoder operation is required");
+      return { configured: true, outcome: "committed_unverified", performed };
     }
     async function tickTime(seconds, name) {
       const value = Number(seconds);
@@ -119,6 +214,24 @@
       if (!committed) throw commandError("UXP_TRANSACTION_FAILED", "Premiere did not commit the transition transaction");
     }
     function canExportFrame() { return !!(ppro.Exporter && typeof ppro.Exporter.exportSequenceFrame === "function"); }
+    function canInspectProject() { return !!(ppro.Project && typeof ppro.Project.getActiveProject === "function"); }
+    async function activeProjectHas(name) {
+      if (!canInspectProject()) return false;
+      const project = await ppro.Project.getActiveProject();
+      return !project || typeof project[name] === "function";
+    }
+    function canSaveProject() { return activeProjectHas("save"); }
+    function canCreatePresetSequence() { return activeProjectHas("createSequenceWithPresetPath"); }
+    function canExportInterchange() {
+      return !!(ppro.ProjectConverter && typeof ppro.ProjectConverter.exportAsOpenTimelineIO === "function" &&
+        typeof ppro.ProjectConverter.exportAsFinalCutProXML === "function");
+    }
+    function canQueryTranscriptLanguages() { return !!(ppro.Transcript && typeof ppro.Transcript.querySupportedLanguages === "function"); }
+    function canInspectObjectMasks() { return !!(ppro.ObjectMaskUtils && typeof ppro.ObjectMaskUtils.hasObjectMask === "function"); }
+    function canConfigureEncoder() {
+      return !!(ppro.EncoderManager && typeof ppro.EncoderManager.launchEncoder === "function" &&
+        typeof ppro.EncoderManager.startBatchEncode === "function");
+    }
     function canListTransitions() { return !!(ppro.TransitionFactory && typeof ppro.TransitionFactory.getVideoTransitionMatchNames === "function"); }
     function canMutateTransitions() {
       return canListTransitions() && typeof ppro.TransitionFactory.createVideoTransition === "function" &&
@@ -129,7 +242,7 @@
 
   function validateAddArgs(args) {
     assertObject(args);
-    assertOnlyKeys(args, ["videoTrackIndex", "clipIndex", "matchName", "position", "durationSeconds", "forceSingleSided", "transitionAlignment"]);
+    assertOnlyKeys(args, ["videoTrackIndex", "clipIndex", "matchName", "position", "durationSeconds", "forceSingleSided", "transitionAlignment", "operationId"]);
     const result = targetArgs(args);
     if (typeof args.matchName !== "string" || !args.matchName.trim() || args.matchName.length > 256) throw commandError("UXP_INVALID_ARGUMENT", "matchName must be a non-empty string of at most 256 characters");
     result.matchName = args.matchName; result.position = optionalPosition(args.position);
@@ -145,7 +258,7 @@
     return result;
   }
   function validateRemoveArgs(args) {
-    assertObject(args); assertOnlyKeys(args, ["videoTrackIndex", "clipIndex", "position"]);
+    assertObject(args); assertOnlyKeys(args, ["videoTrackIndex", "clipIndex", "position", "operationId"]);
     const result = targetArgs(args); result.position = optionalPosition(args.position); return result;
   }
   function targetArgs(args) { return { videoTrackIndex: nonNegativeInt(args.videoTrackIndex, "videoTrackIndex"), clipIndex: nonNegativeInt(args.clipIndex, "clipIndex") }; }
@@ -155,6 +268,9 @@
   function nonNegativeInt(value, name) { if (!Number.isInteger(value) || value < 0) throw commandError("UXP_INVALID_ARGUMENT", name + " must be a non-negative integer"); return value; }
   function positiveNumber(value, name) { const number = Number(value); if (!Number.isFinite(number) || number <= 0) throw commandError("UXP_INVALID_ARGUMENT", name + " must be positive"); return number; }
   function positiveInt(value, fallback, name) { return Math.round(positiveNumber(value == null ? fallback : value, name)); }
+  function requiredString(value, name) { if (typeof value !== "string" || !value.trim() || value.length > 4096) throw commandError("UXP_INVALID_ARGUMENT", name + " must be a non-empty string"); return value; }
+  function validateOperationId(value) { if (value == null) return null; if (typeof value !== "string" || !/^[A-Za-z0-9._:-]{1,128}$/.test(value)) throw commandError("UXP_INVALID_ARGUMENT", "operationId must be 1-128 safe characters"); return value; }
+  function simpleRevision(value) { var hash = 2166136261; for (var i = 0; i < value.length; i += 1) { hash ^= value.charCodeAt(i); hash = Math.imul(hash, 16777619); } return "uxp-" + (hash >>> 0).toString(16); }
   function commandError(code, message) { const error = new Error(message); error.code = code; return error; }
   return { createCommandRegistry, validateAddArgs, validateRemoveArgs, commandError };
 });


### PR DESCRIPTION
## What changed

- expands the authenticated UXP bridge with documented project inspection/save, preset sequence creation, OTIO/FCP XML interchange, transcript language discovery, Object Mask detection, and Adobe Media Encoder controls
- adds runtime capability metadata including minimum host versions, read/write, destructive, undoable, idempotent, documented, and backend status
- adds explicit mutation outcomes and bounded per-command operation-ID deduplication to avoid repeating completed work after a client retry
- adds a compact revisioned project snapshot for lower-cost state inspection
- documents the compatibility matrix and live-host validation boundary
- extends UXP routing, capability, idempotency, and MCP registration tests

## Why

The existing server has broad CEP/ExtendScript and QE coverage, but only a small supported UXP surface. Current Premiere 26.2-26.3 releases expose documented APIs that can reduce synchronous bridge traffic and replace undocumented behavior for important professional workflows. This PR creates the capability-aware foundation for migrating those workflows safely without silently retrying partially successful mutations through another backend.

## User and developer impact

Users with Premiere 26.2-26.3 gain seven additional documented UXP workflows. Clients receive clearer support and verification semantics. Premiere 2020-2025 compatibility remains on CEP, and existing tools are unchanged.

## Validation

- `npm test` — 24 files, 484 tests passed
- `npm run build` — passed
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- `git diff --check` — passed

## Remaining gate

Automated tests use a contract host. The new commands still require live verification in compatible Premiere 26.2 and 26.3 hosts before claiming production host coverage.