### PR TITLE
fix: verify project creation before reporting success

### DIFF
--- a/src/tools/project.ts
+++ b/src/tools/project.ts
@@ -133,15 +133,38 @@ export function getProjectTools(bridgeOptions: BridgeOptions) {
             type: "string",
             description: "Full file path for the new .prproj file",
           },
-        },
-        required: ["path"],
+      },
+      required: ["path"],
       },
       handler: async (args: { path: string }) => {
+        const requestedPath = args.path.trim();
+        if (!/\.prproj$/i.test(requestedPath)) {
+          return {
+            success: false,
+            error:
+              "create_project path must be a full .prproj file path; Premiere cannot create a project from a directory path.",
+          };
+        }
         const script = buildToolScript(`
-          app.newProject("${escapeForExtendScript(args.path)}");
+          var requestedPath = "${escapeForExtendScript(requestedPath)}";
+          function __normalizedProjectPath(path) {
+            return String(path || "").replace(/\\\\/g, "/").toLowerCase();
+          }
+          var beforePath = app.project ? String(app.project.path || "") : "";
+          if (__normalizedProjectPath(beforePath) === __normalizedProjectPath(requestedPath)) {
+            return __error("A project is already open at " + requestedPath + "; choose a new .prproj file path instead.");
+          }
+          app.newProject(requestedPath);
           var project = app.project;
-          if (!project) return __error("Failed to create project");
-          return __result({ created: true, name: project.name, path: project.path });
+          var actualPath = project ? String(project.path || "") : "";
+          if (!project || !actualPath || __normalizedProjectPath(actualPath) !== __normalizedProjectPath(requestedPath)) {
+            return __error(
+              "Premiere did not create a project at " + requestedPath +
+              "; the active project is still " + (actualPath || beforePath || "unavailable") +
+              ". Check that the path is a new .prproj file and its parent directory exists."
+            );
+          }
+          return __result({ created: true, name: project.name, path: actualPath });
         `);
         return sendCommand(script, bridgeOptions);
       },

--- a/tests/tools/tool-modules.test.ts
+++ b/tests/tools/tool-modules.test.ts
@@ -217,6 +217,37 @@ describe("Tool Handler Behavior", () => {
     });
   });
 
+  describe("project.create_project", () => {
+    it("rejects a directory path without invoking Premiere", async () => {
+      const tools = getProjectTools(bridgeOptions);
+
+      const result = await (tools.create_project.handler as any)({
+        path: "/tmp/film-test",
+      });
+
+      expect(result).toEqual({
+        success: false,
+        error:
+          "create_project path must be a full .prproj file path; Premiere cannot create a project from a directory path.",
+      });
+      expect(mockedSendCommand).not.toHaveBeenCalled();
+    });
+
+    it("verifies the active project path after creating a project", async () => {
+      const tools = getProjectTools(bridgeOptions);
+
+      await (tools.create_project.handler as any)({
+        path: "/tmp/Film Test.prproj",
+      });
+
+      const script = mockedSendCommand.mock.calls[0][0];
+      expect(script).toContain('var requestedPath = "/tmp/Film Test.prproj"');
+      expect(script).toContain("var beforePath = app.project");
+      expect(script).toContain("var actualPath = project ? String(project.path || \"\") : \"\"");
+      expect(script).toContain("__normalizedProjectPath(actualPath) !== __normalizedProjectPath(requestedPath)");
+    });
+  });
+
   describe("health.get_capabilities", () => {
     it("reports platform support without requiring Premiere to be running", async () => {
       const tools = getHealthTools(bridgeOptions);


### PR DESCRIPTION
## What changed

- Rejects directory paths before invoking Premiere; `create_project` now requires a full `.prproj` path.
- Captures the previously active project path and verifies the post-create project path matches the requested path before reporting success.
- Adds regression coverage for both the local validation and the host-side path verification.

## Why

`app.project` remains truthy when `app.newProject()` fails while another project is open. The former handler interpreted that unchanged project as a newly created one and returned a false success.

## User impact

A failed project creation now returns an explicit error instead of allowing later edits to target the previously open project.

## Validation

- `npm run build`
- `npm test` — 24 files, 487 tests passed
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- `git diff --check`