### PR TITLE
release: prepare v1.6.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "premiere-pro",
       "source": "./claude-plugins/premiere-pro",
       "description": "Inspect, edit, verify, and export local Premiere Pro projects through MCP.",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "category": "creative",
       "tags": ["premiere-pro", "video-editing", "mcp"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-07-31
+
+### Added
+
+- Added a capability-aware UXP foundation for revisioned project inspection, verified saves,
+  preset-based sequence creation, OTIO/FCP XML interchange, transcript-language discovery,
+  Object Mask detection, and Adobe Media Encoder controls on compatible Premiere hosts.
+- Added explicit UXP operation outcomes and bounded operation-ID replay protection so a client retry
+  does not repeat a completed command within the same panel session.
+
+### Changed
+
+- Documented the 10 UXP MCP tools that become available when an authenticated local panel is
+  connected, including their host-version and live-verification boundaries.
+- Updated the MCP SDK and Node type dependencies and GitHub Actions artifact actions.
+
+### Fixed
+
+- `create_project` now rejects directory paths and verifies that Premiere switched to the exact
+  requested `.prproj` path before reporting success, preventing edits from continuing in a
+  previously open project after a failed creation attempt.
+- Claude Desktop bundle packaging now invokes npm through the active Node executable so the
+  release build works on Windows where `npm` is exposed as a command shim.
+
 ## [1.5.0] - 2026-07-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Give AI full control over Adobe Premiere Pro.**
 
-279 tools across 31 modules, 3 resources, and 4 guided workflows.
+279 core tools across 31 modules, 3 resources, and 4 guided workflows. A connected UXP host adds 10 capability-gated tools.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Node.js](https://img.shields.io/badge/Node.js-20.19%2B-green.svg)](https://nodejs.org)
@@ -27,18 +27,14 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 "Add the B-roll clips to V2, apply a cross dissolve between each, color correct them to match the A-roll, and export a 1080p ProRes."
 ```
 
-The AI handles the entire workflow through 279 tools spanning the supported ExtendScript, QE DOM, local media analysis, and safe edit-planning surfaces.
+The AI handles the entire workflow through 279 core tools spanning the supported ExtendScript, QE DOM, local media analysis, and safe edit-planning surfaces. A compatible, authenticated UXP panel adds 10 documented, capability-gated workflows without replacing the production CEP bridge.
 
-### What's new in 1.3.1
+### What's new in 1.6.0
 
-- Windows npm releases now include a verified, signed CEP ZXP and install it automatically, covering
-  hosts that reject the raw development bundle even when `PlayerDebugMode` is enabled.
-- `set_sequence_frame_rate` now converts frames per second to Premiere ticks per frame and verifies
-  the applied setting instead of assigning a numeric frame period.
-- `premiere-pro-mcp --diagnose-cep` checks the installed manifest, debug-key types, and recent
-  Premiere signature failures.
-- TypeScript 7, Vitest 4, Zod 4, MCP SDK 1.29, Next.js 16.2, and patched transitive dependencies
-  modernize the toolchain and remove production audit findings.
+- **Capability-aware UXP foundation:** compatible Premiere 25.6-26.3 hosts can expose revisioned project inspection, verified saves, preset sequence creation, OTIO/FCP XML interchange, transcript-language discovery, Object Mask detection, and Adobe Media Encoder controls.
+- **Retry-safe UXP mutations:** optional operation IDs prevent a client retry from repeating a completed command in the same panel session, while each command reports `verified` or `committed_unverified` evidence honestly.
+- **Safe project creation:** `create_project` rejects directory paths and verifies Premiere opened the requested `.prproj` before reporting success.
+- **Current distribution metadata:** the CEP/UXP panels, Codex and Claude plugins, landing page, and npm package now all identify v1.6.0.
 
 ### Added in 1.2.0
 
@@ -252,11 +248,11 @@ From a clone of this repository:
 ```bash
 codex plugin marketplace add .
 codex plugin add premiere-pro@premiere-pro-mcp
-npx -y premiere-pro-mcp@1.3.1 --install-cep
+npx -y premiere-pro-mcp@1.6.0 --install-cep
 ```
 
 Restart Premiere Pro and start a new Codex session after installation. The plugin
-launches `premiere-pro-mcp@1.3.1` through `npx`; the separate CEP installation is
+launches `premiere-pro-mcp@1.6.0` through `npx`; the separate CEP installation is
 required because the MCP server communicates with the running Premiere host through
 the local bridge.
 
@@ -276,7 +272,7 @@ For Claude Code, add this repository as a marketplace and install the plugin:
 Then install the Premiere bridge and start a new Claude Code session:
 
 ```bash
-npx -y premiere-pro-mcp@1.3.1 --install-cep
+npx -y premiere-pro-mcp@1.6.0 --install-cep
 ```
 
 The Claude Code package lives in
@@ -366,7 +362,7 @@ PREMIERE_UXP_TOKEN="replace-with-a-long-random-secret" premiere-pro-mcp
 
 Enter the same token in the UXP panel. The listener binds only to `127.0.0.1:7777`, authenticates the WebSocket upgrade, requires a versioned capability handshake, correlates concurrent requests, and fails pending work on timeout or disconnect. Set `PREMIERE_UXP_PORT` to use another loopback port.
 
-When enabled, MCP discovery includes `get_uxp_capabilities`, `get_uxp_state`, and `export_frame_uxp`. A failed UXP command is never silently retried through CEP because the first operation may have partially succeeded.
+When enabled, MCP discovery includes `get_uxp_capabilities`, `get_uxp_state`, `inspect_project_uxp`, `save_project_uxp`, `create_sequence_with_preset_uxp`, `export_interchange_uxp`, `get_transcript_languages_uxp`, `detect_object_masks_uxp`, `configure_encoder_uxp`, and `export_frame_uxp`. Commands are advertised only while the authenticated local UXP bridge is connected; the host capability handshake remains the authority for support in the running Premiere build. A failed UXP command is never silently retried through CEP because the first operation may have partially succeeded.
 
 Premiere 26.2-26.3 hosts also expose documented UXP workflows for revisioned project
 inspection, verified project saves, preset-based sequence creation, OTIO/FCP XML
@@ -417,7 +413,7 @@ The file-based IPC bridge is simple, reliable, and works across macOS and Window
 
 ---
 
-## Tools (279 total; 277 under the default profile)
+## Tools (279 core total; 277 under the default profile; 287 with a connected UXP bridge)
 
 ### Discovery & Inspection (10 + 10)
 

--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.5.0" ExtensionBundleName="MCP Bridge">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.6.0" ExtensionBundleName="MCP Bridge">
   <ExtensionList>
-    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.5.0"/>
-    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.5.0"/>
+    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.6.0"/>
+    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.6.0"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/cep-plugin/index.html
+++ b/cep-plugin/index.html
@@ -65,7 +65,7 @@
     <section class="update-section" aria-live="polite">
       <div class="update-copy">
         <span class="section-label">Connector updates</span>
-        <strong id="updateTitle">Version 1.5.0</strong>
+        <strong id="updateTitle">Version 1.6.0</strong>
         <span id="updateDetail">Checking for updates…</span>
       </div>
       <button id="btnUpdate" class="button button-update" onclick="handleUpdateClick()" type="button" disabled>

--- a/cep-plugin/updater.cjs
+++ b/cep-plugin/updater.cjs
@@ -7,7 +7,7 @@
 })(this, function () {
   "use strict";
 
-  var CURRENT_VERSION = "1.5.0";
+  var CURRENT_VERSION = "1.6.0";
   var LATEST_RELEASE_API =
     "https://api.github.com/repos/leancoderkavy/premiere-pro-mcp/releases/latest";
   var RELEASES_URL =

--- a/claude-desktop/manifest.json
+++ b/claude-desktop/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "premiere-pro-mcp",
   "display_name": "Premiere Pro MCP",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Control a local Adobe Premiere Pro project through MCP.",
   "long_description": "Inspect projects, assemble and modify timelines, manage media, effects, audio and captions, and export deliverables through a local bridge to Adobe Premiere Pro.",
   "author": {

--- a/claude-plugins/premiere-pro/.claude-plugin/plugin.json
+++ b/claude-plugins/premiere-pro/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "premiere-pro",
   "displayName": "Premiere Pro MCP",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Inspect, edit, verify, and export local Adobe Premiere Pro projects through MCP.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/claude-plugins/premiere-pro/.mcp.json
+++ b/claude-plugins/premiere-pro/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "premiere-pro": {
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.5.0"]
+      "args": ["-y", "premiere-pro-mcp@1.6.0"]
     }
   }
 }

--- a/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.5.0 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.6.0 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -4,6 +4,27 @@ import { ArrowLeft, ArrowUpRight, Github, Package } from "lucide-react"
 
 const releases = [
   {
+    version: "1.6.0",
+    date: "2026-07-31",
+    label: "Capability-aware UXP workflows and verified project creation",
+    groups: [
+      {
+        title: "Added",
+        items: [
+          "Capability-aware UXP workflows for project inspection and saves, preset sequences, OTIO/FCP XML interchange, transcript languages, Object Mask detection, and Adobe Media Encoder controls.",
+          "Operation-ID replay protection and explicit verification outcomes for supported UXP mutations.",
+        ],
+      },
+      {
+        title: "Fixed",
+        items: [
+          "Project creation now verifies that Premiere opened the requested project before reporting success.",
+          "Updated package, panel, client-plugin, and landing metadata for v1.6.0.",
+        ],
+      },
+    ],
+  },
+  {
     version: "1.5.0",
     date: "2026-07-30",
     label: "Verified structural edits and silence detection",
@@ -320,8 +341,8 @@ export default function ChangelogPage() {
             </div>
             <div className="border-l border-purple-400/40 pl-5">
               <p className="text-xs uppercase tracking-[0.18em] text-zinc-600">Latest release</p>
-              <p className="mt-2 font-mono text-2xl text-white">v1.5.0</p>
-              <p className="mt-1 text-sm text-zinc-500">July 30, 2026</p>
+              <p className="mt-2 font-mono text-2xl text-white">v1.6.0</p>
+              <p className="mt-1 text-sm text-zinc-500">July 31, 2026</p>
             </div>
           </div>
         </div>

--- a/landing/app/page.tsx
+++ b/landing/app/page.tsx
@@ -41,7 +41,7 @@ const structuredData = {
       name: "Premiere Pro MCP",
       applicationCategory: "DeveloperApplication",
       operatingSystem: "macOS, Windows",
-      softwareVersion: "1.5.0",
+      softwareVersion: "1.6.0",
       description:
         "Open-source Model Context Protocol server with 279 tools for AI-assisted editing and automation in Adobe Premiere Pro.",
       url: "https://premiere-pro-mcp.com/",
@@ -56,7 +56,7 @@ const structuredData = {
       author: { "@id": "https://premiere-pro-mcp.com/#organization" },
       publisher: { "@id": "https://premiere-pro-mcp.com/#organization" },
       image: "https://premiere-pro-mcp.com/og-image.png",
-      dateModified: "2026-07-30",
+      dateModified: "2026-07-31",
       featureList: [
         "Timeline editing",
         "Effects and Lumetri color control",

--- a/landing/components/sections/hero.tsx
+++ b/landing/components/sections/hero.tsx
@@ -14,7 +14,7 @@ const navItems = [
 ]
 
 const proofItems = [
-  { icon: Sparkles, title: "v1.5.0", detail: "Current release" },
+  { icon: Sparkles, title: "v1.6.0", detail: "Current release" },
   { icon: Monitor, title: "macOS + Windows", detail: "Apple Silicon + Intel" },
   { icon: ShieldCheck, title: "Local-first", detail: "Your media stays local" },
   { icon: Github, title: "MIT licensed", detail: "Open source" },

--- a/landing/components/sections/tools-marquee.tsx
+++ b/landing/components/sections/tools-marquee.tsx
@@ -65,7 +65,7 @@ export function ToolsMarquee() {
   return (
     <section className="relative overflow-hidden bg-black py-20">
       <div className="mb-12 text-center">
-        <p className="text-sm font-semibold uppercase tracking-widest text-zinc-500">279 tools across 31 modules</p>
+        <p className="text-sm font-semibold uppercase tracking-widest text-zinc-500">279 core tools across 31 modules</p>
         <h2 className="mt-2 text-3xl font-bold text-white md:text-4xl">Everything the AI needs to edit</h2>
       </div>
 

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -7,11 +7,11 @@ Documentation: https://premiere-pro-mcp.com/docs/
 Source: https://github.com/leancoderkavy/premiere-pro-mcp
 npm: https://www.npmjs.com/package/premiere-pro-mcp
 License: MIT
-Current release: 1.5.0
+Current release: 1.6.0
 
 ## What it does
 
-The server exposes 279 tools for project inspection, timeline editing, media import and organization, clip selection, effects, Lumetri color, audio, silence detection, keyframes, markers, captions, transitions, playback, metadata, proxies, and Adobe Media Encoder export. It also exposes three MCP resources and four workflow prompts.
+The server exposes 279 core tools for project inspection, timeline editing, media import and organization, clip selection, effects, Lumetri color, audio, silence detection, keyframes, markers, captions, transitions, playback, metadata, proxies, and Adobe Media Encoder export. An authenticated compatible UXP panel adds 10 capability-gated tools for documented UXP workflows. It also exposes three MCP resources and four workflow prompts.
 
 ## How it connects
 

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Open-source, local-first Model Context Protocol server for AI-assisted editing and automation in Adobe Premiere Pro.
 
-Premiere Pro MCP exposes 279 structured tools for timeline editing, effects, Lumetri color, keyframes, media management, silence detection, project organization, and export. Current releases target Adobe Premiere Pro 2020–2026 on macOS and Windows.
+Premiere Pro MCP exposes 279 core structured tools for timeline editing, effects, Lumetri color, keyframes, media management, silence detection, project organization, and export. An authenticated compatible UXP host adds 10 capability-gated tools. Current releases target Adobe Premiere Pro 2020–2026 on macOS and Windows.
 
 ## Canonical resources
 
@@ -24,8 +24,8 @@ The recommended setup runs the MCP server and CEP bridge locally. Project media 
 
 ## Verified facts
 
-- Current project release: 1.5.0.
-- Tool surface: 279 structured MCP tools, 3 resources, and 4 prompts.
+- Current project release: 1.6.0.
+- Tool surface: 279 core structured MCP tools, 3 resources, and 4 prompts; 10 additional UXP tools appear while an authenticated panel is connected.
 - Supported desktop platforms: Windows and macOS.
 - Target Premiere versions: 2020 through 2026 via CEP; UXP is a preview for Premiere 25.6 and newer.
 - License: MIT.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "premiere-pro-mcp",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.5.0",
-  "description": "Adobe Premiere Pro MCP server with 279 AI video editing tools for timeline automation, effects, media management, and export.",
+  "version": "1.6.0",
+  "description": "Adobe Premiere Pro MCP server with 279 core AI video editing tools and a capability-aware UXP bridge for supported Premiere workflows.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
   "type": "module",

--- a/plugins/premiere-pro/.codex-plugin/plugin.json
+++ b/plugins/premiere-pro/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Plan, execute, verify, and export video edits in Adobe Premiere Pro through the Premiere Pro MCP server.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/plugins/premiere-pro/.mcp.json
+++ b/plugins/premiere-pro/.mcp.json
@@ -4,7 +4,7 @@
       "title": "Premiere Pro MCP",
       "description": "Inspect and edit a local Adobe Premiere Pro project through the Premiere Pro MCP bridge.",
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.5.0"]
+      "args": ["-y", "premiere-pro-mcp@1.6.0"]
     }
   }
 }

--- a/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.5.0 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.6.0 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/scripts/build-claude-desktop.mjs
+++ b/scripts/build-claude-desktop.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { cp, copyFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { spawn } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -21,6 +22,22 @@ const run = (command, args, cwd) =>
       else reject(new Error(`${command} exited with code ${code}`));
     });
   });
+
+function runNpm(args, cwd) {
+  // On Windows, spawn("npm", ...) can fail because npm is exposed as npm.cmd
+  // rather than an executable. Running npm's bundled CLI through this Node
+  // process works on every supported platform and keeps shell execution off.
+  const npmCli = path.join(
+    path.dirname(process.execPath),
+    "node_modules",
+    "npm",
+    "bin",
+    "npm-cli.js",
+  );
+  return existsSync(npmCli)
+    ? run(process.execPath, [npmCli, ...args], cwd)
+    : run("npm", args, cwd);
+}
 
 await rm(stage, { recursive: true, force: true });
 await mkdir(path.join(stage, "server"), { recursive: true });
@@ -49,7 +66,7 @@ await writeFile(
   )}\n`,
 );
 
-await run("npm", ["ci", "--omit=dev", "--ignore-scripts"], stage);
+await runNpm(["ci", "--omit=dev", "--ignore-scripts"], stage);
 
 const mcpbPath = path.join(
   artifacts,
@@ -60,9 +77,8 @@ const dxtPath = path.join(
   `premiere-pro-mcp-${packageJson.version}.dxt`,
 );
 
-await run(
-  "npx",
-  ["-y", "@anthropic-ai/mcpb@2.1.2", "pack", stage, mcpbPath],
+await runNpm(
+  ["exec", "--yes", "@anthropic-ai/mcpb@2.1.2", "pack", stage, mcpbPath],
   root,
 );
 await copyFile(mcpbPath, dxtPath);

--- a/uxp-plugin/manifest.json
+++ b/uxp-plugin/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.ppmcp.premiere.uxp",
   "name": "Premiere Pro MCP Bridge",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "main": "index.html",
   "host": { "app": "premierepro", "minVersion": "25.6.0" },
   "entrypoints": [


### PR DESCRIPTION
## Release v1.6.0

### What changed

- Updated the README with the complete connected-UXP command surface, capability handshake boundary, and v1.6.0 installation instructions.
- Added release notes and synchronized the npm package, CEP/UXP panels, Codex/Claude distributions, and public landing metadata.
- Corrected Windows Claude Desktop bundle packaging by invoking npm through the active Node executable.

### Release content

- Capability-aware UXP workflows for revisioned inspection, verified save, preset sequence creation, OTIO/FCP XML export, transcript languages, Object Mask detection, and Adobe Media Encoder controls.
- Operation-ID replay protection and explicit mutation outcomes.
- Verified project creation so an invalid request cannot report the previously open project as newly created.

### Validation

- `npm run build`
- `npm test` — 24 files, 487 tests passed
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- `npm run publish:npm:dry-run` — 124 files
- `npm run build:claude` — v1.6.0 `.mcpb` and `.dxt`
- `scripts/build-signed-cep.ps1` — signed and verified ZXP
- Landing `npm run build`
- `git diff --check`