### PR TITLE
Release premiere-pro-mcp v1.7.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "premiere-pro",
       "source": "./claude-plugins/premiere-pro",
       "description": "Inspect, edit, verify, and export local Premiere Pro projects through MCP.",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "category": "creative",
       "tags": ["premiere-pro", "video-editing", "mcp"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-08-01
+
 ### Added
 
 - Added six capability-gated Premiere 26.3+ UXP tools: `rename_track_uxp`,

--- a/README.md
+++ b/README.md
@@ -29,18 +29,12 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 
 The AI handles the entire workflow through 279 core tools spanning the supported ExtendScript, QE DOM, local media analysis, and safe edit-planning surfaces. A compatible, authenticated UXP panel adds 16 documented, capability-gated workflows without replacing the production CEP bridge.
 
-### What's new in 1.6.0
-
-- **Capability-aware UXP foundation:** compatible Premiere 25.6-26.3 hosts can expose revisioned project inspection, verified saves, preset sequence creation, OTIO/FCP XML interchange, transcript-language discovery, Object Mask detection, and Adobe Media Encoder controls.
-- **Retry-safe UXP mutations:** optional operation IDs prevent a client retry from repeating a completed command in the same panel session, while each command reports `verified` or `committed_unverified` evidence honestly.
-- **Safe project creation:** `create_project` rejects directory paths and verifies Premiere opened the requested `.prproj` before reporting success.
-- **Current distribution metadata:** the CEP/UXP panels, Codex and Claude plugins, landing page, and npm package now all identify v1.6.0.
-
-### Adobe UXP 26.3 coverage (unreleased)
+### What's new in 1.7.0
 
 - **Six documented workflows:** compatible 26.3+ hosts can expose UXP track renaming, subclip creation, stable marker IDs, Source Monitor seeking, transcript presence checks, and AAF export.
 - **Capability first:** a tool is discoverable only with the authenticated local panel; the panel's live `capabilities.get` response—not package metadata—decides whether the current host supports it.
 - **Evidence boundary:** automated tests validate schemas, routing, capability declarations, transactions, and result envelopes. They do not verify a specific Premiere installation. See [Adobe UXP 26.3 coverage](docs/adobe-uxp-26.3-coverage.md) for the exact host gate and the stable-versus-beta policy.
+- **Adobe-aligned validation:** the official Premiere 26.3 declarations and ESLint rules now enforce supported signatures and lock/transaction boundaries in CI.
 
 ### Added in 1.2.0
 
@@ -254,11 +248,11 @@ From a clone of this repository:
 ```bash
 codex plugin marketplace add .
 codex plugin add premiere-pro@premiere-pro-mcp
-npx -y premiere-pro-mcp@1.6.0 --install-cep
+npx -y premiere-pro-mcp@1.7.0 --install-cep
 ```
 
 Restart Premiere Pro and start a new Codex session after installation. The plugin
-launches `premiere-pro-mcp@1.6.0` through `npx`; the separate CEP installation is
+launches `premiere-pro-mcp@1.7.0` through `npx`; the separate CEP installation is
 required because the MCP server communicates with the running Premiere host through
 the local bridge.
 
@@ -278,7 +272,7 @@ For Claude Code, add this repository as a marketplace and install the plugin:
 Then install the Premiere bridge and start a new Claude Code session:
 
 ```bash
-npx -y premiere-pro-mcp@1.6.0 --install-cep
+npx -y premiere-pro-mcp@1.7.0 --install-cep
 ```
 
 The Claude Code package lives in

--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.6.0" ExtensionBundleName="MCP Bridge">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.7.0" ExtensionBundleName="MCP Bridge">
   <ExtensionList>
-    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.6.0"/>
-    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.6.0"/>
+    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.7.0"/>
+    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.7.0"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/cep-plugin/index.html
+++ b/cep-plugin/index.html
@@ -65,7 +65,7 @@
     <section class="update-section" aria-live="polite">
       <div class="update-copy">
         <span class="section-label">Connector updates</span>
-        <strong id="updateTitle">Version 1.6.0</strong>
+        <strong id="updateTitle">Version 1.7.0</strong>
         <span id="updateDetail">Checking for updates…</span>
       </div>
       <button id="btnUpdate" class="button button-update" onclick="handleUpdateClick()" type="button" disabled>

--- a/cep-plugin/updater.cjs
+++ b/cep-plugin/updater.cjs
@@ -7,7 +7,7 @@
 })(this, function () {
   "use strict";
 
-  var CURRENT_VERSION = "1.6.0";
+  var CURRENT_VERSION = "1.7.0";
   var LATEST_RELEASE_API =
     "https://api.github.com/repos/leancoderkavy/premiere-pro-mcp/releases/latest";
   var RELEASES_URL =

--- a/claude-desktop/manifest.json
+++ b/claude-desktop/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "premiere-pro-mcp",
   "display_name": "Premiere Pro MCP",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Control a local Adobe Premiere Pro project through MCP.",
   "long_description": "Inspect projects, assemble and modify timelines, manage media, effects, audio and captions, and export deliverables through a local bridge to Adobe Premiere Pro.",
   "author": {

--- a/claude-plugins/premiere-pro/.claude-plugin/plugin.json
+++ b/claude-plugins/premiere-pro/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "premiere-pro",
   "displayName": "Premiere Pro MCP",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Inspect, edit, verify, and export local Adobe Premiere Pro projects through MCP.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/claude-plugins/premiere-pro/.mcp.json
+++ b/claude-plugins/premiere-pro/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "premiere-pro": {
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.6.0"]
+      "args": ["-y", "premiere-pro-mcp@1.7.0"]
     }
   }
 }

--- a/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.6.0 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.7.0 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -4,6 +4,27 @@ import { ArrowLeft, ArrowUpRight, Github, Package } from "lucide-react"
 
 const releases = [
   {
+    version: "1.7.0",
+    date: "2026-08-01",
+    label: "Adobe Premiere Pro 26.3 UXP API coverage",
+    groups: [
+      {
+        title: "Added",
+        items: [
+          "Six capability-gated UXP tools for track rename, subclip creation, stable marker IDs, Source Monitor positioning, transcript detection, and AAF export.",
+          "Adobe 26.3 declarations, lint rules, coverage metadata, and contract tests for the supported API surface.",
+        ],
+      },
+      {
+        title: "Changed",
+        items: [
+          "Expanded the connected UXP surface from 10 to 16 tools while preserving explicit host capability and verification boundaries.",
+          "Separated the stable Adobe 26.3 baseline from beta-only 26.5 declarations.",
+        ],
+      },
+    ],
+  },
+  {
     version: "1.6.0",
     date: "2026-07-31",
     label: "Capability-aware UXP workflows and verified project creation",
@@ -341,7 +362,7 @@ export default function ChangelogPage() {
             </div>
             <div className="border-l border-purple-400/40 pl-5">
               <p className="text-xs uppercase tracking-[0.18em] text-zinc-600">Latest release</p>
-              <p className="mt-2 font-mono text-2xl text-white">v1.6.0</p>
+              <p className="mt-2 font-mono text-2xl text-white">v1.7.0</p>
               <p className="mt-1 text-sm text-zinc-500">July 31, 2026</p>
             </div>
           </div>

--- a/landing/app/page.tsx
+++ b/landing/app/page.tsx
@@ -41,7 +41,7 @@ const structuredData = {
       name: "Premiere Pro MCP",
       applicationCategory: "DeveloperApplication",
       operatingSystem: "macOS, Windows",
-      softwareVersion: "1.6.0",
+      softwareVersion: "1.7.0",
       description:
         "Open-source Model Context Protocol server with 279 tools for AI-assisted editing and automation in Adobe Premiere Pro.",
       url: "https://premiere-pro-mcp.com/",
@@ -56,7 +56,7 @@ const structuredData = {
       author: { "@id": "https://premiere-pro-mcp.com/#organization" },
       publisher: { "@id": "https://premiere-pro-mcp.com/#organization" },
       image: "https://premiere-pro-mcp.com/og-image.png",
-      dateModified: "2026-07-31",
+      dateModified: "2026-08-01",
       featureList: [
         "Timeline editing",
         "Effects and Lumetri color control",

--- a/landing/components/sections/hero.tsx
+++ b/landing/components/sections/hero.tsx
@@ -14,7 +14,7 @@ const navItems = [
 ]
 
 const proofItems = [
-  { icon: Sparkles, title: "v1.6.0", detail: "Current release" },
+  { icon: Sparkles, title: "v1.7.0", detail: "Current release" },
   { icon: Monitor, title: "macOS + Windows", detail: "Apple Silicon + Intel" },
   { icon: ShieldCheck, title: "Local-first", detail: "Your media stays local" },
   { icon: Github, title: "MIT licensed", detail: "Open source" },

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -7,11 +7,11 @@ Documentation: https://premiere-pro-mcp.com/docs/
 Source: https://github.com/leancoderkavy/premiere-pro-mcp
 npm: https://www.npmjs.com/package/premiere-pro-mcp
 License: MIT
-Current release: 1.6.0
+Current release: 1.7.0
 
 ## What it does
 
-The server exposes 279 core tools for project inspection, timeline editing, media import and organization, clip selection, effects, Lumetri color, audio, silence detection, keyframes, markers, captions, transitions, playback, metadata, proxies, and Adobe Media Encoder export. An authenticated compatible UXP panel adds 10 capability-gated tools for documented UXP workflows. It also exposes three MCP resources and four workflow prompts.
+The server exposes 279 core tools for project inspection, timeline editing, media import and organization, clip selection, effects, Lumetri color, audio, silence detection, keyframes, markers, captions, transitions, playback, metadata, proxies, and Adobe Media Encoder export. An authenticated compatible UXP panel adds 16 capability-gated tools for documented UXP workflows. It also exposes three MCP resources and four workflow prompts.
 
 ## How it connects
 

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Open-source, local-first Model Context Protocol server for AI-assisted editing and automation in Adobe Premiere Pro.
 
-Premiere Pro MCP exposes 279 core structured tools for timeline editing, effects, Lumetri color, keyframes, media management, silence detection, project organization, and export. An authenticated compatible UXP host adds 10 capability-gated tools. Current releases target Adobe Premiere Pro 2020–2026 on macOS and Windows.
+Premiere Pro MCP exposes 279 core structured tools for timeline editing, effects, Lumetri color, keyframes, media management, silence detection, project organization, and export. An authenticated compatible UXP host adds 16 capability-gated tools. Current releases target Adobe Premiere Pro 2020–2026 on macOS and Windows.
 
 ## Canonical resources
 
@@ -24,8 +24,8 @@ The recommended setup runs the MCP server and CEP bridge locally. Project media 
 
 ## Verified facts
 
-- Current project release: 1.6.0.
-- Tool surface: 279 core structured MCP tools, 3 resources, and 4 prompts; 10 additional UXP tools appear while an authenticated panel is connected.
+- Current project release: 1.7.0.
+- Tool surface: 279 core structured MCP tools, 3 resources, and 4 prompts; 16 additional UXP tools appear while an authenticated panel is connected.
 - Supported desktop platforms: Windows and macOS.
 - Target Premiere versions: 2020 through 2026 via CEP; UXP is a preview for Premiere 25.6 and newer.
 - License: MIT.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "premiere-pro-mcp",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Adobe Premiere Pro MCP server with 279 core AI video editing tools and a capability-aware UXP bridge for supported Premiere workflows.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/premiere-pro/.codex-plugin/plugin.json
+++ b/plugins/premiere-pro/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Plan, execute, verify, and export video edits in Adobe Premiere Pro through the Premiere Pro MCP server.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/plugins/premiere-pro/.mcp.json
+++ b/plugins/premiere-pro/.mcp.json
@@ -4,7 +4,7 @@
       "title": "Premiere Pro MCP",
       "description": "Inspect and edit a local Adobe Premiere Pro project through the Premiere Pro MCP bridge.",
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.6.0"]
+      "args": ["-y", "premiere-pro-mcp@1.7.0"]
     }
   }
 }

--- a/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.6.0 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.7.0 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/uxp-plugin/manifest.json
+++ b/uxp-plugin/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.ppmcp.premiere.uxp",
   "name": "Premiere Pro MCP Bridge",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "main": "index.html",
   "host": { "app": "premierepro", "minVersion": "25.6.0" },
   "entrypoints": [


### PR DESCRIPTION
## What changed

- promote the Adobe Premiere Pro 26.3 UXP expansion to v1.7.0
- update package, CEP, UXP, Codex, Claude, updater, landing, and LLM-discovery metadata
- refresh the README and public changelog for the six new capability-gated UXP workflows
- update the connected UXP surface count from 10 to 16

## Why

The merged Adobe 26.3 API coverage is a backwards-compatible feature release. All distribution and discovery surfaces must identify the same release before npm, GitHub, and Fly publication.

## Validation

- `npm run check` — Adobe lint, TypeScript build, 28 test files, 500 tests
- `npm run publish:npm:dry-run`
- `npm audit --omit=dev --audit-level=high` — 0 production vulnerabilities
- `npm run build --prefix landing`
- `npm audit --prefix landing --omit=dev` — 0 production vulnerabilities
- `git diff --check`

## Verification boundary

Automated contracts cover the v1.7.0 UXP schemas and routing. Real Premiere Pro 26.3 host verification remains required before the six new commands are labeled live-host verified.
