### PR TITLE
Fix v1.7.0 Docker release build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN npm ci
 
 COPY tsconfig.json ./
 COPY src/ ./src/
+COPY scripts/copy-adobe-uxp-coverage.mjs ./scripts/copy-adobe-uxp-coverage.mjs
 
 RUN npm run build
 

--- a/tests/docker-build-context.test.ts
+++ b/tests/docker-build-context.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("Docker release build context", () => {
+  it("copies every repository script required by the package build", () => {
+    const dockerfile = readFileSync("Dockerfile", "utf8");
+    const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {
+      scripts: Record<string, string>;
+    };
+
+    expect(packageJson.scripts.build).toContain("scripts/copy-adobe-uxp-coverage.mjs");
+    expect(dockerfile).toContain(
+      "COPY scripts/copy-adobe-uxp-coverage.mjs ./scripts/copy-adobe-uxp-coverage.mjs",
+    );
+  });
+});


### PR DESCRIPTION
Includes the Adobe coverage-copy script in the Docker builder context and adds a regression test that ties the Dockerfile to the package build command. Local validation: npm run check, 501 tests.