### PR TITLE
Add native transcript edit planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Give AI full control over Adobe Premiere Pro.**
 
-279 core tools across 31 modules, 3 resources, and 4 guided workflows. A connected UXP host adds 16 capability-gated tools.
+279 core tools across 31 modules, 3 resources, and 4 guided workflows. A connected UXP host adds 19 capability-gated tools.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Node.js](https://img.shields.io/badge/Node.js-20.19%2B-green.svg)](https://nodejs.org)
@@ -27,7 +27,7 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 "Add the B-roll clips to V2, apply a cross dissolve between each, color correct them to match the A-roll, and export a 1080p ProRes."
 ```
 
-The AI handles the entire workflow through 279 core tools spanning the supported ExtendScript, QE DOM, local media analysis, and safe edit-planning surfaces. A compatible, authenticated UXP panel adds 16 documented, capability-gated workflows without replacing the production CEP bridge.
+The AI handles the entire workflow through 279 core tools spanning the supported ExtendScript, QE DOM, local media analysis, and safe edit-planning surfaces. A compatible, authenticated UXP panel adds 19 documented, capability-gated workflows without replacing the production CEP bridge.
 
 ### What's new in 1.7.0
 
@@ -362,7 +362,17 @@ PREMIERE_UXP_TOKEN="replace-with-a-long-random-secret" premiere-pro-mcp
 
 Enter the same token in the UXP panel. The listener binds only to `127.0.0.1:7777`, authenticates the WebSocket upgrade, requires a versioned capability handshake, correlates concurrent requests, and fails pending work on timeout or disconnect. Set `PREMIERE_UXP_PORT` to use another loopback port.
 
-When enabled, MCP discovery includes `get_uxp_capabilities`, `get_uxp_state`, `inspect_project_uxp`, `save_project_uxp`, `create_sequence_with_preset_uxp`, `export_interchange_uxp`, `get_transcript_languages_uxp`, `detect_object_masks_uxp`, `configure_encoder_uxp`, `export_frame_uxp`, `rename_track_uxp`, `create_subclip_uxp`, `list_markers_uxp`, `set_source_monitor_position_uxp`, `has_transcript_uxp`, and `export_aaf_uxp`. Commands are advertised only while the authenticated local UXP bridge is connected; the host capability handshake remains the authority for support in the running Premiere build. A failed UXP command is never silently retried through CEP because the first operation may have partially succeeded.
+When enabled, MCP discovery includes `get_uxp_capabilities`, `get_uxp_state`, `inspect_project_uxp`, `save_project_uxp`, `create_sequence_with_preset_uxp`, `export_interchange_uxp`, `get_transcript_languages_uxp`, `get_clip_transcript_uxp`, `search_clip_transcript_uxp`, `preview_transcript_edit_uxp`, `detect_object_masks_uxp`, `configure_encoder_uxp`, `export_frame_uxp`, `rename_track_uxp`, `create_subclip_uxp`, `list_markers_uxp`, `set_source_monitor_position_uxp`, `has_transcript_uxp`, and `export_aaf_uxp`. Commands are advertised only while the authenticated local UXP bridge is connected; the host capability handshake remains the authority for support in the running Premiere build. A failed UXP command is never silently retried through CEP because the first operation may have partially succeeded.
+
+Native transcript editing starts with a read-only, revision-locked planning flow. Use
+`get_clip_transcript_uxp` to export the transcript Premiere generated for a source
+clip, select source-time ranges from that JSON, and pass its SHA-256 revision to
+`preview_transcript_edit_uxp`. The preview sorts and merges ranges and returns a
+confirmation token without changing the timeline. Premiere does not expose a
+documented operation that directly turns deleted transcript text into timeline cuts,
+so automatic application remains withheld until the source-to-sequence mapping and
+documented reconstruction path pass live-host validation. `search_clip_transcript_uxp`
+provides read-only discovery without substituting an external transcription engine.
 
 Premiere 26.2-26.3 hosts also expose documented UXP workflows for revisioned project
 inspection, verified project saves, preset-based sequence creation, OTIO/FCP XML
@@ -416,7 +426,7 @@ The file-based IPC bridge is simple, reliable, and works across macOS and Window
 
 ---
 
-## Tools (279 core total; 277 under the default profile; 293 with a connected UXP bridge)
+## Tools (279 core total; 277 under the default profile; 296 with a connected UXP bridge)
 
 ### Discovery & Inspection (10 + 10)
 
@@ -659,7 +669,7 @@ premiere-pro-mcp/
 ├── src/
 │   ├── index.ts                 # Entry point — stdio transport setup
 │   ├── http-server.ts           # Entry point — HTTP/SSE transport (Fly.io / remote)
-│   ├── server.ts                # MCP server — registers 279 tools, filtered by authority profile
+│   ├── server.ts                # MCP server — registers 279 core tools, filtered by authority profile
 │   ├── bridge/
 │   │   ├── file-bridge.ts       # File-based IPC (write .jsx, poll .json)
 │   │   └── script-builder.ts    # ExtendScript generator with ES3 helpers

--- a/src/security/capabilities.ts
+++ b/src/security/capabilities.ts
@@ -55,7 +55,12 @@ export function requireCapability(
 
 export const UNSAFE_TOOL_NAMES = new Set(["execute_extendscript", "send_raw_script", "evaluate_expression"]);
 
-const INSPECT_TOOL_NAMES = new Set(["ping", "get_capabilities", "preview_edit_plan"]);
+const INSPECT_TOOL_NAMES = new Set([
+  "ping",
+  "get_capabilities",
+  "preview_edit_plan",
+  "preview_transcript_edit_uxp",
+]);
 // detect_silence reads a media file from disk and shells out to ffmpeg. It
 // changes nothing in Premiere, so classifying it as "edit" would overstate what
 // it does; filesystem is the authority it actually needs.

--- a/src/tools/transcript-edits.ts
+++ b/src/tools/transcript-edits.ts
@@ -1,0 +1,89 @@
+import { createHash } from "node:crypto";
+
+export interface TranscriptDeletionRange {
+  start_seconds: number;
+  end_seconds: number;
+}
+
+export interface TranscriptEditPreview {
+  transcriptRevision: string;
+  deletionRanges: TranscriptDeletionRange[];
+  deletedSeconds: number;
+  confirmationToken: string;
+  applied: false;
+}
+
+const MAX_DELETION_RANGES = 100;
+
+export function transcriptRevision(json: string): string {
+  return `sha256:${createHash("sha256").update(json).digest("hex")}`;
+}
+
+function roundSeconds(value: number): number {
+  return Number(value.toFixed(6));
+}
+
+export function normalizeTranscriptDeletionRanges(
+  value: unknown,
+  handleSeconds = 0,
+): TranscriptDeletionRange[] {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error("deletions must contain at least one transcript time range");
+  }
+  if (value.length > MAX_DELETION_RANGES) {
+    throw new Error(`transcript edits are limited to ${MAX_DELETION_RANGES} deletion ranges`);
+  }
+  if (!Number.isFinite(handleSeconds) || handleSeconds < 0 || handleSeconds > 10) {
+    throw new Error("handle_seconds must be between 0 and 10");
+  }
+
+  const ranges = value.map((entry, index) => {
+    if (!entry || typeof entry !== "object") {
+      throw new Error(`deletion ${index} must be an object`);
+    }
+    const range = entry as Partial<TranscriptDeletionRange>;
+    if (!Number.isFinite(range.start_seconds) || Number(range.start_seconds) < 0) {
+      throw new Error(`deletion ${index} start_seconds must be a non-negative number`);
+    }
+    if (!Number.isFinite(range.end_seconds) || Number(range.end_seconds) <= Number(range.start_seconds)) {
+      throw new Error(`deletion ${index} end_seconds must be greater than start_seconds`);
+    }
+    return {
+      start_seconds: roundSeconds(Math.max(0, Number(range.start_seconds) - handleSeconds)),
+      end_seconds: roundSeconds(Number(range.end_seconds) + handleSeconds),
+    };
+  }).sort((left, right) => left.start_seconds - right.start_seconds || left.end_seconds - right.end_seconds);
+
+  const merged: TranscriptDeletionRange[] = [];
+  for (const range of ranges) {
+    const previous = merged.at(-1);
+    if (previous && range.start_seconds <= previous.end_seconds) {
+      previous.end_seconds = roundSeconds(Math.max(previous.end_seconds, range.end_seconds));
+    } else {
+      merged.push({ ...range });
+    }
+  }
+  return merged;
+}
+
+export function previewTranscriptEdit(
+  json: string,
+  requestedRevision: string,
+  deletions: unknown,
+  handleSeconds = 0,
+): TranscriptEditPreview {
+  if (typeof json !== "string" || !json) throw new Error("Premiere returned an empty transcript");
+  const revision = transcriptRevision(json);
+  if (requestedRevision !== revision) {
+    throw new Error("Transcript revision does not match the current Premiere transcript; export it again before planning edits");
+  }
+  const deletionRanges = normalizeTranscriptDeletionRanges(deletions, handleSeconds);
+  const canonical = JSON.stringify({ transcriptRevision: revision, deletionRanges });
+  return {
+    transcriptRevision: revision,
+    deletionRanges,
+    deletedSeconds: roundSeconds(deletionRanges.reduce((total, range) => total + range.end_seconds - range.start_seconds, 0)),
+    confirmationToken: createHash("sha256").update(canonical).digest("hex"),
+    applied: false,
+  };
+}

--- a/src/tools/uxp.ts
+++ b/src/tools/uxp.ts
@@ -1,4 +1,5 @@
 import type { UxpWebSocketBridge } from "../bridge/uxp-websocket-bridge.js";
+import { previewTranscriptEdit, transcriptRevision } from "./transcript-edits.js";
 
 function invoke(
   bridge: UxpWebSocketBridge,
@@ -83,6 +84,92 @@ export function getUxpTools(bridge: UxpWebSocketBridge) {
       description: "List transcription languages supported by the connected Premiere 26.3+ host.",
       parameters: {},
       handler: async () => invoke(bridge, "transcript.languages"),
+    },
+    get_clip_transcript_uxp: {
+      description: "Export Premiere's native transcript JSON for one source media clip. Returns a revision hash that must be used when previewing transcript edits. This is read-only and does not run Speech-to-Text.",
+      parameters: {
+        type: "object" as const,
+        properties: {
+          project_item_id: { type: "string", maxLength: 512, description: "Source project-item ID. Omit with project_item_name to use exactly one Project panel selection." },
+          project_item_name: { type: "string", maxLength: 255, description: "Unique source media-clip name. Not allowed together with project_item_id." },
+        },
+      },
+      handler: async (args: { project_item_id?: string; project_item_name?: string }) => {
+        try {
+          const result = await bridge.request("transcript.export", {
+            ...(args.project_item_id ? { projectItemId: args.project_item_id } : {}),
+            ...(args.project_item_name ? { projectItemName: args.project_item_name } : {}),
+          }) as { json?: unknown };
+          if (typeof result?.json !== "string" || !result.json) throw new Error("Premiere returned an empty transcript");
+          return { success: true, data: { backend: "uxp", result: { ...result, transcriptRevision: transcriptRevision(result.json) } } };
+        } catch (error) {
+          return { success: false, error: error instanceof Error ? error.message : String(error) };
+        }
+      },
+    },
+    search_clip_transcript_uxp: {
+      description: "Search Premiere's native transcript JSON without modifying the clip or timeline.",
+      parameters: {
+        type: "object" as const,
+        properties: {
+          project_item_id: { type: "string", maxLength: 512, description: "Source project-item ID." },
+          project_item_name: { type: "string", maxLength: 255, description: "Unique source media-clip name." },
+          query: { type: "string", minLength: 1, maxLength: 1000, description: "Transcript text to find." },
+          case_sensitive: { type: "boolean", description: "Use case-sensitive matching; defaults to false." },
+          max_results: { type: "integer", minimum: 1, maximum: 500, description: "Maximum matches; defaults to 50." },
+        },
+        required: ["query"],
+      },
+      handler: async (args: { project_item_id?: string; project_item_name?: string; query: string; case_sensitive?: boolean; max_results?: number }) =>
+        invoke(bridge, "transcript.search", {
+          ...(args.project_item_id ? { projectItemId: args.project_item_id } : {}),
+          ...(args.project_item_name ? { projectItemName: args.project_item_name } : {}),
+          query: args.query,
+          ...(args.case_sensitive === undefined ? {} : { caseSensitive: args.case_sensitive }),
+          ...(args.max_results === undefined ? {} : { maxResults: args.max_results }),
+        }),
+    },
+    preview_transcript_edit_uxp: {
+      description: "Validate and merge source-time ranges selected from Premiere's native transcript. Returns a confirmation token and never changes the timeline. Automatic timeline application remains withheld until the source-to-sequence mapping is live-host verified.",
+      parameters: {
+        type: "object" as const,
+        properties: {
+          project_item_id: { type: "string", maxLength: 512, description: "Source project-item ID used for the transcript export." },
+          project_item_name: { type: "string", maxLength: 255, description: "Unique source media-clip name." },
+          transcript_revision: { type: "string", pattern: "^sha256:[a-f0-9]{64}$", description: "Revision returned by get_clip_transcript_uxp." },
+          deletions: {
+            type: "array", minItems: 1, maxItems: 100,
+            items: {
+              type: "object", additionalProperties: false,
+              properties: {
+                start_seconds: { type: "number", minimum: 0 },
+                end_seconds: { type: "number", exclusiveMinimum: 0 },
+              },
+              required: ["start_seconds", "end_seconds"],
+            },
+            description: "Source-media time ranges corresponding to transcript words or segments to remove.",
+          },
+          handle_seconds: { type: "number", minimum: 0, maximum: 10, description: "Optional context added to both sides before overlapping ranges are merged." },
+        },
+        required: ["transcript_revision", "deletions"],
+      },
+      handler: async (args: { project_item_id?: string; project_item_name?: string; transcript_revision: string; deletions: unknown; handle_seconds?: number }) => {
+        try {
+          const exported = await bridge.request("transcript.export", {
+            ...(args.project_item_id ? { projectItemId: args.project_item_id } : {}),
+            ...(args.project_item_name ? { projectItemName: args.project_item_name } : {}),
+          }) as { json?: unknown; projectItemId?: unknown; projectItemName?: unknown };
+          if (typeof exported?.json !== "string") throw new Error("Premiere returned an empty transcript");
+          const preview = previewTranscriptEdit(exported.json, args.transcript_revision, args.deletions, args.handle_seconds);
+          return { success: true, data: { backend: "uxp", result: {
+            projectItemId: exported.projectItemId,
+            projectItemName: exported.projectItemName,
+            ...preview,
+          } } };
+        } catch (error) {
+          return { success: false, error: error instanceof Error ? error.message : String(error) };
+        }
+      },
     },
     detect_object_masks_uxp: {
       description: "Detect whether the active project or sequence contains an Object Mask using Premiere 26.3+.",

--- a/tests/security-capabilities.test.ts
+++ b/tests/security-capabilities.test.ts
@@ -33,6 +33,7 @@ describe("capability profiles", () => {
     expect(capabilityForTool("verify_delivery_file")).toBe("filesystem");
     expect(capabilityForTool("import_media")).toBe("filesystem");
     expect(capabilityForTool("get_project_info")).toBe("inspect");
+    expect(capabilityForTool("preview_transcript_edit_uxp")).toBe("inspect");
     expect(capabilityForTool("ping")).toBe("inspect");
     expect(capabilityForTool("trim_clip")).toBe("edit");
   });

--- a/tests/tools/adobe-26-3-uxp-catalog.test.ts
+++ b/tests/tools/adobe-26-3-uxp-catalog.test.ts
@@ -44,7 +44,7 @@ describe("Adobe Premiere 26.3 UXP public MCP catalog", () => {
       expect(listed.tools.map((tool) => tool.name)).toEqual(
         expect.arrayContaining(ADOBE_26_3_TOOLS),
       );
-      expect(listed.tools).toHaveLength(293);
+      expect(listed.tools).toHaveLength(296);
     } finally {
       await client.close();
       await server.close();

--- a/tests/tools/transcript-edits.test.ts
+++ b/tests/tools/transcript-edits.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import type { UxpWebSocketBridge } from "../../src/bridge/uxp-websocket-bridge.js";
+import {
+  normalizeTranscriptDeletionRanges,
+  previewTranscriptEdit,
+  transcriptRevision,
+} from "../../src/tools/transcript-edits.js";
+import { getUxpTools } from "../../src/tools/uxp.js";
+
+describe("transcript edit planning", () => {
+  it("creates stable transcript revisions", () => {
+    expect(transcriptRevision('{"segments":[]}')).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(transcriptRevision('{"segments":[]}')).toBe(transcriptRevision('{"segments":[]}'));
+    expect(transcriptRevision('{"segments":[1]}')).not.toBe(transcriptRevision('{"segments":[]}'));
+  });
+
+  it("sorts, adds handles, and merges overlapping deletion ranges", () => {
+    expect(normalizeTranscriptDeletionRanges([
+      { start_seconds: 5, end_seconds: 7 },
+      { start_seconds: 1, end_seconds: 3 },
+      { start_seconds: 2.9, end_seconds: 5.1 },
+    ], 0.1)).toEqual([{ start_seconds: 0.9, end_seconds: 7.1 }]);
+  });
+
+  it("rejects invalid or excessive deletion ranges", () => {
+    expect(() => normalizeTranscriptDeletionRanges([])).toThrow("at least one");
+    expect(() => normalizeTranscriptDeletionRanges([{ start_seconds: 2, end_seconds: 1 }])).toThrow("greater than");
+    expect(() => normalizeTranscriptDeletionRanges([{ start_seconds: 0, end_seconds: 1 }], 11)).toThrow("between 0 and 10");
+    expect(() => normalizeTranscriptDeletionRanges(Array.from({ length: 101 }, (_, i) => ({ start_seconds: i, end_seconds: i + 0.5 })))).toThrow("limited to 100");
+  });
+
+  it("revision-locks previews and returns a deterministic confirmation token", () => {
+    const json = '{"segments":[{"text":"remove this"}]}';
+    const revision = transcriptRevision(json);
+    const first = previewTranscriptEdit(json, revision, [
+      { start_seconds: 4, end_seconds: 5 },
+      { start_seconds: 1, end_seconds: 2.5 },
+    ]);
+    const second = previewTranscriptEdit(json, revision, [
+      { start_seconds: 1, end_seconds: 2.5 },
+      { start_seconds: 4, end_seconds: 5 },
+    ]);
+    expect(first).toMatchObject({ deletedSeconds: 2.5, applied: false });
+    expect(first.confirmationToken).toBe(second.confirmationToken);
+    expect(() => previewTranscriptEdit(json, transcriptRevision("different"), [{ start_seconds: 1, end_seconds: 2 }])).toThrow("does not match");
+  });
+});
+
+describe("transcript UXP MCP tools", () => {
+  it("exports native transcript JSON with a stable revision", async () => {
+    const json = '{"segments":[]}';
+    const request = vi.fn().mockResolvedValue({ projectItemId: "clip-1", projectItemName: "Interview", json });
+    const bridge = { request, getState: vi.fn() } as unknown as UxpWebSocketBridge;
+    const result = await getUxpTools(bridge).get_clip_transcript_uxp.handler({ project_item_id: "clip-1" });
+    expect(request).toHaveBeenCalledWith("transcript.export", { projectItemId: "clip-1" });
+    expect(result).toMatchObject({
+      success: true,
+      data: { result: { projectItemId: "clip-1", json, transcriptRevision: transcriptRevision(json) } },
+    });
+  });
+
+  it("maps bounded search arguments to the native transcript command", async () => {
+    const request = vi.fn().mockResolvedValue({ matches: [] });
+    const bridge = { request, getState: vi.fn() } as unknown as UxpWebSocketBridge;
+    await getUxpTools(bridge).search_clip_transcript_uxp.handler({
+      project_item_name: "Interview",
+      query: "launch date",
+      case_sensitive: true,
+      max_results: 10,
+    });
+    expect(request).toHaveBeenCalledWith("transcript.search", {
+      projectItemName: "Interview",
+      query: "launch date",
+      caseSensitive: true,
+      maxResults: 10,
+    });
+  });
+
+  it("re-exports the transcript before producing a revision-locked preview", async () => {
+    const json = '{"segments":[{"text":"cut this"}]}';
+    const request = vi.fn().mockResolvedValue({ projectItemId: "clip-1", projectItemName: "Interview", json });
+    const bridge = { request, getState: vi.fn() } as unknown as UxpWebSocketBridge;
+    const result = await getUxpTools(bridge).preview_transcript_edit_uxp.handler({
+      project_item_id: "clip-1",
+      transcript_revision: transcriptRevision(json),
+      deletions: [{ start_seconds: 2, end_seconds: 4 }],
+    });
+    expect(request).toHaveBeenCalledWith("transcript.export", { projectItemId: "clip-1" });
+    expect(result).toMatchObject({
+      success: true,
+      data: { result: { projectItemId: "clip-1", deletedSeconds: 2, applied: false } },
+    });
+  });
+});

--- a/tests/tools/uxp-tools.test.ts
+++ b/tests/tools/uxp-tools.test.ts
@@ -98,6 +98,9 @@ describe("UXP MCP tools", () => {
           "create_sequence_with_preset_uxp",
           "export_interchange_uxp",
           "get_transcript_languages_uxp",
+          "get_clip_transcript_uxp",
+          "search_clip_transcript_uxp",
+          "preview_transcript_edit_uxp",
           "detect_object_masks_uxp",
           "configure_encoder_uxp",
           "rename_track_uxp",
@@ -109,9 +112,9 @@ describe("UXP MCP tools", () => {
           "export_frame_uxp",
         ]),
       );
-      // The default profile excludes two unsafe-script tools. Six documented
-      // Premiere 26.3 UXP tools raise the connected adapter surface to 293.
-      expect(tools.tools).toHaveLength(293);
+      // The default profile excludes two unsafe-script tools. The native
+      // transcript workflow adds three read-only UXP tools to the catalog.
+      expect(tools.tools).toHaveLength(296);
     } finally {
       await client.close();
       await server.close();

--- a/uxp-plugin/README.md
+++ b/uxp-plugin/README.md
@@ -12,6 +12,13 @@ It also exposes documented Premiere 25.6+ video-transition and transcript workfl
 
 Transition names must come from `transition.video.list`. Transcript targets can be selected in the Project panel or addressed by project-item ID/name. Caption creation, text/timing mutation, and deletion remain explicitly unsupported because Premiere does not document those UXP APIs.
 
+The MCP adapter exposes `transcript.export` as `get_clip_transcript_uxp` and adds a
+SHA-256 revision to the result. `search_clip_transcript_uxp` maps to the existing
+read-only search command. `preview_transcript_edit_uxp` re-exports the transcript,
+rejects stale revisions, validates and merges selected source-time deletion ranges,
+and returns a confirmation token. It never changes the transcript or timeline;
+automatic transcript-to-timeline application remains a live-host validation gate.
+
 ## Premiere 26.3 commands
 
 The following commands use APIs Adobe introduced in Premiere 26.3. They are


### PR DESCRIPTION
## What changed

- expose Premiere's existing native `transcript.export` and `transcript.search` UXP commands as first-class MCP tools
- add a SHA-256 transcript revision so edit selections cannot be applied against a regenerated transcript
- add `preview_transcript_edit_uxp` to validate, sort, add bounded handles to, and merge source-time deletion ranges
- return a deterministic confirmation token while explicitly reporting that no timeline mutation occurred
- classify transcript previewing as read-only inspection and document the live-host boundary
- add unit, adapter, capability, and MCP catalog coverage

## Why

Issue #77 asks to let AI work from the transcript Premiere generates instead of replacing it with Whisper. Adobe documents native transcript export and search, but does not expose a direct operation that turns deleted transcript text into timeline cuts. This PR adds the safe planning foundation without promising an unverified destructive edit.

## User and developer impact

With an authenticated compatible UXP panel, clients can now export and search Premiere's native clip transcript, select explicit source-time ranges, and obtain a revision-locked edit preview. Automatic timeline application remains intentionally withheld until transcript JSON fixtures, source-to-sequence mapping, and the documented reconstruction path are validated in a real Premiere host.

Closes the discovery and planning portion of #77; the issue should remain open for host-verified application.

## Validation

- `npm test` — 30 files, 508 tests passed
- focused transcript, UXP catalog, and capability tests — 4 files, 36 tests passed
- `npm run build` — passed
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- `git diff --check` — passed

## Remaining live-host gate

- capture representative native transcript JSON fixtures from Premiere 25.6 and 26.3
- verify source-time semantics for in-pointed, repeated, speed-changed, reversed, multicam, and nested clips
- implement duplicate-sequence reconstruction with documented UXP actions
- verify every resulting edit boundary before exposing an apply tool
