### PR TITLE
Configure Copilot repository guidance and setup

### DIFF
--- a/.agents/product-marketing.md
+++ b/.agents/product-marketing.md
@@ -22,7 +22,7 @@ Use outcome-led, evidence-bounded language:
 - Keep the recommended Premiere, MCP server, CEP bridge, and media on the same computer.
 - Verify a real host connection with `get_capabilities` and `ping`; packaged compatibility is not proof that every operation works on every Premiere release.
 
-Do not lead with the tool count alone. The 269-tool surface is supporting proof after the visitor understands the first useful outcome.
+Do not lead with the tool count alone. The 279-tool surface is supporting proof after the visitor understands the first useful outcome.
 
 ## Proof and constraints
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,40 @@
+# GitHub Copilot repository instructions
+
+## Project and architecture
+
+- This repository is the TypeScript MCP server for Adobe Premiere Pro. The production path is a local Node.js server communicating with the CEP bridge through private file-based IPC. The UXP bridge is a capability-aware preview for supported Premiere 25.6+ APIs.
+- `src/server.ts` assembles the MCP surface. Tool modules live in `src/tools/`, bridge code in `src/bridge/`, the production CEP extension in `cep-plugin/`, and the preview backend in `uxp-plugin/`.
+- Treat `README.md`, `SECURITY.md`, `CONTRIBUTING.md`, and `RESEARCH.md` as the canonical product, trust-model, contribution, and compatibility references.
+
+## Development workflow
+
+- Use Node.js 24 for repository work; the supported runtime floor is Node.js 20.19.
+- Install deterministically with `npm ci`.
+- Before requesting review, run `npm run check`. For changes that affect coverage-sensitive behavior, also run `npm run test:coverage`.
+- Keep generated build output, credentials, certificates, Premiere project/media files, and local diagnostics out of commits.
+- Make focused changes. Do not rewrite unrelated files or update dependency lockfiles unless the task requires it.
+
+## Implementation rules
+
+- Generated ExtendScript must remain ECMAScript 3 compatible: use `var`, traditional functions and loops, and no arrow functions, `let`, `const`, template literals, or other modern syntax.
+- Escape every user-controlled string embedded in ExtendScript with the existing escaping helpers. Never interpolate raw paths, names, expressions, or prompts into generated scripts.
+- Preserve capability and authority boundaries. Raw scripting tools stay disabled unless the explicit `unsafe-script` capability is enabled.
+- Prefer documented Premiere APIs. QE DOM behavior is experimental and must be described as such.
+- Mutating tools must verify their postconditions. Do not report success from a host API return value alone, and do not silently retry a failed UXP mutation through CEP or QE.
+- Keep tool schemas, descriptions, registrations, structured results, tests, documentation, and reported counts synchronized.
+- Reuse existing helpers and module patterns before introducing new abstractions or dependencies.
+
+## Testing and review expectations
+
+- Add or update tests for behavior changes, failure paths, escaping, validation, authority enforcement, and tool registration.
+- Automated tests and CI prove package behavior only. Claims about Premiere-side compatibility require a real supported Premiere host with the applicable CEP or UXP bridge running.
+- Clearly distinguish `committed`, `verified`, `committed_unverified`, and failed host mutations in user-visible results and documentation.
+- Do not weaken authentication, private temp-directory ownership checks, script-size limits, telemetry privacy, or secret handling.
+- Telemetry must remain bounded to operational metadata. Never collect prompts, arguments, results, tokens, IP addresses, project paths, media names, or person profiles.
+
+## Pull requests
+
+- Explain the user impact and the compatibility boundary.
+- Link the related issue when one exists.
+- Report the exact checks run and whether live Premiere verification was performed.
+- Never claim a release, registry publication, deployment, or host-side validation unless it was directly verified.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,7 @@ Closes #
 |-----------|--------|-------------|
 | | | |
 
-**Total tool count after this PR:** (update if changed from 269)
+**Total tool count after this PR:** (update if changed from 279)
 
 ## Checklist
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,33 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: npm
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build

--- a/RESEARCH.md
+++ b/RESEARCH.md
@@ -11,7 +11,11 @@
 
 ---
 
-## Current Repository Snapshot (2026-07-20)
+## Historical Repository Snapshot (2026-07-20)
+
+This is a dated research snapshot, not the source of truth for current releases or
+tool counts. Use `README.md` and `CHANGELOG.md` for current product and release
+information.
 
 - **Release candidate:** `1.2.0` is integrated on `main`; `package.json`, `package-lock.json`, and
   both CEP extension entries in `cep-plugin/CSXS/manifest.xml` are version-aligned.


### PR DESCRIPTION
## What changed

- add repository-wide Copilot instructions for architecture, security, testing, and live-host verification
- add the recognized Copilot setup workflow with Node.js 24, deterministic dependency installation, and a build check
- update stale 269-tool references to the current 279-tool surface

## Why

Copilot code review was configured to use repository instructions, but the repository did not contain them. Cloud-agent sessions also used the default environment rather than a deterministic project setup.

## Validation

- `npm ci`
- `npm run check` (lint, TypeScript build, 501 tests)
- `git diff --check`

Live Premiere verification is not applicable because this changes repository automation and guidance only.