### PR TITLE
release: v1.8.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "premiere-pro",
       "source": "./claude-plugins/premiere-pro",
       "description": "Inspect, edit, verify, and export local Premiere Pro projects through MCP.",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "category": "creative",
       "tags": ["premiere-pro", "video-editing", "mcp"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-08-01
+
+### Added
+
+- Added three read-only, capability-gated UXP transcript tools: native transcript
+  export, native transcript search, and revision-locked transcript edit previews.
+- Added a deterministic SHA-256 transcript revision and confirmation token so a
+  proposed edit cannot be confused with a regenerated transcript.
+
+### Changed
+
+- Expanded the connected UXP surface from 16 to 19 tools while keeping automatic
+  transcript-to-timeline application unavailable pending real-host validation.
+- Added repository Copilot instructions and a deterministic Node 24 setup workflow.
+
+### Validation
+
+- Automated tests cover transcript range validation, revision locking, capability
+  registration, and the MCP catalog. A real Premiere 25.6 or 26.3 host still must
+  validate transcript semantics before any apply operation is introduced.
+
 ## [1.7.0] - 2026-08-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -29,7 +29,18 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 
 The AI handles the entire workflow through 279 core tools spanning the supported ExtendScript, QE DOM, local media analysis, and safe edit-planning surfaces. A compatible, authenticated UXP panel adds 19 documented, capability-gated workflows without replacing the production CEP bridge.
 
-### What's new in 1.7.0
+### What's new in 1.8.0
+
+- **Native transcript planning:** compatible UXP hosts can export and search the
+  transcript Premiere generated for a clip, then preview a revision-locked set of
+  source-time deletion ranges.
+- **No false edit promise:** previews return a deterministic confirmation token and
+  never modify a clip or timeline. Automated application remains withheld until the
+  documented source-to-sequence reconstruction path passes real-host validation.
+- **19 connected UXP tools:** the capability-gated UXP surface grows from 16 to 19
+  without changing the 279 core-tool surface.
+
+### Previous release: 1.7.0
 
 - **Six documented workflows:** compatible 26.3+ hosts can expose UXP track renaming, subclip creation, stable marker IDs, Source Monitor seeking, transcript presence checks, and AAF export.
 - **Capability first:** a tool is discoverable only with the authenticated local panel; the panel's live `capabilities.get` response—not package metadata—decides whether the current host supports it.
@@ -248,11 +259,11 @@ From a clone of this repository:
 ```bash
 codex plugin marketplace add .
 codex plugin add premiere-pro@premiere-pro-mcp
-npx -y premiere-pro-mcp@1.7.0 --install-cep
+npx -y premiere-pro-mcp@1.8.0 --install-cep
 ```
 
 Restart Premiere Pro and start a new Codex session after installation. The plugin
-launches `premiere-pro-mcp@1.7.0` through `npx`; the separate CEP installation is
+launches `premiere-pro-mcp@1.8.0` through `npx`; the separate CEP installation is
 required because the MCP server communicates with the running Premiere host through
 the local bridge.
 
@@ -272,7 +283,7 @@ For Claude Code, add this repository as a marketplace and install the plugin:
 Then install the Premiere bridge and start a new Claude Code session:
 
 ```bash
-npx -y premiere-pro-mcp@1.7.0 --install-cep
+npx -y premiere-pro-mcp@1.8.0 --install-cep
 ```
 
 The Claude Code package lives in

--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.7.0" ExtensionBundleName="MCP Bridge">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.8.0" ExtensionBundleName="MCP Bridge">
   <ExtensionList>
-    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.7.0"/>
-    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.7.0"/>
+    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.8.0"/>
+    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.8.0"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/cep-plugin/index.html
+++ b/cep-plugin/index.html
@@ -65,7 +65,7 @@
     <section class="update-section" aria-live="polite">
       <div class="update-copy">
         <span class="section-label">Connector updates</span>
-        <strong id="updateTitle">Version 1.7.0</strong>
+        <strong id="updateTitle">Version 1.8.0</strong>
         <span id="updateDetail">Checking for updates…</span>
       </div>
       <button id="btnUpdate" class="button button-update" onclick="handleUpdateClick()" type="button" disabled>

--- a/cep-plugin/updater.cjs
+++ b/cep-plugin/updater.cjs
@@ -7,7 +7,7 @@
 })(this, function () {
   "use strict";
 
-  var CURRENT_VERSION = "1.7.0";
+  var CURRENT_VERSION = "1.8.0";
   var LATEST_RELEASE_API =
     "https://api.github.com/repos/leancoderkavy/premiere-pro-mcp/releases/latest";
   var RELEASES_URL =

--- a/claude-desktop/manifest.json
+++ b/claude-desktop/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": "0.3",
   "name": "premiere-pro-mcp",
   "display_name": "Premiere Pro MCP",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Control a local Adobe Premiere Pro project through MCP.",
   "long_description": "Inspect projects, assemble and modify timelines, manage media, effects, audio and captions, and export deliverables through a local bridge to Adobe Premiere Pro.",
   "author": {

--- a/claude-plugins/premiere-pro/.claude-plugin/plugin.json
+++ b/claude-plugins/premiere-pro/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "premiere-pro",
   "displayName": "Premiere Pro MCP",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Inspect, edit, verify, and export local Adobe Premiere Pro projects through MCP.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/claude-plugins/premiere-pro/.mcp.json
+++ b/claude-plugins/premiere-pro/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "premiere-pro": {
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.7.0"]
+      "args": ["-y", "premiere-pro-mcp@1.8.0"]
     }
   }
 }

--- a/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.7.0 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.8.0 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -4,6 +4,27 @@ import { ArrowLeft, ArrowUpRight, Github, Package } from "lucide-react"
 
 const releases = [
   {
+    version: "1.8.0",
+    date: "2026-08-01",
+    label: "Native transcript edit planning",
+    groups: [
+      {
+        title: "Added",
+        items: [
+          "Three read-only, capability-gated UXP tools for native transcript export, native transcript search, and revision-locked edit previews.",
+          "Deterministic transcript revisions and confirmation tokens so edit plans cannot be applied to a regenerated transcript.",
+        ],
+      },
+      {
+        title: "Changed",
+        items: [
+          "Expanded the connected UXP surface from 16 to 19 tools without changing the 279 core-tool surface.",
+          "Automatic transcript-to-timeline application remains unavailable until a real Premiere host validates documented source-to-sequence reconstruction.",
+        ],
+      },
+    ],
+  },
+  {
     version: "1.7.0",
     date: "2026-08-01",
     label: "Adobe Premiere Pro 26.3 UXP API coverage",
@@ -362,8 +383,8 @@ export default function ChangelogPage() {
             </div>
             <div className="border-l border-purple-400/40 pl-5">
               <p className="text-xs uppercase tracking-[0.18em] text-zinc-600">Latest release</p>
-              <p className="mt-2 font-mono text-2xl text-white">v1.7.0</p>
-              <p className="mt-1 text-sm text-zinc-500">July 31, 2026</p>
+              <p className="mt-2 font-mono text-2xl text-white">v1.8.0</p>
+              <p className="mt-1 text-sm text-zinc-500">August 1, 2026</p>
             </div>
           </div>
         </div>

--- a/landing/app/page.tsx
+++ b/landing/app/page.tsx
@@ -41,7 +41,7 @@ const structuredData = {
       name: "Premiere Pro MCP",
       applicationCategory: "DeveloperApplication",
       operatingSystem: "macOS, Windows",
-      softwareVersion: "1.7.0",
+      softwareVersion: "1.8.0",
       description:
         "Open-source Model Context Protocol server with 279 tools for AI-assisted editing and automation in Adobe Premiere Pro.",
       url: "https://premiere-pro-mcp.com/",

--- a/landing/components/sections/hero.tsx
+++ b/landing/components/sections/hero.tsx
@@ -14,7 +14,7 @@ const navItems = [
 ]
 
 const proofItems = [
-  { icon: Sparkles, title: "v1.7.0", detail: "Current release" },
+  { icon: Sparkles, title: "v1.8.0", detail: "Current release" },
   { icon: Monitor, title: "macOS + Windows", detail: "Apple Silicon + Intel" },
   { icon: ShieldCheck, title: "Local-first", detail: "Your media stays local" },
   { icon: Github, title: "MIT licensed", detail: "Open source" },

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -7,7 +7,7 @@ Documentation: https://premiere-pro-mcp.com/docs/
 Source: https://github.com/leancoderkavy/premiere-pro-mcp
 npm: https://www.npmjs.com/package/premiere-pro-mcp
 License: MIT
-Current release: 1.7.0
+Current release: 1.8.0
 
 ## What it does
 

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Open-source, local-first Model Context Protocol server for AI-assisted editing and automation in Adobe Premiere Pro.
 
-Premiere Pro MCP exposes 279 core structured tools for timeline editing, effects, Lumetri color, keyframes, media management, silence detection, project organization, and export. An authenticated compatible UXP host adds 16 capability-gated tools. Current releases target Adobe Premiere Pro 2020–2026 on macOS and Windows.
+Premiere Pro MCP exposes 279 core structured tools for timeline editing, effects, Lumetri color, keyframes, media management, silence detection, project organization, and export. An authenticated compatible UXP host adds 19 capability-gated tools. Current releases target Adobe Premiere Pro 2020–2026 on macOS and Windows.
 
 ## Canonical resources
 
@@ -24,8 +24,8 @@ The recommended setup runs the MCP server and CEP bridge locally. Project media 
 
 ## Verified facts
 
-- Current project release: 1.7.0.
-- Tool surface: 279 core structured MCP tools, 3 resources, and 4 prompts; 16 additional UXP tools appear while an authenticated panel is connected.
+- Current project release: 1.8.0.
+- Tool surface: 279 core structured MCP tools, 3 resources, and 4 prompts; 19 additional UXP tools appear while an authenticated panel is connected.
 - Supported desktop platforms: Windows and macOS.
 - Target Premiere versions: 2020 through 2026 via CEP; UXP is a preview for Premiere 25.6 and newer.
 - License: MIT.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "premiere-pro-mcp",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Adobe Premiere Pro MCP server with 279 core AI video editing tools and a capability-aware UXP bridge for supported Premiere workflows.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/premiere-pro/.codex-plugin/plugin.json
+++ b/plugins/premiere-pro/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Plan, execute, verify, and export video edits in Adobe Premiere Pro through the Premiere Pro MCP server.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/plugins/premiere-pro/.mcp.json
+++ b/plugins/premiere-pro/.mcp.json
@@ -4,7 +4,7 @@
       "title": "Premiere Pro MCP",
       "description": "Inspect and edit a local Adobe Premiere Pro project through the Premiere Pro MCP bridge.",
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.7.0"]
+      "args": ["-y", "premiere-pro-mcp@1.8.0"]
     }
   }
 }

--- a/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.7.0 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.8.0 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/uxp-plugin/manifest.json
+++ b/uxp-plugin/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.ppmcp.premiere.uxp",
   "name": "Premiere Pro MCP Bridge",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "main": "index.html",
   "host": { "app": "premierepro", "minVersion": "25.6.0" },
   "entrypoints": [


### PR DESCRIPTION
## What changed

- release Premiere Pro MCP 1.8.0
- align package, CEP, UXP, Claude/Codex, landing, and install metadata
- document the native transcript export, search, and revision-locked planning flow
- update the public connected-UXP count from 16 to 19
- include the merged Copilot repository guidance and its corrected historical research provenance

## Why

PRs #84 and #85 are already merged. This isolated release commit is required because repository rules require all changes to main to land through a checked PR.

## Impact

Users installing 1.8.0 receive the new read-only native transcript planning surface. Automatic transcript-to-timeline application remains explicitly unavailable pending real Premiere host validation.

## Validation

- `npm run check` — lint, build, 508 tests passed
- `npm run publish:npm:dry-run` — passed
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- landing `npm run build` — passed
- landing production-only audit — 0 vulnerabilities
- `git diff --check` — passed

Real Premiere 25.6/26.3 host validation remains an open gate.