### PR TITLE
Release v1.9.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "premiere-pro",
       "source": "./claude-plugins/premiere-pro",
       "description": "Inspect, edit, verify, and export local Premiere Pro projects through MCP.",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "category": "creative",
       "tags": ["premiere-pro", "video-editing", "mcp"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-08-02
+
+### Added
+
+- Added a read-only `verify_premiere_connection` tool, human-readable `--doctor`
+  diagnostics, and a privacy-sanitized `--support-bundle` for guided recovery.
+- Added an accessible in-panel Connection Center and native Windows/macOS CEP
+  installer pipelines that require trusted platform signing for production use.
+- Added deterministic direct and Marketplace-channel UXP CCX packaging with
+  explicit Adobe identity and live-host verification gates.
+
+### Changed
+
+- Reworked onboarding around the AI assistant an editor already uses, with the
+  Claude Desktop MCPB route first and npm/JSON configuration under Advanced.
+- Upgraded the Claude Desktop bundle manifest to MCPB v0.4 and stopped emitting
+  an unsupported `.dxt` copy of the same bytes.
+- Registered 280 core tools, exposed 278 under the default profile, and exposed
+  297 tools when the 19 capability-gated UXP tools are connected.
+
+### Validation
+
+- Automated checks cover distribution schemas, deterministic CCX packaging,
+  support-bundle privacy, installer path containment, production signing gates,
+  and connection evidence states. Real Premiere host verification and external
+  Adobe/Anthropic approvals remain separate release gates.
+
 ## [1.8.0] - 2026-08-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -29,7 +29,20 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 
 The AI handles the entire workflow through 280 core tools spanning the supported ExtendScript, QE DOM, local media analysis, safe edit-planning, and connection-verification surfaces. A compatible, authenticated UXP panel adds 19 documented, capability-gated workflows without replacing the production CEP bridge.
 
-### What's new in 1.8.0
+### What's new in 1.9.0
+
+- **Assistant-first setup:** Claude Desktop users start with a validated MCPB
+  bundle, while npm and manual JSON configuration stay under Advanced setup.
+- **Safe connection help:** `verify_premiere_connection`, `--doctor`, the CEP
+  Connection Center, and sanitized support bundles explain exactly what is
+  installed, configured, connected, and live-verified.
+- **Distribution foundations:** MCPB v0.4, deterministic direct/Marketplace CCX
+  packaging, and native Windows/macOS CEP installer pipelines make the supported
+  routes easier to package without overstating signing or Marketplace approval.
+- **Canonical tool surface:** 280 registered tools, 278 in the default profile,
+  and 297 while the 19 capability-gated UXP tools are connected.
+
+### Previous release: 1.8.0
 
 - **Native transcript planning:** compatible UXP hosts can export and search the
   transcript Premiere generated for a clip, then preview a revision-locked set of
@@ -40,7 +53,7 @@ The AI handles the entire workflow through 280 core tools spanning the supported
 - **19 connected UXP tools:** the capability-gated UXP surface grows from 16 to 19
   without changing the 279 core-tool surface.
 
-### Previous release: 1.7.0
+### Earlier release: 1.7.0
 
 - **Six documented workflows:** compatible 26.3+ hosts can expose UXP track renaming, subclip creation, stable marker IDs, Source Monitor seeking, transcript presence checks, and AAF export.
 - **Capability first:** a tool is discoverable only with the authenticated local panel; the panel's live `capabilities.get` response—not package metadata—decides whether the current host supports it.
@@ -60,9 +73,9 @@ The AI handles the entire workflow through 280 core tools spanning the supported
 
 ### Easiest supported path: Claude Desktop
 
-1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.8.0/premiere-pro-mcp-1.8.0.mcpb).
+1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.9.0/premiere-pro-mcp-1.9.0.mcpb).
 2. In Claude Desktop, open **Settings > Extensions > Advanced settings > Install Extension**, select the downloaded bundle, and restart Claude Desktop.
-3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.8.0/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
+3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.9.0/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
 4. Restart Premiere, open a project, then open **Window > Extensions > MCP Bridge**.
 5. In Claude, enter: `Safely check my Premiere connection with verify_premiere_connection. Make no changes.`
 
@@ -286,11 +299,11 @@ From a clone of this repository:
 ```bash
 codex plugin marketplace add .
 codex plugin add premiere-pro@premiere-pro-mcp
-npx -y premiere-pro-mcp@1.8.0 --install-cep
+npx -y premiere-pro-mcp@1.9.0 --install-cep
 ```
 
 Restart Premiere Pro and start a new Codex session after installation. The plugin
-launches `premiere-pro-mcp@1.8.0` through `npx`; the separate CEP installation is
+launches `premiere-pro-mcp@1.9.0` through `npx`; the separate CEP installation is
 required because the MCP server communicates with the running Premiere host through
 the local bridge.
 
@@ -310,7 +323,7 @@ For Claude Code, add this repository as a marketplace and install the plugin:
 Then install the Premiere bridge and start a new Claude Code session:
 
 ```bash
-npx -y premiere-pro-mcp@1.8.0 --install-cep
+npx -y premiere-pro-mcp@1.9.0 --install-cep
 ```
 
 The Claude Code package lives in

--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.8.0" ExtensionBundleName="MCP Bridge">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.9.0" ExtensionBundleName="MCP Bridge">
   <ExtensionList>
-    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.8.0"/>
-    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.8.0"/>
+    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.9.0"/>
+    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.9.0"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/cep-plugin/index.html
+++ b/cep-plugin/index.html
@@ -81,7 +81,7 @@
     <section class="update-section" aria-live="polite">
       <div class="update-copy">
         <span class="section-label">Connector updates</span>
-        <strong id="updateTitle">Version 1.8.0</strong>
+        <strong id="updateTitle">Version 1.9.0</strong>
         <span id="updateDetail">Checking for updates…</span>
       </div>
       <button id="btnUpdate" class="button button-update" onclick="handleUpdateClick()" type="button" disabled>

--- a/cep-plugin/updater.cjs
+++ b/cep-plugin/updater.cjs
@@ -7,7 +7,7 @@
 })(this, function () {
   "use strict";
 
-  var CURRENT_VERSION = "1.8.0";
+  var CURRENT_VERSION = "1.9.0";
   var LATEST_RELEASE_API =
     "https://api.github.com/repos/leancoderkavy/premiere-pro-mcp/releases/latest";
   var RELEASES_URL =

--- a/claude-desktop/manifest.json
+++ b/claude-desktop/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "premiere-pro-mcp",
   "display_name": "Premiere Pro MCP",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Control a local Adobe Premiere Pro project through MCP.",
   "long_description": "Inspect projects, assemble and modify timelines, manage media, effects, audio and captions, and export deliverables through a local bridge to Adobe Premiere Pro.",
   "author": {

--- a/claude-plugins/premiere-pro/.claude-plugin/plugin.json
+++ b/claude-plugins/premiere-pro/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "premiere-pro",
   "displayName": "Premiere Pro MCP",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Inspect, edit, verify, and export local Adobe Premiere Pro projects through MCP.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/claude-plugins/premiere-pro/.mcp.json
+++ b/claude-plugins/premiere-pro/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "premiere-pro": {
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.8.0"]
+      "args": ["-y", "premiere-pro-mcp@1.9.0"]
     }
   }
 }

--- a/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.8.0 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.9.0 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -5,6 +5,27 @@ import { product } from "@/lib/product"
 
 const releases = [
   {
+    version: "1.9.0",
+    date: "2026-08-02",
+    label: "Nontechnical onboarding and safe connection recovery",
+    groups: [
+      {
+        title: "Added",
+        items: [
+          "Read-only connection verification, human-readable doctor diagnostics, sanitized support bundles, and an accessible in-panel Connection Center.",
+          "Deterministic UXP CCX distribution plus native Windows and macOS CEP installer pipelines with fail-closed production signing gates.",
+        ],
+      },
+      {
+        title: "Changed",
+        items: [
+          "Reworked setup around the editor's AI assistant, with Claude Desktop first and npm or manual JSON configuration under Advanced.",
+          "Aligned the catalog at 280 registered tools, 278 under the default profile, and 297 with the 19 capability-gated UXP tools connected.",
+        ],
+      },
+    ],
+  },
+  {
     version: "1.8.0",
     date: "2026-08-01",
     label: "Native transcript edit planning",
@@ -385,7 +406,7 @@ export default function ChangelogPage() {
             <div className="border-l border-purple-400/40 pl-5">
               <p className="text-xs uppercase tracking-[0.18em] text-zinc-600">Latest release</p>
               <p className="mt-2 font-mono text-2xl text-white">v{product.version}</p>
-              <p className="mt-1 text-sm text-zinc-500">August 1, 2026</p>
+              <p className="mt-1 text-sm text-zinc-500">August 2, 2026</p>
             </div>
           </div>
         </div>

--- a/landing/lib/product.ts
+++ b/landing/lib/product.ts
@@ -1,6 +1,6 @@
 export const product = {
   name: "Premiere Pro MCP",
-  version: "1.8.0",
+  version: "1.9.0",
   coreToolCount: 280,
   defaultProfileToolCount: 278,
   connectedUxpToolCount: 297,
@@ -9,10 +9,10 @@ export const product = {
   uxpMinimumVersion: "25.6",
   downloads: {
     claudeBundle:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.8.0/premiere-pro-mcp-1.8.0.mcpb",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.9.0/premiere-pro-mcp-1.9.0.mcpb",
     signedCepConnector:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.8.0/MCPBridgeCEP.zxp",
-    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.8.0",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.9.0/MCPBridgeCEP.zxp",
+    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.9.0",
   },
   links: {
     repository: "https://github.com/leancoderkavy/premiere-pro-mcp",

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -7,7 +7,7 @@ Documentation: https://premiere-pro-mcp.com/docs/
 Source: https://github.com/leancoderkavy/premiere-pro-mcp
 npm: https://www.npmjs.com/package/premiere-pro-mcp
 License: MIT
-Current release: 1.8.0
+Current release: 1.9.0
 
 ## What it does
 

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -24,7 +24,7 @@ The recommended setup runs the MCP server and CEP bridge locally. Project media 
 
 ## Verified facts
 
-- Current project release: 1.8.0.
+- Current project release: 1.9.0.
 - Tool surface: 280 core structured MCP tools are registered; the default profile exposes 278. With an authenticated compatible UXP panel, 19 additional capability-gated tools bring the connected surface to 297. The server also exposes 3 resources and 4 prompts.
 - Supported desktop platforms: Windows and macOS.
 - Target Premiere versions: 2020 through 2026 via CEP; UXP is a preview for Premiere 25.6 and newer.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "premiere-pro-mcp",
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Adobe Premiere Pro MCP server with 280 core AI video editing tools and a capability-aware UXP bridge for supported Premiere workflows.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/premiere-pro/.codex-plugin/plugin.json
+++ b/plugins/premiere-pro/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Plan, execute, verify, and export video edits in Adobe Premiere Pro through the Premiere Pro MCP server.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/plugins/premiere-pro/.mcp.json
+++ b/plugins/premiere-pro/.mcp.json
@@ -4,7 +4,7 @@
       "title": "Premiere Pro MCP",
       "description": "Inspect and edit a local Adobe Premiere Pro project through the Premiere Pro MCP bridge.",
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.8.0"]
+      "args": ["-y", "premiere-pro-mcp@1.9.0"]
     }
   }
 }

--- a/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.8.0 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.9.0 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.8.0",
+  "version": "1.9.0",
   "coreTools": 280,
   "defaultProfileTools": 278,
   "uxpAdditionalTools": 19,

--- a/uxp-plugin/manifest.json
+++ b/uxp-plugin/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.ppmcp.premiere.uxp",
   "name": "Premiere Pro MCP Bridge",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "main": "index.html",
   "host": { "app": "premierepro", "minVersion": "25.6.0" },
   "entrypoints": [


### PR DESCRIPTION
## Release v1.9.0

Publishes the nontechnical onboarding, safe connection diagnostics, MCPB/CCX distribution modernization, and native connector installer foundations merged in #87.

## Release surface

- 280 registered core tools
- 278 tools under the default profile
- 297 tools with 19 capability-gated UXP tools connected
- MCPB manifest v0.4
- deterministic direct CCX
- signed CEP ZXP in npm/GitHub release workflow

## Validation

- 33 test files / 522 tests
- release metadata contract
- MCPB and CCX build/validation
- npm pack dry run with signed ZXP
- Windows self-contained installer build
- landing lint/build
- full and production landing audits: zero vulnerabilities

Live Premiere installation, trusted MCPB/platform signing, and Adobe/Anthropic directory approval remain external evidence gates.