### PR TITLE
Add production HTTP security headers

### DIFF
--- a/src/http-security.ts
+++ b/src/http-security.ts
@@ -1,0 +1,30 @@
+import type http from "node:http";
+
+export const HTTP_SECURITY_HEADERS = Object.freeze({
+  "Content-Security-Policy": [
+    "default-src 'self'",
+    "base-uri 'self'",
+    "frame-ancestors 'none'",
+    "object-src 'none'",
+    "form-action 'self'",
+    "img-src 'self' data: https:",
+    "media-src 'self'",
+    "font-src 'self'",
+    "style-src 'self' 'unsafe-inline'",
+    "script-src 'self' 'unsafe-inline' https://www.googletagmanager.com",
+    "connect-src 'self' https://www.google-analytics.com https://www.googletagmanager.com https://us.i.posthog.com https://*.posthog.com",
+    "upgrade-insecure-requests",
+  ].join("; "),
+  "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+  "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "Permissions-Policy": "camera=(), microphone=(), geolocation=()",
+  "Cross-Origin-Opener-Policy": "same-origin",
+});
+
+export function applyHttpSecurityHeaders(res: http.ServerResponse): void {
+  for (const [name, value] of Object.entries(HTTP_SECURITY_HEADERS)) {
+    res.setHeader(name, value);
+  }
+}

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -31,6 +31,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { createServer } from "./server.js";
 import { cleanupTempDir, getTempDir } from "./bridge/file-bridge.js";
 import { getTelemetry } from "./telemetry.js";
+import { applyHttpSecurityHeaders } from "./http-security.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const LANDING_DIR = path.resolve(__dirname, "../landing-dist");
@@ -118,6 +119,8 @@ cleanupTempDir(bridgeOptions);
 
 // Each request gets its own transport+server instance (stateless per-request model)
 const httpServer = http.createServer(async (req, res) => {
+  applyHttpSecurityHeaders(res);
+
   // Health check
   if (req.method === "GET" && req.url === "/health") {
     res.writeHead(200, { "Content-Type": "application/json" });

--- a/tests/http-security.test.ts
+++ b/tests/http-security.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { applyHttpSecurityHeaders, HTTP_SECURITY_HEADERS } from "../src/http-security.js";
+
+describe("HTTP security headers", () => {
+  it("sets a restrictive baseline on every response", () => {
+    const setHeader = vi.fn();
+    applyHttpSecurityHeaders({ setHeader } as never);
+
+    expect(setHeader).toHaveBeenCalledWith("X-Content-Type-Options", "nosniff");
+    expect(setHeader).toHaveBeenCalledWith("X-Frame-Options", "DENY");
+    expect(setHeader).toHaveBeenCalledWith(
+      "Strict-Transport-Security",
+      "max-age=31536000; includeSubDomains",
+    );
+    expect(setHeader).toHaveBeenCalledWith(
+      "Permissions-Policy",
+      "camera=(), microphone=(), geolocation=()",
+    );
+  });
+
+  it("blocks framing, plugins, and unlisted network destinations", () => {
+    const policy = HTTP_SECURITY_HEADERS["Content-Security-Policy"];
+    expect(policy).toContain("frame-ancestors 'none'");
+    expect(policy).toContain("object-src 'none'");
+    expect(policy).toContain("connect-src 'self'");
+    expect(policy).not.toContain("connect-src *");
+  });
+});


### PR DESCRIPTION
Production verification after v1.9.0 found that landing and health responses did not emit baseline browser security headers.

This adds CSP, HSTS, nosniff, frame denial, referrer policy, permissions policy, and cross-origin opener policy to every HTTP response. CSP permits only the current static app, Google Analytics loader/collection hosts, and the bounded PostHog host while blocking framing and plugins.

Validation: 34 test files / 524 tests, including focused header-policy coverage. This PR is the corrective production pass after the v1.9.0 deployment.