### PR TITLE
Release v1.9.1 security patch

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "premiere-pro",
       "source": "./claude-plugins/premiere-pro",
       "description": "Inspect, edit, verify, and export local Premiere Pro projects through MCP.",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "category": "creative",
       "tags": ["premiere-pro", "video-editing", "mcp"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.9.1] - 2026-08-02
+
+### Security
+
+- Added a production HTTP header baseline for the landing site, health route,
+  and remote MCP responses: CSP, HSTS, MIME sniffing protection, frame denial,
+  referrer and permissions policies, and cross-origin opener isolation.
+- Restricted the browser connection policy to the application, configured
+  analytics endpoints, and the bounded PostHog host.
+
 ## [1.9.0] - 2026-08-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 
 The AI handles the entire workflow through 280 core tools spanning the supported ExtendScript, QE DOM, local media analysis, safe edit-planning, and connection-verification surfaces. A compatible, authenticated UXP panel adds 19 documented, capability-gated workflows without replacing the production CEP bridge.
 
-### What's new in 1.9.0
+### What's new in 1.9.1
+
+- **Production browser hardening:** every HTTP response now includes CSP, HSTS,
+  MIME sniffing protection, frame denial, bounded permissions, and explicit
+  referrer and cross-origin policies.
+
+### Previous release: 1.9.0
 
 - **Assistant-first setup:** Claude Desktop users start with a validated MCPB
   bundle, while npm and manual JSON configuration stay under Advanced setup.
@@ -73,9 +79,9 @@ The AI handles the entire workflow through 280 core tools spanning the supported
 
 ### Easiest supported path: Claude Desktop
 
-1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.9.0/premiere-pro-mcp-1.9.0.mcpb).
+1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.9.1/premiere-pro-mcp-1.9.1.mcpb).
 2. In Claude Desktop, open **Settings > Extensions > Advanced settings > Install Extension**, select the downloaded bundle, and restart Claude Desktop.
-3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.9.0/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
+3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.9.1/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
 4. Restart Premiere, open a project, then open **Window > Extensions > MCP Bridge**.
 5. In Claude, enter: `Safely check my Premiere connection with verify_premiere_connection. Make no changes.`
 
@@ -299,11 +305,11 @@ From a clone of this repository:
 ```bash
 codex plugin marketplace add .
 codex plugin add premiere-pro@premiere-pro-mcp
-npx -y premiere-pro-mcp@1.9.0 --install-cep
+npx -y premiere-pro-mcp@1.9.1 --install-cep
 ```
 
 Restart Premiere Pro and start a new Codex session after installation. The plugin
-launches `premiere-pro-mcp@1.9.0` through `npx`; the separate CEP installation is
+launches `premiere-pro-mcp@1.9.1` through `npx`; the separate CEP installation is
 required because the MCP server communicates with the running Premiere host through
 the local bridge.
 
@@ -323,7 +329,7 @@ For Claude Code, add this repository as a marketplace and install the plugin:
 Then install the Premiere bridge and start a new Claude Code session:
 
 ```bash
-npx -y premiere-pro-mcp@1.9.0 --install-cep
+npx -y premiere-pro-mcp@1.9.1 --install-cep
 ```
 
 The Claude Code package lives in

--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.9.0" ExtensionBundleName="MCP Bridge">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.9.1" ExtensionBundleName="MCP Bridge">
   <ExtensionList>
-    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.9.0"/>
-    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.9.0"/>
+    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.9.1"/>
+    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.9.1"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/cep-plugin/index.html
+++ b/cep-plugin/index.html
@@ -81,7 +81,7 @@
     <section class="update-section" aria-live="polite">
       <div class="update-copy">
         <span class="section-label">Connector updates</span>
-        <strong id="updateTitle">Version 1.9.0</strong>
+        <strong id="updateTitle">Version 1.9.1</strong>
         <span id="updateDetail">Checking for updates…</span>
       </div>
       <button id="btnUpdate" class="button button-update" onclick="handleUpdateClick()" type="button" disabled>

--- a/cep-plugin/updater.cjs
+++ b/cep-plugin/updater.cjs
@@ -7,7 +7,7 @@
 })(this, function () {
   "use strict";
 
-  var CURRENT_VERSION = "1.9.0";
+  var CURRENT_VERSION = "1.9.1";
   var LATEST_RELEASE_API =
     "https://api.github.com/repos/leancoderkavy/premiere-pro-mcp/releases/latest";
   var RELEASES_URL =

--- a/claude-desktop/manifest.json
+++ b/claude-desktop/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "premiere-pro-mcp",
   "display_name": "Premiere Pro MCP",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Control a local Adobe Premiere Pro project through MCP.",
   "long_description": "Inspect projects, assemble and modify timelines, manage media, effects, audio and captions, and export deliverables through a local bridge to Adobe Premiere Pro.",
   "author": {

--- a/claude-plugins/premiere-pro/.claude-plugin/plugin.json
+++ b/claude-plugins/premiere-pro/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "premiere-pro",
   "displayName": "Premiere Pro MCP",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Inspect, edit, verify, and export local Adobe Premiere Pro projects through MCP.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/claude-plugins/premiere-pro/.mcp.json
+++ b/claude-plugins/premiere-pro/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "premiere-pro": {
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.9.0"]
+      "args": ["-y", "premiere-pro-mcp@1.9.1"]
     }
   }
 }

--- a/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.9.0 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.9.1 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -5,6 +5,20 @@ import { product } from "@/lib/product"
 
 const releases = [
   {
+    version: "1.9.1",
+    date: "2026-08-02",
+    label: "Production HTTP security headers",
+    groups: [
+      {
+        title: "Security",
+        items: [
+          "Added CSP, HSTS, MIME sniffing protection, frame denial, bounded permissions, and explicit referrer and cross-origin policies to every HTTP response.",
+          "Restricted browser network destinations to the application and configured analytics endpoints.",
+        ],
+      },
+    ],
+  },
+  {
     version: "1.9.0",
     date: "2026-08-02",
     label: "Nontechnical onboarding and safe connection recovery",

--- a/landing/lib/product.ts
+++ b/landing/lib/product.ts
@@ -1,6 +1,6 @@
 export const product = {
   name: "Premiere Pro MCP",
-  version: "1.9.0",
+  version: "1.9.1",
   coreToolCount: 280,
   defaultProfileToolCount: 278,
   connectedUxpToolCount: 297,
@@ -9,10 +9,10 @@ export const product = {
   uxpMinimumVersion: "25.6",
   downloads: {
     claudeBundle:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.9.0/premiere-pro-mcp-1.9.0.mcpb",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.9.1/premiere-pro-mcp-1.9.1.mcpb",
     signedCepConnector:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.9.0/MCPBridgeCEP.zxp",
-    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.9.0",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.9.1/MCPBridgeCEP.zxp",
+    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.9.1",
   },
   links: {
     repository: "https://github.com/leancoderkavy/premiere-pro-mcp",

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -7,7 +7,7 @@ Documentation: https://premiere-pro-mcp.com/docs/
 Source: https://github.com/leancoderkavy/premiere-pro-mcp
 npm: https://www.npmjs.com/package/premiere-pro-mcp
 License: MIT
-Current release: 1.9.0
+Current release: 1.9.1
 
 ## What it does
 

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -24,7 +24,7 @@ The recommended setup runs the MCP server and CEP bridge locally. Project media 
 
 ## Verified facts
 
-- Current project release: 1.9.0.
+- Current project release: 1.9.1.
 - Tool surface: 280 core structured MCP tools are registered; the default profile exposes 278. With an authenticated compatible UXP panel, 19 additional capability-gated tools bring the connected surface to 297. The server also exposes 3 resources and 4 prompts.
 - Supported desktop platforms: Windows and macOS.
 - Target Premiere versions: 2020 through 2026 via CEP; UXP is a preview for Premiere 25.6 and newer.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "premiere-pro-mcp",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Adobe Premiere Pro MCP server with 280 core AI video editing tools and a capability-aware UXP bridge for supported Premiere workflows.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/premiere-pro/.codex-plugin/plugin.json
+++ b/plugins/premiere-pro/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Plan, execute, verify, and export video edits in Adobe Premiere Pro through the Premiere Pro MCP server.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/plugins/premiere-pro/.mcp.json
+++ b/plugins/premiere-pro/.mcp.json
@@ -4,7 +4,7 @@
       "title": "Premiere Pro MCP",
       "description": "Inspect and edit a local Adobe Premiere Pro project through the Premiere Pro MCP bridge.",
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.9.0"]
+      "args": ["-y", "premiere-pro-mcp@1.9.1"]
     }
   }
 }

--- a/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.9.0 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.9.1 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.9.0",
+  "version": "1.9.1",
   "coreTools": 280,
   "defaultProfileTools": 278,
   "uxpAdditionalTools": 19,

--- a/uxp-plugin/manifest.json
+++ b/uxp-plugin/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.ppmcp.premiere.uxp",
   "name": "Premiere Pro MCP Bridge",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "main": "index.html",
   "host": { "app": "premierepro", "minVersion": "25.6.0" },
   "entrypoints": [


### PR DESCRIPTION
Publishes the production HTTP security-header correction from #89 to npm and the distributable artifacts.

Validation:
- 34 test files / 524 tests
- release metadata contract
- MCPB, direct CCX, and signed ZXP builds
- npm publication dry run including `http-security`
- landing lint/build and zero production audit findings
- live Fly deployment already verified CSP, HSTS, nosniff, frame denial, referrer, permissions, and COOP headers