### PR TITLE
fix(uxp): harden protocol replay safety

### DIFF
--- a/tests/uxp/advanced-workflows.test.ts
+++ b/tests/uxp/advanced-workflows.test.ts
@@ -268,7 +268,7 @@ function advancedHost() {
   return {
     registry: Commands.createCommandRegistry({ ppro, Protocol, workspace }),
     project, ppro, workspace, markers, markerValues, root, bin, clip,
-    settingsState, parameterState, trackState, editor, manager,
+    sequence, settingsState, parameterState, trackState, editor, manager,
   };
 }
 
@@ -448,6 +448,44 @@ describe("advanced stable Premiere UXP workflows", () => {
     await expect(value.registry.dispatch("sequences.delete", { confirmNonUndoable: true }))
       .rejects.toMatchObject({ code: "UXP_PROJECT_TOO_LARGE" });
     expect(value.project.deleteSequence).not.toHaveBeenCalled();
+  });
+
+  it("rejects bounded collection additions before starting a host mutation", async () => {
+    const markerValue = advancedHost();
+    markerValue.markers.getMarkers.mockReturnValue(Array.from({ length: 2048 }, () => markerValue.markerValues[0]));
+    await expect(markerValue.registry.dispatch("markers.add", {
+      name: "Over capacity", operationId: "marker-capacity",
+    })).rejects.toMatchObject({ code: "UXP_PROJECT_TOO_LARGE" });
+    expect(markerValue.markers.createAddMarkerAction).not.toHaveBeenCalled();
+    expect(markerValue.project.lockedAccess).not.toHaveBeenCalled();
+
+    const binValue = advancedHost();
+    binValue.bin.children = Array.from({ length: 1024 }, () => binValue.clip);
+    await expect(binValue.registry.dispatch("bins.create", {
+      parentBinId: "bin-1", name: "Over capacity", operationId: "bin-capacity",
+    })).rejects.toMatchObject({ code: "UXP_PROJECT_TOO_LARGE" });
+    expect(binValue.bin.createBinAction).not.toHaveBeenCalled();
+    expect(binValue.project.lockedAccess).not.toHaveBeenCalled();
+
+    const smartBinValue = advancedHost();
+    smartBinValue.bin.children = Array.from({ length: 1024 }, () => smartBinValue.clip);
+    await expect(smartBinValue.registry.dispatch("bins.createSmart", {
+      parentBinId: "bin-1", name: "Over capacity", searchQuery: "label:red",
+      operationId: "smart-bin-capacity",
+    })).rejects.toMatchObject({ code: "UXP_PROJECT_TOO_LARGE" });
+    expect(smartBinValue.bin.createSmartBinAction).not.toHaveBeenCalled();
+    expect(smartBinValue.project.lockedAccess).not.toHaveBeenCalled();
+
+    const sequenceValue = advancedHost();
+    sequenceValue.project.getSequences.mockResolvedValue(Array.from({ length: 1024 }, (_, index) => ({
+      guid: `sequence-${index + 1}`,
+      name: `Sequence ${index + 1}`,
+    })));
+    await expect(sequenceValue.registry.dispatch("sequences.clone", {
+      operationId: "sequence-capacity",
+    })).rejects.toMatchObject({ code: "UXP_PROJECT_TOO_LARGE" });
+    expect(sequenceValue.sequence.createCloneAction).not.toHaveBeenCalled();
+    expect(sequenceValue.project.lockedAccess).not.toHaveBeenCalled();
   });
 
   it("clones sequences with identity readback and gates AME writes on explicit confirmation", async () => {

--- a/tests/uxp/advanced-workflows.test.ts
+++ b/tests/uxp/advanced-workflows.test.ts
@@ -268,7 +268,7 @@ function advancedHost() {
   return {
     registry: Commands.createCommandRegistry({ ppro, Protocol, workspace }),
     project, ppro, workspace, markers, markerValues, root, bin, clip,
-    sequence, settingsState, parameterState, trackState, editor, manager,
+    sequence, sequences, settingsState, parameterState, trackState, editor, manager,
   };
 }
 
@@ -486,6 +486,48 @@ describe("advanced stable Premiere UXP workflows", () => {
     })).rejects.toMatchObject({ code: "UXP_PROJECT_TOO_LARGE" });
     expect(sequenceValue.sequence.createCloneAction).not.toHaveBeenCalled();
     expect(sequenceValue.project.lockedAccess).not.toHaveBeenCalled();
+  });
+
+  it("serializes distinct append operations against each target capacity", async () => {
+    const markerValue = advancedHost();
+    markerValue.markerValues.push(...Array.from({ length: 2046 }, () => markerValue.markerValues[0]));
+    const markerResults = await Promise.allSettled([
+      markerValue.registry.dispatch("markers.add", { name: "First", operationId: "marker-first" }),
+      markerValue.registry.dispatch("markers.add", { name: "Second", operationId: "marker-second" }),
+    ]);
+    expect(markerResults.map((result) => result.status).sort()).toEqual(["fulfilled", "rejected"]);
+    expect(markerResults.find((result) => result.status === "rejected")).toMatchObject({ reason: { code: "UXP_PROJECT_TOO_LARGE" } });
+    expect(markerValue.markers.createAddMarkerAction).toHaveBeenCalledOnce();
+    expect(markerValue.markerValues).toHaveLength(2048);
+
+    const binValue = advancedHost();
+    binValue.bin.children = Array.from({ length: 1023 }, () => binValue.clip);
+    const binResults = await Promise.allSettled([
+      binValue.registry.dispatch("bins.create", {
+        parentBinId: "bin-1", name: "Regular", operationId: "bin-first",
+      }),
+      binValue.registry.dispatch("bins.createSmart", {
+        parentBinId: "bin-1", name: "Smart", searchQuery: "label:red", operationId: "bin-second",
+      }),
+    ]);
+    expect(binResults.map((result) => result.status).sort()).toEqual(["fulfilled", "rejected"]);
+    expect(binResults.find((result) => result.status === "rejected")).toMatchObject({ reason: { code: "UXP_PROJECT_TOO_LARGE" } });
+    expect((binValue.bin.createBinAction?.mock.calls.length || 0) + (binValue.bin.createSmartBinAction?.mock.calls.length || 0)).toBe(1);
+    expect(binValue.bin.children).toHaveLength(1024);
+
+    const sequenceValue = advancedHost();
+    sequenceValue.sequences.push(...Array.from({ length: 1022 }, (_, index) => ({
+      guid: `existing-sequence-${index}`,
+      name: `Existing Sequence ${index}`,
+    })));
+    const sequenceResults = await Promise.allSettled([
+      sequenceValue.registry.dispatch("sequences.clone", { operationId: "sequence-first" }),
+      sequenceValue.registry.dispatch("sequences.clone", { operationId: "sequence-second" }),
+    ]);
+    expect(sequenceResults.map((result) => result.status).sort()).toEqual(["fulfilled", "rejected"]);
+    expect(sequenceResults.find((result) => result.status === "rejected")).toMatchObject({ reason: { code: "UXP_PROJECT_TOO_LARGE" } });
+    expect(sequenceValue.sequence.createCloneAction).toHaveBeenCalledOnce();
+    expect(sequenceValue.sequences).toHaveLength(1024);
   });
 
   it("clones sequences with identity readback and gates AME writes on explicit confirmation", async () => {

--- a/tests/uxp/commands.test.ts
+++ b/tests/uxp/commands.test.ts
@@ -124,6 +124,26 @@ describe("UXP command registry", () => {
     expect(value.project.save).toHaveBeenCalledOnce();
   });
 
+  it("coalesces concurrent mutations with the same operation id", async () => {
+    const value = host();
+    let releaseSave: (saved: boolean) => void = () => undefined;
+    value.project.save.mockReturnValue(new Promise<boolean>((resolve) => { releaseSave = resolve; }));
+    const args = { operationId: "save-concurrent" };
+
+    const first = value.registry.dispatch("project.save", args);
+    const second = value.registry.dispatch("project.save", args);
+    await vi.waitFor(() => expect(value.project.save).toHaveBeenCalledOnce());
+    releaseSave(true);
+
+    const results = await Promise.all([first, second]);
+    expect(results).toEqual(expect.arrayContaining([
+      expect.objectContaining({ saved: true, operationId: "save-concurrent" }),
+      expect.objectContaining({ saved: true, operationId: "save-concurrent", replayed: true }),
+    ]));
+    expect(results.filter((result) => result.replayed === true)).toHaveLength(1);
+    expect(value.project.save).toHaveBeenCalledOnce();
+  });
+
   it("exports supported interchange formats and configures AME", async () => {
     const value = host();
     await expect(value.registry.dispatch("interchange.export", {

--- a/tests/uxp/commands.test.ts
+++ b/tests/uxp/commands.test.ts
@@ -144,6 +144,58 @@ describe("UXP command registry", () => {
     expect(value.project.save).toHaveBeenCalledOnce();
   });
 
+  it("shares concurrent mutation failures and releases the operation id for retry", async () => {
+    const value = host();
+    let rejectSave: (error: Error) => void = () => undefined;
+    value.project.save
+      .mockReturnValueOnce(new Promise<boolean>((_resolve, reject) => { rejectSave = reject; }))
+      .mockResolvedValueOnce(true);
+    const args = { operationId: "save-retry" };
+
+    const first = value.registry.dispatch("project.save", args);
+    const second = value.registry.dispatch("project.save", args);
+    await vi.waitFor(() => expect(value.project.save).toHaveBeenCalledOnce());
+    rejectSave(new Error("save failed"));
+
+    const failures = await Promise.allSettled([first, second]);
+    expect(failures).toEqual([
+      expect.objectContaining({ status: "rejected", reason: expect.objectContaining({ message: "save failed" }) }),
+      expect.objectContaining({ status: "rejected", reason: expect.objectContaining({ message: "save failed" }) }),
+    ]);
+    await expect(value.registry.dispatch("project.save", args)).resolves.toMatchObject({
+      saved: true, operationId: "save-retry",
+    });
+    expect(value.project.save).toHaveBeenCalledTimes(2);
+  });
+
+  it("applies replay protection to the injected transcript import mutator", async () => {
+    const value = host();
+    const importTranscript = vi.fn(async () => ({ imported: true }));
+    const registry = Commands.createCommandRegistry({
+      ppro: value.ppro,
+      Protocol,
+      transcriptImportHandler: importTranscript,
+      transcriptImportProbe: () => true,
+    });
+    const args = { json: "{}", operationId: "transcript-import" };
+
+    const results = await Promise.all([
+      registry.dispatch("transcript.import", args),
+      registry.dispatch("transcript.import", args),
+    ]);
+    expect(results).toEqual(expect.arrayContaining([
+      expect.objectContaining({ imported: true, operationId: "transcript-import" }),
+      expect.objectContaining({ imported: true, operationId: "transcript-import", replayed: true }),
+    ]));
+    await expect(registry.dispatch("transcript.import", args)).resolves.toMatchObject({
+      imported: true, replayed: true,
+    });
+    expect(importTranscript).toHaveBeenCalledOnce();
+    await expect(registry.capabilities()).resolves.toMatchObject({
+      commands: { "transcript.import": { supported: true, destructive: true, undoable: true } },
+    });
+  });
+
   it("exports supported interchange formats and configures AME", async () => {
     const value = host();
     await expect(value.registry.dispatch("interchange.export", {

--- a/tests/uxp/protocol.test.ts
+++ b/tests/uxp/protocol.test.ts
@@ -54,6 +54,11 @@ describe("UXP bridge protocol", () => {
     expect(validation).toBeGreaterThan(dispatchStart);
     expect(completion).toBeGreaterThan(validation);
   });
+  it("routes transcript imports through the replay-aware command registry", () => {
+    const panel = readFileSync(new URL("../../uxp-plugin/index.cjs", import.meta.url), "utf8");
+    expect(panel).toContain("transcriptImportHandler: importTranscript");
+    expect(panel).not.toContain('cmd.command === "transcript.import") result = await importTranscript');
+  });
   it("prevents filename path traversal", () => {
     expect(protocol.safeFilename("shot-01.png")).toBe("shot-01.png");
     expect(() => protocol.safeFilename("../shot.png")).toThrow();

--- a/tests/uxp/protocol.test.ts
+++ b/tests/uxp/protocol.test.ts
@@ -13,11 +13,24 @@ describe("UXP bridge protocol", () => {
   it("parses commands with safe defaults", () => {
     expect(protocol.parseCommand('{"type":"command","command":"state.get"}')).toEqual({ requestId: null, command: "state.get", args: {} });
   });
+  it.each([
+    "projectSelection.views",
+    "bins.createSmart",
+    "sequenceSettings.update",
+    "parameters.keyframeAdd",
+    "timeline.cloneSelection",
+    "sequences.createFromMedia",
+    "encoder.projectItem",
+  ])("accepts registered lower-camel command segments: %s", (command) => {
+    expect(protocol.parseCommand({ type: "command", command })).toMatchObject({ command });
+  });
   it("rejects malformed commands", () => expect(() => protocol.parseCommand({ type: "event" })).toThrow("Invalid UXP bridge command"));
   it("rejects invalid protocol versions and argument shapes", () => {
     expect(() => protocol.parseCommand({ protocolVersion: 1, type: "command", command: "state.get" })).toThrow("Unsupported UXP protocol version");
     expect(() => protocol.parseCommand({ type: "command", command: "state.get", args: [] })).toThrow("args must be an object");
     expect(() => protocol.parseCommand({ type: "command", command: "../state" })).toThrow("Invalid UXP bridge command");
+    expect(() => protocol.parseCommand({ type: "command", command: "ProjectSelection.views" })).toThrow("Invalid UXP bridge command");
+    expect(() => protocol.parseCommand({ type: "command", command: "project_selection.views" })).toThrow("Invalid UXP bridge command");
   });
   it("bounds request identifiers and command size", () => {
     expect(() => protocol.parseCommand({ type: "command", requestId: "", command: "state.get" })).toThrow("requestId");

--- a/uxp-plugin/advanced-workflows.cjs
+++ b/uxp-plugin/advanced-workflows.cjs
@@ -15,6 +15,7 @@
 
   function createAdvancedWorkflowDefinitions(deps) {
     const ppro = deps.ppro, Protocol = deps.Protocol, workspace = deps.workspace;
+    const appendLocks = new Map();
     const definitions = {
       "projectSelection.views": { readOnly: true, minHostVersion: "25.6.0", probe: canUseProjectViews, handler: listProjectViews },
       "projectSelection.inspect": { readOnly: true, minHostVersion: "25.6.0", probe: canUseProjectViews, handler: inspectProjectSelection },
@@ -305,13 +306,17 @@
       const context = await markerContext(args, true), name = boundedString(args.name, "name", 255);
       const markerType = args.markerType == null ? String(ppro.Marker && ppro.Marker.MARKER_TYPE_COMMENT || "Comment") : boundedString(args.markerType, "markerType", 128);
       const start = tick(finiteNumber(args.startSeconds == null ? 0 : args.startSeconds, "startSeconds", 0, 86400), "startSeconds"), duration = tick(finiteNumber(args.durationSeconds == null ? 0 : args.durationSeconds, "durationSeconds", 0, 86400), "durationSeconds");
-      const comments = args.comments == null ? "" : boundedStringAllowEmpty(args.comments, "comments", 4000), before = await markerList(context.collection);
-      assertAppendCapacity(before, MAX_MARKERS, "Marker creation");
-      context.project.lockedAccess(() => {
-        commitActions(context.project, "Add marker", [context.collection.createAddMarkerAction(name, markerType, start, duration, comments)]);
+      const comments = args.comments == null ? "" : boundedStringAllowEmpty(args.comments, "comments", 4000);
+      const ownerId = context.ownerType === "sequence" ? guidString(context.owner && context.owner.guid) : await projectItemId(context.owner);
+      return withAppendLock(appendLockKey(context.project, "markers", context.ownerType + ":" + ownerId), async () => {
+        const before = await markerList(context.collection);
+        assertAppendCapacity(before, MAX_MARKERS, "Marker creation");
+        context.project.lockedAccess(() => {
+          commitActions(context.project, "Add marker", [context.collection.createAddMarkerAction(name, markerType, start, duration, comments)]);
+        });
+        const after = await markerList(context.collection), added = after.filter((value) => !before.some((old) => old.guid === value.guid));
+        return mutationResult(added.length === 1, { added: true, marker: added[0] || null, beforeCount: before.length, afterCount: after.length }, "marker_guid_readback", "Add marker");
       });
-      const after = await markerList(context.collection), added = after.filter((value) => !before.some((old) => old.guid === value.guid));
-      return mutationResult(added.length === 1, { added: true, marker: added[0] || null, beforeCount: before.length, afterCount: after.length }, "marker_guid_readback", "Add marker");
     }
 
     async function updateMarker(args) {
@@ -363,25 +368,31 @@
 
     async function createBin(args) {
       assertObject(args); assertOnlyKeys(args, ["parentBinId", "name", "makeUnique", "operationId"]);
-      const project = await activeProject(true), folder = await resolveFolder(project, args.parentBinId, "parentBinId"), name = boundedString(args.name, "name", 255), before = await binChildren(folder);
+      const project = await activeProject(true), folder = await resolveFolder(project, args.parentBinId, "parentBinId"), name = boundedString(args.name, "name", 255);
       const makeUnique = optionalBoolean(args.makeUnique, true, "makeUnique");
-      assertAppendCapacity(before, MAX_BIN_CHILDREN, "Project-bin creation");
-      project.lockedAccess(() => {
-        commitActions(project, "Create project bin", [folder.createBinAction(name, makeUnique)]);
+      return withAppendLock(appendLockKey(project, "bin", await projectItemId(folder)), async () => {
+        const before = await binChildren(folder);
+        assertAppendCapacity(before, MAX_BIN_CHILDREN, "Project-bin creation");
+        project.lockedAccess(() => {
+          commitActions(project, "Create project bin", [folder.createBinAction(name, makeUnique)]);
+        });
+        const after = await binChildren(folder), added = after.filter((value) => !before.some((old) => old.id === value.id));
+        return mutationResult(added.length === 1, { created: true, item: added[0] || null }, "bin_child_id_readback", "Create project bin");
       });
-      const after = await binChildren(folder), added = after.filter((value) => !before.some((old) => old.id === value.id));
-      return mutationResult(added.length === 1, { created: true, item: added[0] || null }, "bin_child_id_readback", "Create project bin");
     }
 
     async function createSmartBin(args) {
       assertObject(args); assertOnlyKeys(args, ["parentBinId", "name", "searchQuery", "operationId"]);
-      const project = await activeProject(true), folder = await resolveFolder(project, args.parentBinId, "parentBinId"), name = boundedString(args.name, "name", 255), query = boundedString(args.searchQuery, "searchQuery", 4000), before = await binChildren(folder);
-      assertAppendCapacity(before, MAX_BIN_CHILDREN, "Smart-bin creation");
-      project.lockedAccess(() => {
-        commitActions(project, "Create smart bin", [folder.createSmartBinAction(name, query)]);
+      const project = await activeProject(true), folder = await resolveFolder(project, args.parentBinId, "parentBinId"), name = boundedString(args.name, "name", 255), query = boundedString(args.searchQuery, "searchQuery", 4000);
+      return withAppendLock(appendLockKey(project, "bin", await projectItemId(folder)), async () => {
+        const before = await binChildren(folder);
+        assertAppendCapacity(before, MAX_BIN_CHILDREN, "Smart-bin creation");
+        project.lockedAccess(() => {
+          commitActions(project, "Create smart bin", [folder.createSmartBinAction(name, query)]);
+        });
+        const after = await binChildren(folder), added = after.filter((value) => !before.some((old) => old.id === value.id));
+        return mutationResult(added.length === 1, { created: true, item: added[0] || null }, "bin_child_id_readback", "Create smart bin");
       });
-      const after = await binChildren(folder), added = after.filter((value) => !before.some((old) => old.id === value.id));
-      return mutationResult(added.length === 1, { created: true, item: added[0] || null }, "bin_child_id_readback", "Create smart bin");
     }
 
     async function renameProjectItem(args) {
@@ -762,13 +773,16 @@
 
     async function cloneSequence(args) {
       assertObject(args); assertOnlyKeys(args, ["sequenceId", "operationId"]);
-      const project = await activeProject(true), sequence = await resolveSequence(project, args.sequenceId), before = await listSequences(project);
-      assertAppendCapacity(before, MAX_SEQUENCES, "Sequence cloning");
-      project.lockedAccess(() => {
-        commitActions(project, "Clone sequence", [sequence.createCloneAction()]);
+      const project = await activeProject(true), sequence = await resolveSequence(project, args.sequenceId);
+      return withAppendLock(appendLockKey(project, "sequences", "all"), async () => {
+        const before = await listSequences(project);
+        assertAppendCapacity(before, MAX_SEQUENCES, "Sequence cloning");
+        project.lockedAccess(() => {
+          commitActions(project, "Clone sequence", [sequence.createCloneAction()]);
+        });
+        const after = await listSequences(project), added = after.filter((value) => !before.some((old) => old.id === value.id));
+        return mutationResult(added.length === 1, { cloned: true, source: await sequenceSnapshot(sequence), sequence: added[0] || null }, "sequence_identity_readback", "Clone sequence");
       });
-      const after = await listSequences(project), added = after.filter((value) => !before.some((old) => old.id === value.id));
-      return mutationResult(added.length === 1, { cloned: true, source: await sequenceSnapshot(sequence), sequence: added[0] || null }, "sequence_identity_readback", "Clone sequence");
     }
 
     async function createSubsequence(args) {
@@ -901,6 +915,24 @@
     function assertAppendCapacity(values, maximum, operation) {
       if (values.length >= maximum) {
         throw commandError("UXP_PROJECT_TOO_LARGE", operation + " requires readback capacity below " + maximum + " entries");
+      }
+    }
+
+    function appendLockKey(project, collectionType, targetId) {
+      return guidString(project && project.guid) + ":" + collectionType + ":" + targetId;
+    }
+
+    async function withAppendLock(key, callback) {
+      const previous = appendLocks.get(key) || Promise.resolve();
+      let release = function () {};
+      const current = new Promise((resolve) => { release = resolve; });
+      appendLocks.set(key, current);
+      await previous;
+      try {
+        return await callback();
+      } finally {
+        release();
+        if (appendLocks.get(key) === current) appendLocks.delete(key);
       }
     }
 

--- a/uxp-plugin/advanced-workflows.cjs
+++ b/uxp-plugin/advanced-workflows.cjs
@@ -11,6 +11,7 @@
   const MAX_KEYFRAMES = 256;
   const MAX_MARKERS = 2048;
   const MAX_SEQUENCES = 1024;
+  const MAX_BIN_CHILDREN = 1024;
 
   function createAdvancedWorkflowDefinitions(deps) {
     const ppro = deps.ppro, Protocol = deps.Protocol, workspace = deps.workspace;
@@ -305,6 +306,7 @@
       const markerType = args.markerType == null ? String(ppro.Marker && ppro.Marker.MARKER_TYPE_COMMENT || "Comment") : boundedString(args.markerType, "markerType", 128);
       const start = tick(finiteNumber(args.startSeconds == null ? 0 : args.startSeconds, "startSeconds", 0, 86400), "startSeconds"), duration = tick(finiteNumber(args.durationSeconds == null ? 0 : args.durationSeconds, "durationSeconds", 0, 86400), "durationSeconds");
       const comments = args.comments == null ? "" : boundedStringAllowEmpty(args.comments, "comments", 4000), before = await markerList(context.collection);
+      assertAppendCapacity(before, MAX_MARKERS, "Marker creation");
       context.project.lockedAccess(() => {
         commitActions(context.project, "Add marker", [context.collection.createAddMarkerAction(name, markerType, start, duration, comments)]);
       });
@@ -347,7 +349,7 @@
 
     async function binChildren(folder) {
       const children = Array.from(await folder.getItems() || []);
-      if (children.length > 1024) throw commandError("UXP_BIN_TOO_LARGE", "Bin inspection exceeds 1024 immediate children");
+      if (children.length > MAX_BIN_CHILDREN) throw commandError("UXP_BIN_TOO_LARGE", "Bin inspection exceeds " + MAX_BIN_CHILDREN + " immediate children");
       const values = [];
       for (const child of children) values.push(await projectItemSnapshot(child));
       return values;
@@ -363,6 +365,7 @@
       assertObject(args); assertOnlyKeys(args, ["parentBinId", "name", "makeUnique", "operationId"]);
       const project = await activeProject(true), folder = await resolveFolder(project, args.parentBinId, "parentBinId"), name = boundedString(args.name, "name", 255), before = await binChildren(folder);
       const makeUnique = optionalBoolean(args.makeUnique, true, "makeUnique");
+      assertAppendCapacity(before, MAX_BIN_CHILDREN, "Project-bin creation");
       project.lockedAccess(() => {
         commitActions(project, "Create project bin", [folder.createBinAction(name, makeUnique)]);
       });
@@ -373,6 +376,7 @@
     async function createSmartBin(args) {
       assertObject(args); assertOnlyKeys(args, ["parentBinId", "name", "searchQuery", "operationId"]);
       const project = await activeProject(true), folder = await resolveFolder(project, args.parentBinId, "parentBinId"), name = boundedString(args.name, "name", 255), query = boundedString(args.searchQuery, "searchQuery", 4000), before = await binChildren(folder);
+      assertAppendCapacity(before, MAX_BIN_CHILDREN, "Smart-bin creation");
       project.lockedAccess(() => {
         commitActions(project, "Create smart bin", [folder.createSmartBinAction(name, query)]);
       });
@@ -759,6 +763,7 @@
     async function cloneSequence(args) {
       assertObject(args); assertOnlyKeys(args, ["sequenceId", "operationId"]);
       const project = await activeProject(true), sequence = await resolveSequence(project, args.sequenceId), before = await listSequences(project);
+      assertAppendCapacity(before, MAX_SEQUENCES, "Sequence cloning");
       project.lockedAccess(() => {
         commitActions(project, "Clone sequence", [sequence.createCloneAction()]);
       });
@@ -891,6 +896,12 @@
       const values = Array.from(collection.getMarkers() || []);
       if (values.length > MAX_MARKERS) throw commandError("UXP_PROJECT_TOO_LARGE", "Marker lookup exceeds " + MAX_MARKERS + " entries");
       return values;
+    }
+
+    function assertAppendCapacity(values, maximum, operation) {
+      if (values.length >= maximum) {
+        throw commandError("UXP_PROJECT_TOO_LARGE", operation + " requires readback capacity below " + maximum + " entries");
+      }
     }
 
     function validateSettingsUpdates(value) {

--- a/uxp-plugin/commands.cjs
+++ b/uxp-plugin/commands.cjs
@@ -8,6 +8,7 @@
   function createCommandRegistry(deps) {
     const ppro = deps.ppro, Protocol = deps.Protocol, workspace = deps.workspace;
     const completedOperations = new Map();
+    const inFlightOperations = new Map();
     const definitions = {
       "capabilities.get": { readOnly: true, handler: capabilities },
       "state.get": { readOnly: true, handler: stateSnapshot },
@@ -49,17 +50,31 @@
       if (!definition.readOnly && operationKey && completedOperations.has(operationKey)) {
         return { ...completedOperations.get(operationKey), replayed: true };
       }
-      const result = await definition.handler(input);
-      const envelope = definition.readOnly ? result : {
-        operationId: operationId || null,
-        outcome: result && result.outcome ? result.outcome : "verified",
-        ...result
+      if (!definition.readOnly && operationKey && inFlightOperations.has(operationKey)) {
+        return { ...await inFlightOperations.get(operationKey), replayed: true };
+      }
+      const execute = async () => {
+        const result = await definition.handler(input);
+        return definition.readOnly ? result : {
+          operationId: operationId || null,
+          outcome: result && result.outcome ? result.outcome : "verified",
+          ...result
+        };
       };
-      if (!definition.readOnly && operationKey) {
+      if (definition.readOnly || !operationKey) return execute();
+
+      // Reserve the idempotency key before the handler starts so concurrent
+      // WebSocket dispatches share one host mutation instead of racing it.
+      const pending = Promise.resolve().then(execute);
+      inFlightOperations.set(operationKey, pending);
+      try {
+        const envelope = await pending;
         completedOperations.set(operationKey, envelope);
         if (completedOperations.size > 256) completedOperations.delete(completedOperations.keys().next().value);
+        return envelope;
+      } finally {
+        if (inFlightOperations.get(operationKey) === pending) inFlightOperations.delete(operationKey);
       }
-      return envelope;
     }
     async function capabilities() {
       let project = null, sequence = null;

--- a/uxp-plugin/commands.cjs
+++ b/uxp-plugin/commands.cjs
@@ -39,6 +39,15 @@
     if (advancedWorkflowApi && typeof advancedWorkflowApi.createAdvancedWorkflowDefinitions === "function") {
       Object.assign(definitions, advancedWorkflowApi.createAdvancedWorkflowDefinitions({ ppro, Protocol, workspace }));
     }
+    if (typeof deps.transcriptImportHandler === "function") {
+      definitions["transcript.import"] = {
+        destructive: true,
+        undoable: true,
+        minHostVersion: "25.6.0",
+        probe: typeof deps.transcriptImportProbe === "function" ? deps.transcriptImportProbe : null,
+        handler: deps.transcriptImportHandler
+      };
+    }
 
     async function dispatch(command, args) {
       const definition = definitions[command];

--- a/uxp-plugin/index.cjs
+++ b/uxp-plugin/index.cjs
@@ -6,7 +6,13 @@ const TranscriptSupport = globalThis.PremiereMcpTranscript;
 const WorkspaceSupport = globalThis.PremiereMcpWorkspace;
 const Commands = globalThis.PremiereMcpCommands;
 const workspaceBroker = WorkspaceSupport.createWorkspaceBroker({ fs: storage && storage.localFileSystem });
-const commandRegistry = Commands.createCommandRegistry({ ppro, Protocol, workspace: workspaceBroker });
+const commandRegistry = Commands.createCommandRegistry({
+  ppro,
+  Protocol,
+  workspace: workspaceBroker,
+  transcriptImportHandler: importTranscript,
+  transcriptImportProbe: canImportTranscript
+});
 let socket = null;
 let reconnectTimer = null;
 let lastState = "";
@@ -48,11 +54,9 @@ async function capabilities() {
   const transcriptExportApi = supportedHost && !!(ppro.Transcript && ppro.Transcript.exportToJSON && ppro.Transcript.importFromJSON);
   const transcriptNativeHasApi = supportedHost && !!(ppro.Transcript && typeof ppro.Transcript.hasTranscript === "function");
   const transcriptHasApi = transcriptNativeHasApi || !!(supportedHost && ppro.Transcript && typeof ppro.Transcript.exportToJSON === "function");
-  const transcriptImportApi = transcriptExportApi && typeof ppro.Transcript.createImportTextSegmentsAction === "function";
   Object.assign(value.commands, {
     "transcript.export": { supported: transcriptExportApi, readOnly: true, minVersion: "25.6.0" },
     "transcript.search": { supported: transcriptExportApi, readOnly: true, minVersion: "25.6.0" },
-    "transcript.import": { supported: transcriptImportApi, destructive: true, undoable: true, minVersion: "25.6.0" },
     "transcript.has": {
       supported: transcriptHasApi, readOnly: true, minVersion: transcriptNativeHasApi ? "26.3.0" : "25.6.0",
       nativeCheckMinVersion: "26.3.0", nativeCheck: transcriptNativeHasApi,
@@ -166,6 +170,13 @@ async function hasTranscript(args) {
   return { projectItemId: context.projectItemId, projectItemName: context.projectItemName, hasTranscript: present, method: "export-probe" };
 }
 
+function canImportTranscript() {
+  return TranscriptSupport.versionAtLeast(host && host.version, "25.6.0")
+    && !!(ppro.Transcript && typeof ppro.Transcript.exportToJSON === "function")
+    && typeof ppro.Transcript.importFromJSON === "function"
+    && typeof ppro.Transcript.createImportTextSegmentsAction === "function";
+}
+
 async function importTranscript(args) {
   if (!args || typeof args.json !== "string") throw new Error("json is required");
   TranscriptSupport.parseTranscriptJSON(args.json);
@@ -266,7 +277,6 @@ async function dispatch(raw) {
     else if (cmd.command === "transcript.export") result = await exportTranscript(cmd.args);
     else if (cmd.command === "transcript.search") result = await searchTranscript(cmd.args);
     else if (cmd.command === "transcript.has") result = await hasTranscript(cmd.args);
-    else if (cmd.command === "transcript.import") result = await importTranscript(cmd.args);
     else if (cmd.command === "captions.inspect") result = await inspectCaptions();
     else {
       assertNotCancelled(operation);

--- a/uxp-plugin/protocol.cjs
+++ b/uxp-plugin/protocol.cjs
@@ -7,7 +7,7 @@
   const PROTOCOL_VERSION = 2;
   const MAX_COMMAND_BYTES = 64 * 1024;
   const MAX_RESULT_BYTES = 1024 * 1024;
-  const COMMAND_NAME = /^[a-z][a-z0-9]*(?:\.[a-z][a-z0-9]*)+$/;
+  const COMMAND_NAME = /^[a-z][A-Za-z0-9]*(?:\.[a-z][A-Za-z0-9]*)+$/;
   function envelope(type, payload, requestId) {
     const value = { protocolVersion: PROTOCOL_VERSION, type, payload: payload || {}, sentAt: new Date().toISOString() };
     if (requestId) value.requestId = requestId;


### PR DESCRIPTION
## Summary

- Allows registered lower-camel UXP command segments through the strict bridge parser while continuing to reject uppercase-leading, snake-case, and traversal-like names.
- Reserves each mutating `command:operationId` key with an in-flight promise before host execution.
- Makes concurrent duplicate requests await and replay the same result instead of executing a second mutation.
- Releases failed in-flight keys so concurrent waiters share the failure and a later retry can execute.
- Routes `transcript.import` through the same replay-aware command registry.
- Rejects bounded marker, bin, smart-bin, and sequence-clone additions before host mutation, and serializes each target’s preflight/commit/readback window across distinct operation IDs.

## Context

This follow-up addresses the replay-safety and capacity findings that arrived after #103 had already passed its protected gate and merged, including the follow-up review of this PR.

## Checks

- `npm run check` — 46 test files, 1008 tests passed
- `npm run test:coverage` — 92.38% statements, 81.67% branches, 95.68% functions, 94.91% lines
- Focused protocol/registry/advanced-workflow suite — 43 tests passed
- `node scripts/validate-distribution.mjs --uxp` — passed
- `npm pack --dry-run` — passed
- `npm audit --omit=dev` — 0 vulnerabilities

No real Premiere Pro host was connected; this PR provides automated protocol, concurrency, replay, and fail-before-mutation contract evidence.