### PR TITLE
release: Premiere Pro MCP v1.10.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "premiere-pro",
       "source": "./claude-plugins/premiere-pro",
       "description": "Inspect, edit, verify, and export local Premiere Pro projects through MCP.",
-      "version": "1.9.3",
+      "version": "1.10.0",
       "category": "creative",
       "tags": ["premiere-pro", "video-editing", "mcp"]
     }

--- a/.github/ISSUE_TEMPLATE/compatibility_report.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility_report.yml
@@ -14,7 +14,7 @@ body:
     id: versions
     attributes:
       label: Premiere Pro and MCP versions
-      placeholder: Premiere 26.3.0, Premiere Pro MCP 1.9.3
+      placeholder: Premiere 26.3.0, Premiere Pro MCP 1.10.0
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/tool_failure.yml
+++ b/.github/ISSUE_TEMPLATE/tool_failure.yml
@@ -17,7 +17,7 @@ body:
     id: package-version
     attributes:
       label: Premiere Pro MCP version
-      placeholder: 1.9.3
+      placeholder: 1.10.0
     validations:
       required: true
   - type: input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,42 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-08-16
+
 ### Added
 
-- Added deterministic native UXP timeline-selection and arbitrary target inspection,
-  plus guarded replace/add/remove/clear actions with sequence and clip fingerprints,
-  replay protection, and exact selection readback. Live Premiere verification
-  remains pending.
+- Added 21 consolidated, capability-gated UXP tools across two stable workflow
+  groups, expanding the connected surface from 297 to 318 tools while retaining
+  CEP as the production-compatible bridge.
+- Added native effects, selection batches, deterministic timeline selection,
+  scene detection, proxy and ingest control, offline relinking, transactional
+  metadata, color conformance, Source Monitor audition, Productions storage
+  preflight, and an operator-selected workspace broker.
+- Added project-panel selection, marker CRUD, bin organization, sequence settings,
+  workspace-gated imports, typed parameter and keyframe automation, track-item
+  transforms, SequenceEditor operations, sequence lifecycle controls, and Adobe
+  Media Encoder submission.
+
+### Changed
+
+- Bounded selection, project, marker, sequence, bin, and keyframe inspection so a
+  request cannot accidentally traverse or serialize an unbounded production project.
+- Grouped compatible mutations into Adobe action transactions with stale-state
+  guards, replay protection, and post-commit readback. A failed UXP mutation is
+  returned to the caller and is never silently retried through CEP.
+- Replaced UXP filesystem full access with operator-selected folder access and kept
+  native paths and persistent tokens inside the panel.
+
+### Security
+
+- Updated vulnerable transitive dependencies and refreshed the validated package
+  lockfiles used by the server and landing build.
+
+### Validation
+
+- Automated unit, contract, distribution, and coverage gates exercise the expanded
+  UXP surface. Real Premiere host verification and latency benchmarking remain
+  pending and are not implied by this release.
 
 ## [1.9.3] - 2026-08-12
 

--- a/README.md
+++ b/README.md
@@ -31,17 +31,18 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 
 The AI handles the entire workflow through 280 core tools spanning the supported ExtendScript, QE DOM, local media analysis, safe edit-planning, and connection-verification surfaces. A compatible, authenticated UXP panel adds 40 documented, capability-gated tools without replacing the production CEP bridge.
 
-### Latest release: 1.9.3
+### Latest release: 1.10.0
 
-- **Focused release overview:** the README now shows only the current release instead of carrying
-  an expanding history of older release summaries.
-- **New media asset:** the landing package includes the Premiere Pro MCP cinematic intro video.
-- **Security reference:** the repository includes the dated security audit report and its explicit
-  verification boundaries.
-- **Patched dependency:** the landing build now resolves the transitive `nanoid` dependency to a
-  version that addresses the latest high-severity advisory.
+- **Expanded native UXP workflows:** 21 consolidated tools cover effects, selections, markers,
+  bins, sequence settings, imports, keyframes, timeline edits, sequence lifecycle, and encoding.
+- **Bounded and transactional execution:** stable IDs, stale-state guards, replay protection,
+  capped traversal, grouped Adobe actions, and post-commit readback reduce ambiguous mutations.
+- **Least-privilege workspace access:** operators choose the folder available to UXP workflows;
+  native paths and persistent tokens stay inside the panel.
+- **Truthful compatibility:** CEP remains the production-compatible bridge, and a failed UXP
+  mutation is never silently retried through CEP.
 
-See the [v1.9.3 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.9.3)
+See the [v1.10.0 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.10.0)
 for complete details. Live installation in Premiere Pro still requires host verification.
 
 ---
@@ -50,9 +51,9 @@ for complete details. Live installation in Premiere Pro still requires host veri
 
 ### Easiest supported path: Claude Desktop
 
-1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.9.3/premiere-pro-mcp-1.9.3.mcpb).
+1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.10.0/premiere-pro-mcp-1.10.0.mcpb).
 2. In Claude Desktop, open **Settings > Extensions > Advanced settings > Install Extension**, select the downloaded bundle, and restart Claude Desktop.
-3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.9.3/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
+3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.10.0/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
 4. Restart Premiere, open a project, then open **Window > Extensions > MCP Bridge**.
 5. In Claude, enter: `Safely check my Premiere connection with verify_premiere_connection. Make no changes.`
 
@@ -276,11 +277,11 @@ From a clone of this repository:
 ```bash
 codex plugin marketplace add .
 codex plugin add premiere-pro@premiere-pro-mcp
-npx -y premiere-pro-mcp@1.9.3 --install-cep
+npx -y premiere-pro-mcp@1.10.0 --install-cep
 ```
 
 Restart Premiere Pro and start a new Codex session after installation. The plugin
-launches `premiere-pro-mcp@1.9.3` through `npx`; the separate CEP installation is
+launches `premiere-pro-mcp@1.10.0` through `npx`; the separate CEP installation is
 required because the MCP server communicates with the running Premiere host through
 the local bridge.
 
@@ -300,7 +301,7 @@ For Claude Code, add this repository as a marketplace and install the plugin:
 Then install the Premiere bridge and start a new Claude Code session:
 
 ```bash
-npx -y premiere-pro-mcp@1.9.3 --install-cep
+npx -y premiere-pro-mcp@1.10.0 --install-cep
 ```
 
 The Claude Code package lives in

--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.9.3" ExtensionBundleName="MCP Bridge">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.10.0" ExtensionBundleName="MCP Bridge">
   <ExtensionList>
-    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.9.3"/>
-    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.9.3"/>
+    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.10.0"/>
+    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.10.0"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/cep-plugin/index.html
+++ b/cep-plugin/index.html
@@ -81,7 +81,7 @@
     <section class="update-section" aria-live="polite">
       <div class="update-copy">
         <span class="section-label">Connector updates</span>
-        <strong id="updateTitle">Version 1.9.3</strong>
+        <strong id="updateTitle">Version 1.10.0</strong>
         <span id="updateDetail">Checking for updates…</span>
       </div>
       <button id="btnUpdate" class="button button-update" onclick="handleUpdateClick()" type="button" disabled>

--- a/cep-plugin/updater.cjs
+++ b/cep-plugin/updater.cjs
@@ -7,7 +7,7 @@
 })(this, function () {
   "use strict";
 
-  var CURRENT_VERSION = "1.9.3";
+  var CURRENT_VERSION = "1.10.0";
   var LATEST_RELEASE_API =
     "https://api.github.com/repos/leancoderkavy/premiere-pro-mcp/releases/latest";
   var RELEASES_URL =

--- a/claude-desktop/manifest.json
+++ b/claude-desktop/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "premiere-pro-mcp",
   "display_name": "Premiere Pro MCP",
-  "version": "1.9.3",
+  "version": "1.10.0",
   "description": "Control a local Adobe Premiere Pro project through MCP.",
   "long_description": "Inspect projects, assemble and modify timelines, manage media, effects, audio and captions, and export deliverables through a local bridge to Adobe Premiere Pro.",
   "author": {

--- a/claude-plugins/premiere-pro/.claude-plugin/plugin.json
+++ b/claude-plugins/premiere-pro/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "premiere-pro",
   "displayName": "Premiere Pro MCP",
-  "version": "1.9.3",
+  "version": "1.10.0",
   "description": "Inspect, edit, verify, and export local Adobe Premiere Pro projects through MCP.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/claude-plugins/premiere-pro/.mcp.json
+++ b/claude-plugins/premiere-pro/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "premiere-pro": {
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.9.3"]
+      "args": ["-y", "premiere-pro-mcp@1.10.0"]
     }
   }
 }

--- a/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.9.3 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.10.0 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -5,6 +5,33 @@ import { product } from "@/lib/product"
 
 const releases = [
   {
+    version: "1.10.0",
+    date: "2026-08-16",
+    label: "Stable, bounded UXP workflow expansion",
+    groups: [
+      {
+        title: "Added",
+        items: [
+          "Added 21 consolidated, capability-gated UXP tools, expanding the connected surface from 297 to 318 tools.",
+          "Added native workflows for effects, selections, scene detection, proxies, relinking, metadata, color, Source Monitor, storage, project organization, keyframes, timeline edits, sequences, and encoding.",
+        ],
+      },
+      {
+        title: "Changed",
+        items: [
+          "Bounded project traversal, grouped compatible Adobe actions into transactions, and added stale-state guards, replay protection, and readback evidence.",
+          "Replaced UXP filesystem full access with an operator-selected workspace while retaining CEP as the production-compatible bridge.",
+        ],
+      },
+      {
+        title: "Validation",
+        items: [
+          "Automated unit, contract, distribution, and coverage gates exercise the expanded surface; real Premiere host verification and latency benchmarking remain pending.",
+        ],
+      },
+    ],
+  },
+  {
     version: "1.9.3",
     date: "2026-08-12",
     label: "Focused release overview and repository assets",

--- a/landing/lib/product.ts
+++ b/landing/lib/product.ts
@@ -1,7 +1,7 @@
 export const product = {
   name: "Premiere Pro MCP",
-  version: "1.9.3",
-  releaseDate: "2026-08-12",
+  version: "1.10.0",
+  releaseDate: "2026-08-16",
   coreToolCount: 280,
   defaultProfileToolCount: 278,
   connectedUxpToolCount: 318,
@@ -10,10 +10,10 @@ export const product = {
   uxpMinimumVersion: "25.6",
   downloads: {
     claudeBundle:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.9.3/premiere-pro-mcp-1.9.3.mcpb",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.10.0/premiere-pro-mcp-1.10.0.mcpb",
     signedCepConnector:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.9.3/MCPBridgeCEP.zxp",
-    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.9.3",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.10.0/MCPBridgeCEP.zxp",
+    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.10.0",
   },
   links: {
     repository: "https://github.com/leancoderkavy/premiere-pro-mcp",

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -7,7 +7,7 @@ Documentation: https://premiere-pro-mcp.com/docs/
 Source: https://github.com/leancoderkavy/premiere-pro-mcp
 npm: https://www.npmjs.com/package/premiere-pro-mcp
 License: MIT
-Current release: 1.9.3
+Current release: 1.10.0
 
 ## What it does
 

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -24,7 +24,7 @@ The recommended setup runs the MCP server and CEP bridge locally. Project media 
 
 ## Verified facts
 
-- Current project release: 1.9.3.
+- Current project release: 1.10.0.
 - Tool surface: 280 core structured MCP tools are registered; the default profile exposes 278. With an authenticated compatible UXP panel, 40 additional capability-gated tools bring the connected surface to 318. The server also exposes 3 resources and 4 prompts.
 - Supported desktop platforms: Windows and macOS.
 - Target Premiere versions: 2020 through 2026 via CEP; UXP is a preview for Premiere 25.6 and newer.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.9.3",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "premiere-pro-mcp",
-      "version": "1.9.3",
+      "version": "1.10.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.9.3",
+  "version": "1.10.0",
   "description": "Adobe Premiere Pro MCP server with 280 core AI video editing tools and a capability-aware UXP bridge for supported Premiere workflows.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/premiere-pro/.codex-plugin/plugin.json
+++ b/plugins/premiere-pro/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro",
-  "version": "1.9.3",
+  "version": "1.10.0",
   "description": "Plan, execute, verify, and export video edits in Adobe Premiere Pro through the Premiere Pro MCP server.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/plugins/premiere-pro/.mcp.json
+++ b/plugins/premiere-pro/.mcp.json
@@ -4,7 +4,7 @@
       "title": "Premiere Pro MCP",
       "description": "Inspect and edit a local Adobe Premiere Pro project through the Premiere Pro MCP bridge.",
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.9.3"]
+      "args": ["-y", "premiere-pro-mcp@1.10.0"]
     }
   }
 }

--- a/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.9.3 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.10.0 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.9.3",
+  "version": "1.10.0",
   "coreTools": 280,
   "defaultProfileTools": 278,
   "uxpAdditionalTools": 40,

--- a/uxp-plugin/manifest.json
+++ b/uxp-plugin/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.ppmcp.premiere.uxp",
   "name": "Premiere Pro MCP Bridge",
-  "version": "1.9.3",
+  "version": "1.10.0",
   "main": "index.html",
   "host": { "app": "premierepro", "minVersion": "25.6.0" },
   "entrypoints": [


### PR DESCRIPTION
## What changed

- bump all active package, connector, plugin, landing, and distribution surfaces to `1.10.0`
- publish release notes for the 21 new capability-gated UXP workflows, taking the connected surface from 297 to 318 tools
- document bounded traversal, transaction/readback safeguards, least-privilege workspace access, and the unchanged CEP compatibility path
- keep historical `1.9.3` changelog and roadmap references intact

## Why

The UXP stable-workflow work merged since `1.9.3` is backward-compatible but materially expands the supported connected tool surface, so it warrants a SemVer minor release.

## User impact

Users receive current npm, MCPB, CEP ZXP, direct UXP CCX, Codex, Claude Code, and landing metadata for the same release. This does not claim real Premiere-host validation; that remains a separate gate.

## Validation

- `npm run check` — 47 files / 1,427 tests passed
- `npm run test:coverage` — 94.18% statements, 90.09% branches, 96.24% functions, 96.08% lines
- `npm run check:release-metadata`
- `npm run publish:npm:dry-run` — 145 files, 262.9 kB package
- `npm audit --omit=dev --audit-level=high` — 0 production vulnerabilities
- `npm run build:claude`
- `node scripts/validate-distribution.mjs --uxp`
- `node scripts/build-uxp-ccx.mjs`
- landing: `npm run lint`, `npm run build`, and production audit
- `git diff --check`