### PR TITLE
fix(audio): convert dB to Premiere's normalised level in set_clip_volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `set_clip_volume` passed decibels straight into Premiere's `Volume > Level`
+  property, which is a normalised 0..1 value where 1.0 is +15 dB, not a dB
+  value. Every negative dB clamped to 0 (silence) and every positive dB clamped
+  to 1.0 (+15 dB), and Premiere reports no error either way, so the failure was
+  silent - a whole timeline could be muted with the tool reporting success.
+  Levels are now converted with `10^((dB-15)/20)`.
+
+### Added
+
+- `get_clip_volume` reads a clip's level back in dB, so a level change can be
+  verified rather than assumed.
+- `set_clips_volume` applies a level to every clip on an audio track (or a
+  chosen subset) in one call. Setting levels across an 80-clip sequence
+  previously meant 80 round trips.
+
 ## [1.10.0] - 2026-08-16
 
 ### Added

--- a/src/tools/track-targeting.ts
+++ b/src/tools/track-targeting.ts
@@ -4,6 +4,29 @@ import {
 } from "../bridge/script-builder.js";
 import { sendCommand, BridgeOptions } from "../bridge/file-bridge.js";
 
+/**
+ * Premiere's audio `Volume > Level` property is NOT in decibels. It is a
+ * normalised 0..1 value where 1.0 is the maximum boost of +15 dB, so unity
+ * (0 dB) sits at 10^(-15/20) = 0.17782794.
+ *
+ * Passing decibels straight to setValue() silently clamps: any negative dB
+ * becomes 0 (total silence) and any positive dB becomes 1.0 (+15 dB). Both
+ * fail without an error, which makes the mistake very hard to spot - the
+ * timeline just plays wrong.
+ */
+export const PREMIERE_MAX_LEVEL_DB = 15;
+
+export function dbToPremiereLevel(db: number): number {
+  if (!Number.isFinite(db)) return 0;
+  const clamped = Math.min(db, PREMIERE_MAX_LEVEL_DB);
+  return Math.pow(10, (clamped - PREMIERE_MAX_LEVEL_DB) / 20);
+}
+
+export function premiereLevelToDb(level: number): number | null {
+  if (!Number.isFinite(level) || level <= 0) return null; // silence
+  return 20 * Math.log10(level) + PREMIERE_MAX_LEVEL_DB;
+}
+
 export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
   return {
     set_target_track: {
@@ -757,6 +780,7 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
         required: ["node_id", "volume_db"],
       },
       handler: async (args: { node_id: string; volume_db: number }) => {
+        const level = dbToPremiereLevel(args.volume_db);
         const script = buildToolScript(`
           var result = __findClip("${escapeForExtendScript(args.node_id)}");
           if (!result) return __error("Clip not found");
@@ -767,7 +791,8 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
             if (clip.components[i].displayName === "Volume") {
               for (var p = 0; p < clip.components[i].properties.numItems; p++) {
                 if (clip.components[i].properties[p].displayName === "Level") {
-                  clip.components[i].properties[p].setValue(${args.volume_db}, true);
+                  // normalised 0..1, NOT dB - see dbToPremiereLevel()
+                  clip.components[i].properties[p].setValue(${level}, true);
                   set = true;
                   break;
                 }
@@ -776,7 +801,119 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
             }
           }
           if (!set) return __error("Could not set volume - is this an audio clip?");
-          return __result({ volumeDb: ${args.volume_db}, clip: clip.name });
+          return __result({ volumeDb: ${args.volume_db}, level: ${level}, clip: clip.name });
+        `);
+        return sendCommand(script, bridgeOptions);
+      },
+    },
+
+    get_clip_volume: {
+      description:
+        "Read the volume level of an audio clip, returned in dB. Use this to verify a level actually applied - setValue() clamps silently.",
+      parameters: {
+        type: "object" as const,
+        properties: {
+          node_id: {
+            type: "string",
+            description: "Node ID of the audio clip",
+          },
+        },
+        required: ["node_id"],
+      },
+      handler: async (args: { node_id: string }) => {
+        const script = buildToolScript(`
+          var result = __findClip("${escapeForExtendScript(args.node_id)}");
+          if (!result) return __error("Clip not found");
+
+          var clip = result.clip;
+          var level = null;
+          for (var i = 0; i < clip.components.numItems; i++) {
+            if (clip.components[i].displayName === "Volume") {
+              for (var p = 0; p < clip.components[i].properties.numItems; p++) {
+                if (clip.components[i].properties[p].displayName === "Level") {
+                  level = clip.components[i].properties[p].getValue();
+                  break;
+                }
+              }
+              break;
+            }
+          }
+          if (level === null) return __error("No volume component - is this an audio clip?");
+          var db = (level > 0) ? (20 * (Math.log(level) / Math.LN10) + ${PREMIERE_MAX_LEVEL_DB}) : null;
+          return __result({ clip: clip.name, level: level, volumeDb: db });
+        `);
+        return sendCommand(script, bridgeOptions);
+      },
+    },
+
+    set_clips_volume: {
+      description:
+        "Set the volume (in dB) on every audio clip of a track, or on a list of clip indices. One round trip instead of one call per clip - essential for sequences with dozens of clips.",
+      parameters: {
+        type: "object" as const,
+        properties: {
+          track_index: {
+            type: "number",
+            description: "Audio track index (0-based)",
+          },
+          volume_db: {
+            type: "number",
+            description:
+              "Volume in dB applied to every selected clip (0 = unity, max +15)",
+          },
+          clip_indices: {
+            type: "array",
+            items: { type: "number" },
+            description:
+              "Optional clip indices on that track. Omit to apply to all clips.",
+          },
+        },
+        required: ["track_index", "volume_db"],
+      },
+      handler: async (args: {
+        track_index: number;
+        volume_db: number;
+        clip_indices?: number[];
+      }) => {
+        const level = dbToPremiereLevel(args.volume_db);
+        const only = Array.isArray(args.clip_indices)
+          ? JSON.stringify(args.clip_indices)
+          : "null";
+        const script = buildToolScript(`
+          var seq = app.project.activeSequence;
+          if (!seq) return __error("No active sequence");
+          if (${args.track_index} >= seq.audioTracks.numTracks)
+            return __error("Track index out of range");
+
+          var track = seq.audioTracks[${args.track_index}];
+          var only = ${only};
+          var wanted = {};
+          if (only) { for (var w = 0; w < only.length; w++) wanted[only[w]] = true; }
+
+          var applied = 0, skipped = 0;
+          for (var c = 0; c < track.clips.numItems; c++) {
+            if (only && !wanted[c]) continue;
+            var clip = track.clips[c], set = false;
+            for (var i = 0; i < clip.components.numItems; i++) {
+              if (clip.components[i].displayName !== "Volume") continue;
+              for (var p = 0; p < clip.components[i].properties.numItems; p++) {
+                if (clip.components[i].properties[p].displayName === "Level") {
+                  clip.components[i].properties[p].setValue(${level}, true);
+                  set = true;
+                  break;
+                }
+              }
+              break;
+            }
+            if (set) applied++; else skipped++;
+          }
+          return __result({
+            trackIndex: ${args.track_index},
+            volumeDb: ${args.volume_db},
+            level: ${level},
+            applied: applied,
+            skipped: skipped
+          });
         `);
         return sendCommand(script, bridgeOptions);
       },

--- a/tests/clip-volume.test.ts
+++ b/tests/clip-volume.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import {
+  dbToPremiereLevel,
+  premiereLevelToDb,
+  PREMIERE_MAX_LEVEL_DB,
+} from "../src/tools/track-targeting.js";
+
+/**
+ * Premiere's `Volume > Level` is a normalised 0..1 value, not decibels.
+ * Measured against Premiere Pro 26.3.2: a clip left untouched (0 dB in the
+ * UI) reads back 0.17782794, which is exactly 10^(-15/20). That fixes the
+ * scale - 1.0 is +15 dB.
+ */
+describe("Premiere audio level conversion", () => {
+  it("maps unity gain to Premiere's observed 0 dB value", () => {
+    expect(dbToPremiereLevel(0)).toBeCloseTo(0.17782794, 7);
+  });
+
+  it("maps the top of the range to 1.0", () => {
+    expect(dbToPremiereLevel(PREMIERE_MAX_LEVEL_DB)).toBeCloseTo(1.0, 10);
+  });
+
+  it("keeps every level inside the range Premiere accepts", () => {
+    for (const db of [-60, -18, -11, -5.8, 0, 6, 15]) {
+      const level = dbToPremiereLevel(db);
+      expect(level).toBeGreaterThanOrEqual(0);
+      expect(level).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("clamps above +15 dB rather than exceeding 1.0", () => {
+    expect(dbToPremiereLevel(40)).toBeCloseTo(1.0, 10);
+  });
+
+  it("round-trips dB -> level -> dB", () => {
+    for (const db of [-24, -17.7, -11, -5.8, 0, 7.5]) {
+      const back = premiereLevelToDb(dbToPremiereLevel(db));
+      expect(back).not.toBeNull();
+      expect(back as number).toBeCloseTo(db, 6);
+    }
+  });
+
+  it("reports silence as null rather than -Infinity", () => {
+    expect(premiereLevelToDb(0)).toBeNull();
+    expect(premiereLevelToDb(-1)).toBeNull();
+  });
+
+  /**
+   * Regression guard. Before the fix, volume_db was passed straight to
+   * setValue(): -11 dB fell outside 0..1 and clamped to 0 (silence), while
+   * +7 dB clamped to 1.0 (+15 dB). Both failed without raising an error.
+   */
+  it("does not pass raw decibels through as a level", () => {
+    expect(dbToPremiereLevel(-11)).not.toBe(-11);
+    expect(dbToPremiereLevel(-11)).toBeGreaterThan(0);
+    expect(dbToPremiereLevel(7)).not.toBe(7);
+    expect(dbToPremiereLevel(7)).toBeLessThan(1);
+  });
+});

--- a/tests/mcp-modernization.test.ts
+++ b/tests/mcp-modernization.test.ts
@@ -89,7 +89,7 @@ describe("modern MCP surface", () => {
       // unsafe-script, so the two scripting tools are not advertised.
       expect(tools.tools.map((tool) => tool.name)).not.toContain("execute_extendscript");
       expect(tools.tools.map((tool) => tool.name)).not.toContain("evaluate_expression");
-      expect(tools.tools).toHaveLength(278);
+      expect(tools.tools).toHaveLength(280);
 
       const capabilities = await client.callTool({
         name: "get_capabilities",

--- a/tests/tools/adobe-26-3-uxp-catalog.test.ts
+++ b/tests/tools/adobe-26-3-uxp-catalog.test.ts
@@ -44,7 +44,7 @@ describe("Adobe Premiere 26.3 UXP public MCP catalog", () => {
       expect(listed.tools.map((tool) => tool.name)).toEqual(
         expect.arrayContaining(ADOBE_26_3_TOOLS),
       );
-      expect(listed.tools).toHaveLength(318);
+      expect(listed.tools).toHaveLength(320);
     } finally {
       await client.close();
       await server.close();

--- a/tests/tools/tool-modules.test.ts
+++ b/tests/tools/tool-modules.test.ts
@@ -175,12 +175,12 @@ describe("Tool Module Structure", () => {
 });
 
 describe("Total Tool Count", () => {
-  it("all modules together have 277 tools", () => {
+  it("all modules together have 280 tools", () => {
     let total = 0;
     for (const mod of ALL_MODULES) {
       total += Object.keys(mod.getter(bridgeOptions)).length;
     }
-    expect(total).toBe(278);
+    expect(total).toBe(280);
   });
 
   it("there are 30 modules", () => {

--- a/tests/tools/uxp-tools.test.ts
+++ b/tests/tools/uxp-tools.test.ts
@@ -116,7 +116,7 @@ describe("UXP MCP tools", () => {
       // transcript workflow and documented Premiere 26.3 tools add nineteen,
       // and the two stable workflow expansions add twenty-one consolidated UXP tools;
       // connection verification adds one default-profile core tool.
-      expect(tools.tools).toHaveLength(318);
+      expect(tools.tools).toHaveLength(320);
     } finally {
       await client.close();
       await server.close();


### PR DESCRIPTION
## The bug

Premiere's audio `Volume > Level` property is **a normalised 0..1 value, not decibels**. `1.0` is the maximum boost of +15 dB, so unity (0 dB) sits at `10^(-15/20)` = `0.17782794`.

`set_clip_volume` passed the caller's dB figure straight into `setValue()`. That value is outside `0..1` for every realistic level, so Premiere clamps it:

| Caller asks for | Premiere stores | Actual result |
|---|---|---|
| `-11` dB | `0` | **total silence** |
| `-18` dB | `0` | **total silence** |
| `+7` dB | `1.0` | **+15 dB** |

Premiere raises no error in either direction, so the tool returned success while the timeline played wrong.

## How it was found

Setting 85 clips to `-11` dB across a sequence produced a silent A1 track. Reading the property back showed the discrepancy:

- clips never touched by the tool: `0.17782794` (= 0 dB, matching Premiere's UI)
- clips set through `set_clip_volume`: `0`

Verified on Premiere Pro 26.3.2.

## The fix

Convert before writing:

```ts
export function dbToPremiereLevel(db: number): number {
  const clamped = Math.min(db, PREMIERE_MAX_LEVEL_DB); // +15
  return Math.pow(10, (clamped - PREMIERE_MAX_LEVEL_DB) / 20);
}
```

## Also added

Two tools this bug made necessary to diagnose:

- **`get_clip_volume`** — reads a level back in dB. There was previously no way to inspect a clip's level, so a silent failure was undetectable through the MCP surface.
- **`set_clips_volume`** — applies a level to a whole audio track, or a chosen subset of clip indices, in one call. Levelling an 80-clip sequence previously required 80 round trips.

## Tests

- New `tests/clip-volume.test.ts` pins the conversion against the measured `0.17782794`, covers round-tripping, clamping above +15 dB, and reporting silence as `null` rather than `-Infinity`.
- Includes a regression guard asserting raw decibels are never passed through as a level.
- Tool count assertions updated 278 → 280 and 318 → 320 for the two new tools.

Full suite: **1438 passed, 48 files**. `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)