### PR TITLE
Release v1.11.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "premiere-pro",
       "source": "./claude-plugins/premiere-pro",
       "description": "Inspect, edit, verify, and export local Premiere Pro projects through MCP.",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "category": "creative",
       "tags": ["premiere-pro", "video-editing", "mcp"]
     }

--- a/.github/ISSUE_TEMPLATE/compatibility_report.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility_report.yml
@@ -14,7 +14,7 @@ body:
     id: versions
     attributes:
       label: Premiere Pro and MCP versions
-      placeholder: Premiere 26.3.0, Premiere Pro MCP 1.10.0
+      placeholder: Premiere 26.3.0, Premiere Pro MCP 1.11.0
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/tool_failure.yml
+++ b/.github/ISSUE_TEMPLATE/tool_failure.yml
@@ -17,7 +17,7 @@ body:
     id: package-version
     attributes:
       label: Premiere Pro MCP version
-      placeholder: 1.10.0
+      placeholder: 1.11.0
     validations:
       required: true
   - type: input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-08-16
+
 ### Fixed
 
 - `set_clip_volume` passed decibels straight into Premiere's `Volume > Level`
@@ -22,6 +24,35 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `set_clips_volume` applies a level to every clip on an audio track (or a
   chosen subset) in one call. Setting levels across an 80-clip sequence
   previously meant 80 round trips.
+- Added eight capability-gated third-wave UXP tools for bounded host events, AME
+  terminal receipts, host readiness, safe multi-project sessions, growing-media
+  leases, transactional checkpoints, media health, caption-aware track state,
+  source-clip trim and framing, and hybrid-acceleration evidence.
+- Added a generated supported-actions catalog covering all 282 core tools, the
+  default profile, resources, prompts, and connected UXP actions with explicit
+  backend and verification boundaries.
+- Added a schema-backed hybrid benchmark evidence template and a fail-closed
+  verifier so accelerated paths cannot be advertised without matching host,
+  dataset, correctness, latency, and provenance evidence.
+
+### Changed
+
+- Expanded the authenticated UXP surface from 40 to 48 capability-gated tools,
+  bringing the connected default profile from 318 to 328 tools while keeping
+  CEP as the production-compatible bridge.
+- Bounded event and readiness history, reported eviction and pending states,
+  and preserved host timeout budgets with a response-delivery buffer.
+- Required explicit confirmation and readback for external project writes,
+  destructive track or source mutations, and pause leases; failed UXP commands
+  are never replayed automatically through CEP.
+
+### Validation
+
+- The merged release tree passes 1,490 automated tests across 53 files with
+  91.26% branch coverage, generated-document checks, landing lint/build, and
+  package-content validation.
+- Real Premiere host validation remains not run; mock and contract evidence does
+  not establish behavior inside a licensed Premiere installation.
 
 ## [1.10.0] - 2026-08-16
 

--- a/README.md
+++ b/README.md
@@ -31,18 +31,20 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 
 The AI handles the entire workflow through 282 core tools spanning the supported ExtendScript, QE DOM, local media analysis, safe edit-planning, and connection-verification surfaces. A compatible, authenticated UXP panel adds 48 documented, capability-gated tools without replacing the production CEP bridge.
 
-### Latest release: 1.10.0
+### Latest release: 1.11.0
 
-- **Expanded native UXP workflows:** 21 consolidated tools cover effects, selections, markers,
-  bins, sequence settings, imports, keyframes, timeline edits, sequence lifecycle, and encoding.
-- **Bounded and transactional execution:** stable IDs, stale-state guards, replay protection,
-  capped traversal, grouped Adobe actions, and post-commit readback reduce ambiguous mutations.
-- **Least-privilege workspace access:** operators choose the folder available to UXP workflows;
-  native paths and persistent tokens stay inside the panel.
-- **Truthful compatibility:** CEP remains the production-compatible bridge, and a failed UXP
-  mutation is never silently retried through CEP.
+- **Host evidence and readiness:** a bounded UXP event journal, AME terminal receipts, and
+  explicit readiness gates distinguish verified completion, pending work, and lost history.
+- **Guarded production workflows:** GUID-targeted project sessions, growing-media pause leases,
+  transactional checkpoints, and bounded media-health inspection fail closed on stale state.
+- **Timeline precision:** caption-aware track controls and source-clip trim and framing add
+  readback-verified mutations; clip-volume writes now convert dB correctly and support batches.
+- **Performance and support evidence:** a hybrid-acceleration benchmark gate and the generated
+  [supported-actions catalog](docs/supported-actions.md) document every current action and boundary.
+- **Truthful compatibility:** CEP remains the production-compatible bridge, and automated UXP
+  contracts do not claim validation inside a real Premiere host.
 
-See the [v1.10.0 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.10.0)
+See the [v1.11.0 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.11.0)
 for complete details. Live installation in Premiere Pro still requires host verification.
 
 ---
@@ -51,9 +53,9 @@ for complete details. Live installation in Premiere Pro still requires host veri
 
 ### Easiest supported path: Claude Desktop
 
-1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.10.0/premiere-pro-mcp-1.10.0.mcpb).
+1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.11.0/premiere-pro-mcp-1.11.0.mcpb).
 2. In Claude Desktop, open **Settings > Extensions > Advanced settings > Install Extension**, select the downloaded bundle, and restart Claude Desktop.
-3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.10.0/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
+3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.11.0/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
 4. Restart Premiere, open a project, then open **Window > Extensions > MCP Bridge**.
 5. In Claude, enter: `Safely check my Premiere connection with verify_premiere_connection. Make no changes.`
 
@@ -277,11 +279,11 @@ From a clone of this repository:
 ```bash
 codex plugin marketplace add .
 codex plugin add premiere-pro@premiere-pro-mcp
-npx -y premiere-pro-mcp@1.10.0 --install-cep
+npx -y premiere-pro-mcp@1.11.0 --install-cep
 ```
 
 Restart Premiere Pro and start a new Codex session after installation. The plugin
-launches `premiere-pro-mcp@1.10.0` through `npx`; the separate CEP installation is
+launches `premiere-pro-mcp@1.11.0` through `npx`; the separate CEP installation is
 required because the MCP server communicates with the running Premiere host through
 the local bridge.
 
@@ -301,7 +303,7 @@ For Claude Code, add this repository as a marketplace and install the plugin:
 Then install the Premiere bridge and start a new Claude Code session:
 
 ```bash
-npx -y premiere-pro-mcp@1.10.0 --install-cep
+npx -y premiere-pro-mcp@1.11.0 --install-cep
 ```
 
 The Claude Code package lives in

--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.10.0" ExtensionBundleName="MCP Bridge">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.11.0" ExtensionBundleName="MCP Bridge">
   <ExtensionList>
-    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.10.0"/>
-    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.10.0"/>
+    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.11.0"/>
+    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.11.0"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/cep-plugin/index.html
+++ b/cep-plugin/index.html
@@ -81,7 +81,7 @@
     <section class="update-section" aria-live="polite">
       <div class="update-copy">
         <span class="section-label">Connector updates</span>
-        <strong id="updateTitle">Version 1.10.0</strong>
+        <strong id="updateTitle">Version 1.11.0</strong>
         <span id="updateDetail">Checking for updates…</span>
       </div>
       <button id="btnUpdate" class="button button-update" onclick="handleUpdateClick()" type="button" disabled>

--- a/cep-plugin/updater.cjs
+++ b/cep-plugin/updater.cjs
@@ -7,7 +7,7 @@
 })(this, function () {
   "use strict";
 
-  var CURRENT_VERSION = "1.10.0";
+  var CURRENT_VERSION = "1.11.0";
   var LATEST_RELEASE_API =
     "https://api.github.com/repos/leancoderkavy/premiere-pro-mcp/releases/latest";
   var RELEASES_URL =

--- a/claude-desktop/manifest.json
+++ b/claude-desktop/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "premiere-pro-mcp",
   "display_name": "Premiere Pro MCP",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Control a local Adobe Premiere Pro project through MCP.",
   "long_description": "Inspect projects, assemble and modify timelines, manage media, effects, audio and captions, and export deliverables through a local bridge to Adobe Premiere Pro.",
   "author": {

--- a/claude-plugins/premiere-pro/.claude-plugin/plugin.json
+++ b/claude-plugins/premiere-pro/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "premiere-pro",
   "displayName": "Premiere Pro MCP",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Inspect, edit, verify, and export local Adobe Premiere Pro projects through MCP.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/claude-plugins/premiere-pro/.mcp.json
+++ b/claude-plugins/premiere-pro/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "premiere-pro": {
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.10.0"]
+      "args": ["-y", "premiere-pro-mcp@1.11.0"]
     }
   }
 }

--- a/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.10.0 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.11.0 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -5,6 +5,38 @@ import { product } from "@/lib/product"
 
 const releases = [
   {
+    version: "1.11.0",
+    date: "2026-08-16",
+    label: "Evidence-backed third-wave UXP workflows",
+    groups: [
+      {
+        title: "Added",
+        items: [
+          "Added eight capability-gated UXP tools for host events, readiness, project sessions, growing media, checkpoints, media health, track state, and source trim and framing.",
+          "Added a generated supported-actions catalog and schema-backed hybrid benchmark evidence gate.",
+        ],
+      },
+      {
+        title: "Fixed",
+        items: [
+          "Corrected clip-volume conversion from decibels to Premiere's normalized Level value and added readback and batch controls.",
+        ],
+      },
+      {
+        title: "Changed",
+        items: [
+          "Expanded the connected surface to 328 tools and added bounded history, explicit confirmations, timeout budgets, and post-mutation readback.",
+        ],
+      },
+      {
+        title: "Validation",
+        items: [
+          "Automated tests, coverage, generated-document checks, and package validation pass; real Premiere host verification remains a separate gate.",
+        ],
+      },
+    ],
+  },
+  {
     version: "1.10.0",
     date: "2026-08-16",
     label: "Stable, bounded UXP workflow expansion",

--- a/landing/lib/product.ts
+++ b/landing/lib/product.ts
@@ -1,6 +1,6 @@
 export const product = {
   name: "Premiere Pro MCP",
-  version: "1.10.0",
+  version: "1.11.0",
   releaseDate: "2026-08-16",
   coreToolCount: 282,
   defaultProfileToolCount: 280,
@@ -10,10 +10,10 @@ export const product = {
   uxpMinimumVersion: "25.6",
   downloads: {
     claudeBundle:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.10.0/premiere-pro-mcp-1.10.0.mcpb",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.11.0/premiere-pro-mcp-1.11.0.mcpb",
     signedCepConnector:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.10.0/MCPBridgeCEP.zxp",
-    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.10.0",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.11.0/MCPBridgeCEP.zxp",
+    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.11.0",
   },
   links: {
     repository: "https://github.com/leancoderkavy/premiere-pro-mcp",

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -7,7 +7,7 @@ Documentation: https://premiere-pro-mcp.com/docs/
 Source: https://github.com/leancoderkavy/premiere-pro-mcp
 npm: https://www.npmjs.com/package/premiere-pro-mcp
 License: MIT
-Current release: 1.10.0
+Current release: 1.11.0
 
 ## What it does
 

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -24,7 +24,7 @@ The recommended setup runs the MCP server and CEP bridge locally. Project media 
 
 ## Verified facts
 
-- Current project release: 1.10.0.
+- Current project release: 1.11.0.
 - Tool surface: 282 core structured MCP tools are registered; the default profile exposes 280. With an authenticated compatible UXP panel, 48 additional capability-gated tools bring the connected surface to 328. The server also exposes 3 resources and 4 prompts.
 - Supported desktop platforms: Windows and macOS.
 - Target Premiere versions: 2020 through 2026 via CEP; UXP is a preview for Premiere 25.6 and newer.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "premiere-pro-mcp",
-      "version": "1.10.0",
+      "version": "1.11.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
@@ -2977,9 +2977,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.10.0",
-  "description": "Adobe Premiere Pro MCP server with 280 core AI video editing tools and a capability-aware UXP bridge for supported Premiere workflows.",
+  "version": "1.11.0",
+  "description": "Adobe Premiere Pro MCP server with 282 core AI video editing tools and a capability-aware UXP bridge for supported Premiere workflows.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",
   "type": "module",
@@ -106,6 +106,7 @@
     "body-parser": "^2.3.0",
     "fast-uri": "^3.1.5",
     "hono": "^4.12.34",
-    "ip-address": "^10.4.0"
+    "ip-address": "^10.4.0",
+    "nanoid": "3.3.18"
   }
 }

--- a/plugins/premiere-pro/.codex-plugin/plugin.json
+++ b/plugins/premiere-pro/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "description": "Plan, execute, verify, and export video edits in Adobe Premiere Pro through the Premiere Pro MCP server.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/plugins/premiere-pro/.mcp.json
+++ b/plugins/premiere-pro/.mcp.json
@@ -4,7 +4,7 @@
       "title": "Premiere Pro MCP",
       "description": "Inspect and edit a local Adobe Premiere Pro project through the Premiere Pro MCP bridge.",
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.10.0"]
+      "args": ["-y", "premiere-pro-mcp@1.11.0"]
     }
   }
 }

--- a/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.10.0 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.11.0 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.10.0",
+  "version": "1.11.0",
   "coreTools": 282,
   "defaultProfileTools": 280,
   "uxpAdditionalTools": 48,

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -11,6 +11,12 @@ describe("canonical release metadata", () => {
 
   it("aligns every distributable manifest with the canonical version", () => {
     expect(readJson("package.json").version).toBe(release.version);
+    expect(readJson("package.json").description).toContain(
+      `${release.coreTools} core AI video editing tools`,
+    );
+    const packageLock = readJson("package-lock.json");
+    expect(packageLock.version).toBe(release.version);
+    expect(packageLock.packages[""].version).toBe(release.version);
     expect(readJson("claude-desktop/manifest.json").version).toBe(release.version);
     expect(readJson("uxp-plugin/manifest.json").version).toBe(release.version);
     expect(readJson("plugins/premiere-pro/.codex-plugin/plugin.json").version).toBe(
@@ -19,10 +25,24 @@ describe("canonical release metadata", () => {
     expect(
       readJson("claude-plugins/premiere-pro/.claude-plugin/plugin.json").version,
     ).toBe(release.version);
+    expect(readJson(".claude-plugin/marketplace.json").plugins[0].version).toBe(
+      release.version,
+    );
+
+    for (const path of [
+      "plugins/premiere-pro/.mcp.json",
+      "claude-plugins/premiere-pro/.mcp.json",
+    ]) {
+      expect(read(path)).toContain(`premiere-pro-mcp@${release.version}`);
+    }
 
     const cepManifest = read("cep-plugin/CSXS/manifest.xml");
     expect(cepManifest).toContain(`ExtensionBundleVersion="${release.version}"`);
     expect(cepManifest).toContain(`Version="${release.version}"`);
+    expect(read("cep-plugin/updater.cjs")).toContain(
+      `CURRENT_VERSION = "${release.version}"`,
+    );
+    expect(read("cep-plugin/index.html")).toContain(`Version ${release.version}`);
   });
 
   it("aligns public release and capability claims", () => {
@@ -54,6 +74,10 @@ describe("canonical release metadata", () => {
       `/releases/download/v${release.version}/MCPBridgeCEP.zxp`,
     );
     expect(landingProduct).toContain(`/releases/tag/v${release.version}`);
+    expect(readme).toContain(`Latest release: ${release.version}`);
+    expect(read("landing/app/changelog/page.tsx")).toContain(
+      `version: "${release.version}"`,
+    );
   });
 
   it("keeps computed tool-count relationships explicit", () => {

--- a/uxp-plugin/manifest.json
+++ b/uxp-plugin/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.ppmcp.premiere.uxp",
   "name": "Premiere Pro MCP Bridge",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "main": "index.html",
   "host": { "app": "premierepro", "minVersion": "25.6.0" },
   "entrypoints": [


### PR DESCRIPTION
## Summary

- release the merged host-evidence, readiness, checkpoint, media-health, track-state, source-trim, benchmark, volume, and supported-actions work as v1.11.0
- align npm, CEP, UXP, Claude Desktop, Codex/Claude plugin, landing, issue-template, and public documentation versions
- expand the documented surface to 282 core / 280 default / 48 UXP / 328 connected tools
- pin nanoid 3.3.18 to clear the development dependency advisory
- add release metadata regression checks for package, lockfile, marketplace, MCP configs, CEP updater/UI, README, and landing changelog

## Validation

- `npm run check` — 53 files / 1,490 tests
- `npm run test:coverage` — 91.26% branch coverage
- `npm audit --audit-level=high` — 0 vulnerabilities
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- `npm run publish:npm:dry-run` — 156-file v1.11.0 tarball
- signed CEP ZXP build and signature verification
- Claude Desktop MCPB build and manifest validation
- direct UXP CCX build and package validation
- `landing`: lint, production build, full and production audits
- distribution source validation for Claude MCPB and UXP CCX

## Release boundary

Automated mocks, contracts, package validation, and CI do not constitute validation inside a licensed Premiere host. The protected CI installer workflow is the Windows installer gate because this workstation does not have a .NET SDK.