### PR TITLE
Release v1.11.1 static-route stability hotfix

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "premiere-pro",
       "source": "./claude-plugins/premiere-pro",
       "description": "Inspect, edit, verify, and export local Premiere Pro projects through MCP.",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "category": "creative",
       "tags": ["premiere-pro", "video-editing", "mcp"]
     }

--- a/.github/ISSUE_TEMPLATE/compatibility_report.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility_report.yml
@@ -14,7 +14,7 @@ body:
     id: versions
     attributes:
       label: Premiere Pro and MCP versions
-      placeholder: Premiere 26.3.0, Premiere Pro MCP 1.11.0
+      placeholder: Premiere 26.3.0, Premiere Pro MCP 1.11.1
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/tool_failure.yml
+++ b/.github/ISSUE_TEMPLATE/tool_failure.yml
@@ -17,7 +17,7 @@ body:
     id: package-version
     attributes:
       label: Premiere Pro MCP version
-      placeholder: 1.11.0
+      placeholder: 1.11.1
     validations:
       required: true
   - type: input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.11.1] - 2026-08-16
+
+### Fixed
+
+- Extensionless landing routes such as `/changelog` now resolve to their
+  exported `index.html` file instead of attempting to stream a directory. The
+  previous behavior emitted an unhandled `EISDIR` error on Linux and restarted
+  the remote HTTP process.
+- Static asset candidates are required to remain inside the landing directory
+  and resolve to regular files, and read-stream failures are handled without
+  terminating the server.
+
+### Validation
+
+- Added regression coverage for extensionless exported routes and asynchronous
+  static-file read failures. The complete release gates remain distinct from
+  validation inside a licensed Premiere host.
+
 ## [1.11.0] - 2026-08-16
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -31,20 +31,19 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 
 The AI handles the entire workflow through 282 core tools spanning the supported ExtendScript, QE DOM, local media analysis, safe edit-planning, and connection-verification surfaces. A compatible, authenticated UXP panel adds 48 documented, capability-gated tools without replacing the production CEP bridge.
 
-### Latest release: 1.11.0
+### Latest release: 1.11.1
 
-- **Host evidence and readiness:** a bounded UXP event journal, AME terminal receipts, and
-  explicit readiness gates distinguish verified completion, pending work, and lost history.
-- **Guarded production workflows:** GUID-targeted project sessions, growing-media pause leases,
-  transactional checkpoints, and bounded media-health inspection fail closed on stale state.
-- **Timeline precision:** caption-aware track controls and source-clip trim and framing add
-  readback-verified mutations; clip-volume writes now convert dB correctly and support batches.
-- **Performance and support evidence:** a hybrid-acceleration benchmark gate and the generated
-  [supported-actions catalog](docs/supported-actions.md) document every current action and boundary.
+- **Remote-server stability:** extensionless exported routes now resolve to `index.html`
+  instead of streaming a directory and crashing the Node process with `EISDIR` on Linux.
+- **Defense in depth:** static paths must remain inside the landing root and resolve to regular
+  files; asynchronous read failures are handled without terminating the server.
+- **v1.11 workflow set included:** host events, AME receipts, readiness gates, guarded project
+  sessions, growing-media leases, checkpoints, media health, track state, source trim and framing,
+  corrected batch volume controls, and evidence-gated acceleration remain available.
 - **Truthful compatibility:** CEP remains the production-compatible bridge, and automated UXP
   contracts do not claim validation inside a real Premiere host.
 
-See the [v1.11.0 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.11.0)
+See the [v1.11.1 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.11.1)
 for complete details. Live installation in Premiere Pro still requires host verification.
 
 ---
@@ -53,9 +52,9 @@ for complete details. Live installation in Premiere Pro still requires host veri
 
 ### Easiest supported path: Claude Desktop
 
-1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.11.0/premiere-pro-mcp-1.11.0.mcpb).
+1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.11.1/premiere-pro-mcp-1.11.1.mcpb).
 2. In Claude Desktop, open **Settings > Extensions > Advanced settings > Install Extension**, select the downloaded bundle, and restart Claude Desktop.
-3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.11.0/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
+3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.11.1/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
 4. Restart Premiere, open a project, then open **Window > Extensions > MCP Bridge**.
 5. In Claude, enter: `Safely check my Premiere connection with verify_premiere_connection. Make no changes.`
 
@@ -279,11 +278,11 @@ From a clone of this repository:
 ```bash
 codex plugin marketplace add .
 codex plugin add premiere-pro@premiere-pro-mcp
-npx -y premiere-pro-mcp@1.11.0 --install-cep
+npx -y premiere-pro-mcp@1.11.1 --install-cep
 ```
 
 Restart Premiere Pro and start a new Codex session after installation. The plugin
-launches `premiere-pro-mcp@1.11.0` through `npx`; the separate CEP installation is
+launches `premiere-pro-mcp@1.11.1` through `npx`; the separate CEP installation is
 required because the MCP server communicates with the running Premiere host through
 the local bridge.
 
@@ -303,7 +302,7 @@ For Claude Code, add this repository as a marketplace and install the plugin:
 Then install the Premiere bridge and start a new Claude Code session:
 
 ```bash
-npx -y premiere-pro-mcp@1.11.0 --install-cep
+npx -y premiere-pro-mcp@1.11.1 --install-cep
 ```
 
 The Claude Code package lives in

--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.11.0" ExtensionBundleName="MCP Bridge">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.11.1" ExtensionBundleName="MCP Bridge">
   <ExtensionList>
-    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.11.0"/>
-    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.11.0"/>
+    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.11.1"/>
+    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.11.1"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/cep-plugin/index.html
+++ b/cep-plugin/index.html
@@ -81,7 +81,7 @@
     <section class="update-section" aria-live="polite">
       <div class="update-copy">
         <span class="section-label">Connector updates</span>
-        <strong id="updateTitle">Version 1.11.0</strong>
+        <strong id="updateTitle">Version 1.11.1</strong>
         <span id="updateDetail">Checking for updates…</span>
       </div>
       <button id="btnUpdate" class="button button-update" onclick="handleUpdateClick()" type="button" disabled>

--- a/cep-plugin/updater.cjs
+++ b/cep-plugin/updater.cjs
@@ -7,7 +7,7 @@
 })(this, function () {
   "use strict";
 
-  var CURRENT_VERSION = "1.11.0";
+  var CURRENT_VERSION = "1.11.1";
   var LATEST_RELEASE_API =
     "https://api.github.com/repos/leancoderkavy/premiere-pro-mcp/releases/latest";
   var RELEASES_URL =

--- a/claude-desktop/manifest.json
+++ b/claude-desktop/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "premiere-pro-mcp",
   "display_name": "Premiere Pro MCP",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Control a local Adobe Premiere Pro project through MCP.",
   "long_description": "Inspect projects, assemble and modify timelines, manage media, effects, audio and captions, and export deliverables through a local bridge to Adobe Premiere Pro.",
   "author": {

--- a/claude-plugins/premiere-pro/.claude-plugin/plugin.json
+++ b/claude-plugins/premiere-pro/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "premiere-pro",
   "displayName": "Premiere Pro MCP",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Inspect, edit, verify, and export local Adobe Premiere Pro projects through MCP.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/claude-plugins/premiere-pro/.mcp.json
+++ b/claude-plugins/premiere-pro/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "premiere-pro": {
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.11.0"]
+      "args": ["-y", "premiere-pro-mcp@1.11.1"]
     }
   }
 }

--- a/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.11.0 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.11.1 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -5,6 +5,26 @@ import { product } from "@/lib/product"
 
 const releases = [
   {
+    version: "1.11.1",
+    date: "2026-08-16",
+    label: "Remote static-route stability hotfix",
+    groups: [
+      {
+        title: "Fixed",
+        items: [
+          "Extensionless exported routes now resolve to their index file instead of streaming a directory and restarting the Linux HTTP process with EISDIR.",
+          "Static candidates must remain inside the landing root and resolve to regular files; asynchronous read failures no longer terminate the server.",
+        ],
+      },
+      {
+        title: "Validation",
+        items: [
+          "Regression tests cover extensionless routes and read-stream failures; real Premiere host verification remains a separate gate.",
+        ],
+      },
+    ],
+  },
+  {
     version: "1.11.0",
     date: "2026-08-16",
     label: "Evidence-backed third-wave UXP workflows",

--- a/landing/lib/product.ts
+++ b/landing/lib/product.ts
@@ -1,6 +1,6 @@
 export const product = {
   name: "Premiere Pro MCP",
-  version: "1.11.0",
+  version: "1.11.1",
   releaseDate: "2026-08-16",
   coreToolCount: 282,
   defaultProfileToolCount: 280,
@@ -10,10 +10,10 @@ export const product = {
   uxpMinimumVersion: "25.6",
   downloads: {
     claudeBundle:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.11.0/premiere-pro-mcp-1.11.0.mcpb",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.11.1/premiere-pro-mcp-1.11.1.mcpb",
     signedCepConnector:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.11.0/MCPBridgeCEP.zxp",
-    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.11.0",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.11.1/MCPBridgeCEP.zxp",
+    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.11.1",
   },
   links: {
     repository: "https://github.com/leancoderkavy/premiere-pro-mcp",

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -7,7 +7,7 @@ Documentation: https://premiere-pro-mcp.com/docs/
 Source: https://github.com/leancoderkavy/premiere-pro-mcp
 npm: https://www.npmjs.com/package/premiere-pro-mcp
 License: MIT
-Current release: 1.11.0
+Current release: 1.11.1
 
 ## What it does
 

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -24,7 +24,7 @@ The recommended setup runs the MCP server and CEP bridge locally. Project media 
 
 ## Verified facts
 
-- Current project release: 1.11.0.
+- Current project release: 1.11.1.
 - Tool surface: 282 core structured MCP tools are registered; the default profile exposes 280. With an authenticated compatible UXP panel, 48 additional capability-gated tools bring the connected surface to 328. The server also exposes 3 resources and 4 prompts.
 - Supported desktop platforms: Windows and macOS.
 - Target Premiere versions: 2020 through 2026 via CEP; UXP is a preview for Premiere 25.6 and newer.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "premiere-pro-mcp",
-      "version": "1.11.0",
+      "version": "1.11.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Adobe Premiere Pro MCP server with 282 core AI video editing tools and a capability-aware UXP bridge for supported Premiere workflows.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/premiere-pro/.codex-plugin/plugin.json
+++ b/plugins/premiere-pro/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "Plan, execute, verify, and export video edits in Adobe Premiere Pro through the Premiere Pro MCP server.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/plugins/premiere-pro/.mcp.json
+++ b/plugins/premiere-pro/.mcp.json
@@ -4,7 +4,7 @@
       "title": "Premiere Pro MCP",
       "description": "Inspect and edit a local Adobe Premiere Pro project through the Premiere Pro MCP bridge.",
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.11.0"]
+      "args": ["-y", "premiere-pro-mcp@1.11.1"]
     }
   }
 }

--- a/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.11.0 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.11.1 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.11.0",
+  "version": "1.11.1",
   "coreTools": 282,
   "defaultProfileTools": 280,
   "uxpAdditionalTools": 48,

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -60,16 +60,47 @@ function serveLanding(req: http.IncomingMessage, res: http.ServerResponse): bool
   // Next.js trailingSlash: /about/ -> /about/index.html
   if (urlPath.endsWith("/")) urlPath += "index.html";
 
-  const filePath = path.join(LANDING_DIR, urlPath);
+  let filePath = path.resolve(LANDING_DIR, `.${urlPath}`);
   // Security: ensure we stay within LANDING_DIR
-  if (!filePath.startsWith(LANDING_DIR)) return false;
+  const relativePath = path.relative(LANDING_DIR, filePath);
+  if (
+    relativePath === ".." ||
+    relativePath.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relativePath)
+  ) return false;
 
   if (!fs.existsSync(filePath)) return false;
 
+  let fileStats: fs.Stats;
+  try {
+    fileStats = fs.statSync(filePath);
+    // Accept extensionless Next.js routes such as /changelog without trying to
+    // stream the directory itself. Streaming a directory emits an unhandled
+    // EISDIR error on Linux and previously restarted the production process.
+    if (fileStats.isDirectory()) {
+      filePath = path.join(filePath, "index.html");
+      if (!fs.existsSync(filePath)) return false;
+      fileStats = fs.statSync(filePath);
+    }
+  } catch {
+    return false;
+  }
+  if (!fileStats.isFile()) return false;
+
   const ext = path.extname(filePath);
   const contentType = MIME[ext] ?? "application/octet-stream";
+  const stream = fs.createReadStream(filePath);
+  stream.once("error", (error) => {
+    console.error("[premiere-pro-mcp] Landing asset read failed:", error);
+    if (!res.headersSent) {
+      res.writeHead(500, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end("Internal server error");
+      return;
+    }
+    res.destroy();
+  });
   res.writeHead(200, { "Content-Type": contentType });
-  fs.createReadStream(filePath).pipe(res);
+  stream.pipe(res);
   return true;
 }
 

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -55,12 +55,25 @@ const MIME: Record<string, string> = {
 function serveLanding(req: http.IncomingMessage, res: http.ServerResponse): boolean {
   if (!fs.existsSync(LANDING_DIR)) return false;
 
-  let urlPath = req.url?.split("?")[0] ?? "/";
-  if (urlPath === "/" || urlPath === "") urlPath = "/index.html";
-  // Next.js trailingSlash: /about/ -> /about/index.html
-  if (urlPath.endsWith("/")) urlPath += "index.html";
+  let urlPath: string;
+  try {
+    urlPath = decodeURIComponent(req.url?.split("?")[0] ?? "/");
+  } catch {
+    return false;
+  }
+  const requestedSegments = urlPath.split("/").filter(Boolean);
+  const safeSegments = requestedSegments.map((segment) => path.basename(segment));
+  if (safeSegments.some((segment, index) => (
+    segment !== requestedSegments[index] ||
+    segment === "." ||
+    segment === ".." ||
+    segment.includes("\\") ||
+    segment.includes("\0")
+  ))) return false;
+  // Next.js trailingSlash exports /about/ as /about/index.html.
+  if (urlPath.endsWith("/") || safeSegments.length === 0) safeSegments.push("index.html");
 
-  let filePath = path.resolve(LANDING_DIR, `.${urlPath}`);
+  let filePath = path.join(LANDING_DIR, ...safeSegments);
   // Security: ensure we stay within LANDING_DIR
   const relativePath = path.relative(LANDING_DIR, filePath);
   if (

--- a/tests/entrypoints-unit.test.ts
+++ b/tests/entrypoints-unit.test.ts
@@ -372,9 +372,11 @@ describe("HTTP entry point", () => {
   it("rejects landing paths that escape the static root", async () => {
     mocks.fsExists.mockReturnValue(true);
     const handler = await loadHttp();
-    const res = response();
-    await handler({ method: "GET", url: "/../outside.txt", headers: {} }, res);
-    expect(res.statusCode).toBe(404);
+    for (const url of ["/../outside.txt", "/%2e%2e/outside.txt", "/..\\outside.txt"]) {
+      const res = response();
+      await handler({ method: "GET", url, headers: {} }, res);
+      expect(res.statusCode).toBe(404);
+    }
     expect(mocks.fsCreateReadStream).not.toHaveBeenCalled();
   });
 

--- a/tests/entrypoints-unit.test.ts
+++ b/tests/entrypoints-unit.test.ts
@@ -15,6 +15,9 @@ const mocks = vi.hoisted(() => ({
   uxpStop: vi.fn(async () => {}),
   execFileSync: vi.fn(),
   fsExists: vi.fn(() => false),
+  fsStat: vi.fn(() => ({ isDirectory: () => false, isFile: () => true })),
+  fsCreateReadStream: vi.fn(),
+  streamOnce: vi.fn(),
   pipe: vi.fn(),
 }));
 
@@ -62,7 +65,8 @@ vi.mock("node:fs", async (original) => {
     default: {
       ...actual,
       existsSync: mocks.fsExists,
-      createReadStream: vi.fn(() => ({ pipe: mocks.pipe })),
+      statSync: mocks.fsStat,
+      createReadStream: mocks.fsCreateReadStream,
     },
   };
 });
@@ -79,6 +83,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   mocks.requestHandler = undefined;
   mocks.fsExists.mockReturnValue(false);
+  mocks.fsStat.mockReturnValue({ isDirectory: () => false, isFile: () => true });
+  mocks.fsCreateReadStream.mockReturnValue({ once: mocks.streamOnce, pipe: mocks.pipe });
   process.env = { ...env };
 });
 afterEach(() => {
@@ -97,6 +103,7 @@ function response() {
     statusCode: 200, headersSent: false, body: "", closeHandler: undefined,
     writeHead: vi.fn((status: number) => { res.statusCode = status; res.headersSent = true; }),
     end: vi.fn((body = "") => { res.body = body; }),
+    destroy: vi.fn(),
     on: vi.fn((name: string, handler: () => void) => { if (name === "close") res.closeHandler = handler; }),
   };
   return res;
@@ -329,6 +336,46 @@ describe("HTTP entry point", () => {
     await handler({ method: "GET", url: "/docs/", headers: {} }, res);
     expect(res.writeHead).toHaveBeenCalledWith(200, { "Content-Type": "text/html; charset=utf-8" });
     expect(mocks.pipe).toHaveBeenCalledWith(res);
+  });
+
+  it("serves extensionless landing routes from their index file", async () => {
+    mocks.fsExists.mockReturnValue(true);
+    mocks.fsStat
+      .mockReturnValueOnce({ isDirectory: () => true, isFile: () => false })
+      .mockReturnValueOnce({ isDirectory: () => false, isFile: () => true });
+    const handler = await loadHttp();
+    const res = response();
+    await handler({ method: "GET", url: "/changelog", headers: {} }, res);
+    expect(mocks.fsCreateReadStream).toHaveBeenCalledWith(
+      expect.stringMatching(/[\\/]changelog[\\/]index\.html$/),
+    );
+    expect(res.statusCode).toBe(200);
+    expect(mocks.pipe).toHaveBeenCalledWith(res);
+  });
+
+  it("does not crash when a landing asset read fails after validation", async () => {
+    mocks.fsExists.mockReturnValue(true);
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const handler = await loadHttp();
+    const res = response();
+    await handler({ method: "GET", url: "/docs/", headers: {} }, res);
+    const streamError = mocks.streamOnce.mock.calls.find(([event]) => event === "error")?.[1];
+    expect(streamError).toBeTypeOf("function");
+    streamError(new Error("read failed"));
+    expect(res.destroy).toHaveBeenCalledOnce();
+    expect(error).toHaveBeenCalledWith(
+      "[premiere-pro-mcp] Landing asset read failed:",
+      expect.any(Error),
+    );
+  });
+
+  it("rejects landing paths that escape the static root", async () => {
+    mocks.fsExists.mockReturnValue(true);
+    const handler = await loadHttp();
+    const res = response();
+    await handler({ method: "GET", url: "/../outside.txt", headers: {} }, res);
+    expect(res.statusCode).toBe(404);
+    expect(mocks.fsCreateReadStream).not.toHaveBeenCalled();
   });
 
   it("returns 404 when no landing asset matches", async () => {

--- a/uxp-plugin/manifest.json
+++ b/uxp-plugin/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.ppmcp.premiere.uxp",
   "name": "Premiere Pro MCP Bridge",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "main": "index.html",
   "host": { "app": "premierepro", "minVersion": "25.6.0" },
   "entrypoints": [


### PR DESCRIPTION
## Summary

- prevent extensionless exported routes such as `/changelog` from streaming a directory and crashing the Linux HTTP process with `EISDIR`
- resolve valid route directories through their `index.html`
- constrain static candidates to the landing root and regular files
- handle asynchronous read-stream failures without terminating the server
- publish the fix consistently as v1.11.1 across npm, CEP, UXP, Claude Desktop, Codex/Claude plugins, landing, and documentation

## Regression evidence

A real local HTTP process was probed after the production-log diagnosis:

- `/changelog`, `/docs`, and `/privacy` without trailing slashes: 200
- static directory without an index: 404
- raw `/../package.json` traversal: 404
- unauthenticated `/mcp`: 401
- `/health` after all probes: 200

## Validation

- `npm run check` — 53 files / 1,493 tests
- `npm run test:coverage` — 91.26% branch coverage
- full and production npm audits — 0 vulnerabilities
- `npm run publish:npm:dry-run` plus signed CEP rebuild
- 156-file npm pack includes `artifacts/MCPBridgeCEP.zxp`
- Claude Desktop MCPB and direct UXP CCX builds validate
- landing lint, production build, and both audits pass
- Claude/UXP source distribution validation passes

## Boundary

This fixes the remote HTTP/static server availability defect. It does not alter Premiere mutation behavior, and automated validation still does not establish behavior inside a licensed Premiere host.