### PR TITLE
Fix Premiere 26.x CEP mutation false successes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `overwrite_clip` now rejects invalid video and audio track indices before invoking
   Premiere and confirms the requested source item appears at the requested frame. A
   no-op or an unverifiable repeat placement returns an error instead of false success.
+- `trim_clip` now proves the requested source point also produced the expected visible timeline
+  edge and duration. It refuses retimed clips and, by default, trims that would strand effect
+  keyframes instead of treating source-metadata-only changes as success on Premiere Pro 26.x.
+- `split_clip` now verifies that a clip spans the requested cut and that QE produced each expected
+  left/right segment, rather than accepting any increase in track clip count. QE keyframe
+  redistribution remains explicitly unverified.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added a context-aware rough-cut prompt and `config://premiere-project-context`
   resource documenting privacy, invalidation, retrieval, and preview requirements.
 
+### Fixed
+
+- `add_track` and QE-backed `add_tracks` now validate their inputs and return success
+  only after the active sequence reports the exact requested track-count increase. The
+  single-track call uses a bounded QE fallback only when the public DOM call made no
+  change, and never retries a partially applied call.
+- `overwrite_clip` now rejects invalid video and audio track indices before invoking
+  Premiere and confirms the requested source item appears at the requested frame. A
+  no-op or an unverifiable repeat placement returns an error instead of false success.
+
 ### Security
 
 - Native media paths are hashed before persistence, credential-like enrichment

--- a/README.md
+++ b/README.md
@@ -552,6 +552,19 @@ the tables below are a shorter workflow-oriented overview.
 | `apply_lut` | Apply LUT files |
 | `stabilize_clip` | Warp Stabilizer with configurable settings |
 
+> **Premiere 26.x component removal:** `remove_effect` and `remove_effect_by_name`
+> require the CEP `Component.remove()` method. Some 26.x components, including
+> Essential Sound's **Amplify**, do not expose that method. The tools return an
+> actionable capability error and leave the component unchanged; use Effect Controls
+> to remove it manually. The QE DOM has no safe targeted-removal fallback.
+
+> **Essential Sound audio automation:** Essential Sound can write ducking or level
+> automation to an **Amplify** component rather than the clip's **Volume > Level**.
+> `adjust_audio_levels`, `set_clip_volume`, and `get_clip_volume` operate only on
+> Volume > Level, so they do not read, change, or verify Amplify automation. Inspect
+> the clip's components (or Effect Controls) before treating a Volume readback as the
+> clip's final gain.
+
 ### Keyframes (8)
 
 | Tool | Description |

--- a/README.md
+++ b/README.md
@@ -542,6 +542,14 @@ the tables below are a shorter workflow-oriented overview.
 > `qeTrack.addTransition`; overlay clips remain a workaround for transitions that do not need
 > to blend adjacent source frames. See [issue #21](https://github.com/leancoderkavy/premiere-pro-mcp/issues/21).
 
+> **Verified track edits:** `add_track` and `add_tracks` validate requested counts and
+> return success only when the active sequence's track counts exactly match the request.
+> `overwrite_clip` validates both selected track indices and confirms the requested source
+> item appears at the requested frame on a target track. On a Premiere 26.x build that
+> ignores any of these calls, the MCP response is an error with the observed state rather
+> than a false success. These are automated CEP contracts, not proof of a particular
+> licensed host configuration.
+
 ### Effects & Color (8)
 
 | Tool | Description |

--- a/README.md
+++ b/README.md
@@ -530,7 +530,7 @@ the tables below are a shorter workflow-oriented overview.
 | `roll_edit` / `slide_edit` / `slip_edit` | Professional trim modes (QE) |
 | `move_clip_to_track` | Move between tracks (QE) |
 | `set_clip_speed_qe` / `reverse_clip` | Speed/reverse (QE) |
-| `split_clip` / `trim_clip` / `move_clip` | Basic edits |
+| `split_clip` / `trim_clip` / `move_clip` | Basic edits; trim verifies source points and visible timeline edges |
 | `set_clip_properties` | Opacity, scale, rotation, position |
 | `link_selection` / `unlink_selection` | Link/unlink A/V |
 
@@ -549,6 +549,16 @@ the tables below are a shorter workflow-oriented overview.
 > ignores any of these calls, the MCP response is an error with the observed state rather
 > than a false success. These are automated CEP contracts, not proof of a particular
 > licensed host configuration.
+
+ `trim_clip` accepts exactly one source-relative `new_in_seconds` or `new_out_seconds` per
+call. It refuses retimed clips because CEP cannot prove their source-to-timeline mapping, then
+reads both source points and visible timeline start/end/duration before reporting success. The
+default `keyframe_policy: "reject"` stops before a trim that would leave effect keyframes beyond
+the visible clip; `keyframe_policy: "preserve"` is an explicit opt-in and reports the remaining
+count. `split_clip` verifies a spanning clip, the expected count increase, and the left/right
+cut boundaries. Its QE path cannot prove effect-keyframe redistribution, so a successful result
+labels those semantics `unverified`. These are CEP contract checks, not validation in a licensed
+Premiere Pro 26.x host.
 
 ### Effects & Color (8)
 

--- a/docs/supported-actions.md
+++ b/docs/supported-actions.md
@@ -47,7 +47,7 @@ operation” when the tool has no enum-based mode.
 | `add_tracks` | Default profile | Single operation | Add video and/or audio tracks to the active sequence. Uses QE DOM. |
 | `add_transition` | Default profile | Single operation | Add a video transition between two clips at a cut point. Uses QE DOM. |
 | `add_transition_to_clip` | Default profile | `position`: `start`, `end`, `both` | Add a transition to a specific clip's start or end |
-| `adjust_audio_levels` | Default profile | Single operation | Adjust the audio level (volume) of a clip in dB |
+| `adjust_audio_levels` | Default profile | Single operation | Adjust a clip's Volume > Level in dB. Does not read or change Essential Sound Amplify automation. |
 | `apply_audio_effect` | Default profile | Single operation | Apply an audio effect to a clip |
 | `apply_edit_plan` | Default profile | Single operation | Apply a previously previewed compound edit after revalidating every target. Requires the edit capability and exact preview confirmation token. |
 | `apply_effect` | Default profile | Single operation | Apply a video effect to a clip. Uses QE DOM for effect lookup. |
@@ -121,7 +121,7 @@ operation” when the tool has no enum-based mode.
 | `get_clip_markers` | Default profile | Single operation | Get all markers on a specific project item (source clip markers, not sequence markers). |
 | `get_clip_properties` | Default profile | Single operation | Get detailed properties of a specific clip by its node ID |
 | `get_clip_speed` | Default profile | Single operation | Get the playback speed and reverse state of a clip |
-| `get_clip_volume` | Default profile | Single operation | Read the volume level of an audio clip, returned in dB. Use this to verify a level actually applied - setValue() clamps silently. |
+| `get_clip_volume` | Default profile | Single operation | Read an audio clip's Volume > Level in dB. Use this to verify a level actually applied - setValue() clamps silently. Does not report Essential Sound Amplify automation. |
 | `get_color_label` | Default profile | Single operation | Get the color label of a project item |
 | `get_color_space` | Default profile | Single operation | Get the color space information for a project item |
 | `get_duplicate_media` | Default profile | Single operation | Find project items that reference the same source media file. Useful for consolidation. |
@@ -221,8 +221,8 @@ operation” when the tool has no enum-based mode.
 | `refresh_media` | Default profile | Single operation | Refresh a project item to pick up changes to the source file |
 | `relink_media` | Default profile | Single operation | Relink an offline media item to a new file path |
 | `remove_all_effects` | Default profile | Single operation | Remove ALL effects from a clip. Uses QE DOM. |
-| `remove_effect` | Default profile | Single operation | Remove an effect from a clip by its index or name |
-| `remove_effect_by_name` | Default profile | Single operation | Remove all instances of a specific effect from a clip by display name. |
+| `remove_effect` | Default profile | Single operation | Remove an effect from a clip by its index or name. Returns a capability error when the host cannot remove an individual component. |
+| `remove_effect_by_name` | Default profile | Single operation | Remove all instances of a specific effect from a clip by display name. Returns a capability error when the host cannot remove individual components. |
 | `remove_from_timeline` | Default profile | Single operation | Remove a clip from the timeline |
 | `remove_keyframe` | Default profile | Single operation | Remove a keyframe at a specific time from an effect property |
 | `remove_keyframe_range` | Default profile | Single operation | Remove all keyframes in a time range from an effect property |
@@ -261,7 +261,7 @@ operation” when the tool has no enum-based mode.
 | `set_clip_selection` | Default profile | Single operation | Select or deselect a clip in the active sequence |
 | `set_clip_speed_qe` | Default profile | Single operation | Set clip playback speed using QE DOM (more reliable than ExtendScript). Supports reverse. |
 | `set_clip_start_time` | Default profile | Single operation | Set the start time (timecode offset) of a project item. This shifts where timecode begins for the source media. |
-| `set_clip_volume` | Default profile | Single operation | Set the volume level on an audio clip (in dB). |
+| `set_clip_volume` | Default profile | Single operation | Set an audio clip's Volume > Level in dB. Does not read or change Essential Sound Amplify automation. |
 | `set_clips_volume` | Default profile | Single operation | Set the volume (in dB) on every audio clip of a track, or on a list of clip indices. One round trip instead of one call per clip - essential for sequences with dozens of clips. |
 | `set_color_label` | Default profile | Single operation | Set the color label on a project item or clip |
 | `set_color_value` | Default profile | Single operation | Set a color value on an effect property (e.g., tint color, fill color) |

--- a/docs/supported-actions.md
+++ b/docs/supported-actions.md
@@ -43,8 +43,8 @@ operation” when the tool has no enum-based mode.
 | `add_text_overlay` | Default profile | `caption_format`: `608`, `708`, `subtitle`, `teletext` | Add a subtitle-style text overlay to the active sequence. Note: Premiere's ExtendScript API does not expose Essential-Graphics title creation, so this routes through the Captions/Subtitle API. Text appears on a caption track at the platform-default subtitle position. For freeform titles, render a PNG and import_media it instead. |
 | `add_to_render_queue` | Default profile | Single operation | Add the active sequence to the Adobe Media Encoder render queue |
 | `add_to_timeline` | Default profile | Single operation | Add a project item (clip) to the timeline at a specific position |
-| `add_track` | Default profile | `track_type`: `video`, `audio` | Add a new video or audio track to the active sequence |
-| `add_tracks` | Default profile | Single operation | Add video and/or audio tracks to the active sequence. Uses QE DOM. |
+| `add_track` | Default profile | `track_type`: `video`, `audio` | Add verified video or audio tracks to the active sequence. Returns an error if Premiere cannot add the exact requested count. |
+| `add_tracks` | Default profile | Single operation | Add video and/or audio tracks through QE and verify the active sequence gained the exact requested counts |
 | `add_transition` | Default profile | Single operation | Add a video transition between two clips at a cut point. Uses QE DOM. |
 | `add_transition_to_clip` | Default profile | `position`: `start`, `end`, `both` | Add a transition to a specific clip's start or end |
 | `adjust_audio_levels` | Default profile | Single operation | Adjust a clip's Volume > Level in dB. Does not read or change Essential Sound Amplify automation. |
@@ -210,7 +210,7 @@ operation” when the tool has no enum-based mode.
 | `nest_clips` | Default profile | Single operation | Nest selected clips into a nested sequence. Select the clips first, then call this tool. |
 | `open_in_source` | Default profile | Single operation | Open a project item in the Source Monitor for preview and trimming. |
 | `open_project` | Default profile | Single operation | Open a Premiere Pro project file |
-| `overwrite_clip` | Default profile | Single operation | Overwrite a project item onto the timeline (replaces existing clips at the insertion point) |
+| `overwrite_clip` | Default profile | Single operation | Overwrite a project item onto validated timeline tracks and verify a new source placement at the requested time |
 | `overwrite_from_source` | Default profile | Single operation | Overwrite the clip from the Source Monitor at the playhead position (overwrite edit — replaces existing clips). |
 | `ping` | Default profile | Single operation | Health check — verify the CEP plugin is running and connected to Premiere Pro. Call this before other tools to confirm connectivity. |
 | `play_source_monitor` | Default profile | Single operation | Start playback of the clip in the Source Monitor |

--- a/docs/supported-actions.md
+++ b/docs/supported-actions.md
@@ -304,12 +304,12 @@ operation” when the tool has no enum-based mode.
 | `slide_edit` | Default profile | Single operation | Perform a slide edit on a clip (moves clip without changing its duration, adjusting adjacent clips). Uses QE DOM. |
 | `slip_edit` | Default profile | Single operation | Perform a slip edit on a clip (changes source in/out points without moving clip on timeline). Uses QE DOM. |
 | `speed_change` | Default profile | Single operation | Change the playback speed of a clip |
-| `split_clip` | Default profile | `track_type`: `video`, `audio` | Split (razor) a clip at a specific time position. Requires QE DOM. |
+| `split_clip` | Default profile | `track_type`: `video`, `audio` | Split every clip on one track that spans a timeline time, then verify both resulting boundaries. Requires QE DOM; effect-keyframe redistribution remains unverified. |
 | `stabilize_clip` | Default profile | `method`: `Subspace Warp`, `Position`, `Position, Scale, Rotation` | Apply the Warp Stabilizer effect to a clip for video stabilization. Uses QE DOM. |
 | `start_batch_encode` | Default profile | Single operation | Start encoding all items in the Adobe Media Encoder render queue |
 | `stop_playback` | Default profile | Single operation | Stop playback of the active sequence timeline. Uses QE DOM. |
 | `toggle_track_visibility` | Default profile | Single operation | Toggle a video track's visibility (eye icon) |
-| `trim_clip` | Default profile | Single operation | Trim a clip's in or out point |
+| `trim_clip` | Default profile | `keyframe_policy`: `reject`, `preserve` | Trim exactly one source in/out point and verify the corresponding visible timeline edge. Refuses retimed clips and, by default, trims that would leave effect keyframes outside the visible clip. |
 | `undo` | Default profile | Single operation | Undo the last action in Premiere Pro |
 | `unlink_selection` | Default profile | Single operation | Unlink the currently selected video and audio clips in the active sequence |
 | `unnest_sequence` | Default profile | Single operation | Unnest a nested sequence on the timeline, replacing it with the contents of the nested sequence |

--- a/src/resources/extendscript-reference.ts
+++ b/src/resources/extendscript-reference.ts
@@ -139,7 +139,7 @@ export const EXTENDSCRIPT_REFERENCE = [
   "comp.displayName               - String",
   "comp.matchName                 - String",
   "comp.properties                - PropertyCollection (.numItems, [i])",
-  "comp.remove()",
+  "comp.remove()                  - Not exposed by every Premiere 26.x CEP component; capability-check before use",
   "",
   "## Property (effect parameters)",
   "prop.displayName               - String",

--- a/src/tools/advanced.ts
+++ b/src/tools/advanced.ts
@@ -597,7 +597,7 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
 
     overwrite_clip: {
       description:
-        "Overwrite a project item onto the timeline (replaces existing clips at the insertion point)",
+        "Overwrite a project item onto validated timeline tracks and verify a new source placement at the requested time",
       parameters: {
         type: "object" as const,
         properties: {
@@ -629,22 +629,81 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
         const startSeconds = args.start_seconds ?? 0;
         const trackIndex = args.track_index ?? 0;
         const audioTrackIndex = args.audio_track_index ?? 0;
+        if (!Number.isFinite(startSeconds) || startSeconds < 0) {
+          return { success: false, error: "start_seconds must be a non-negative finite number" };
+        }
+        if (!Number.isSafeInteger(trackIndex) || trackIndex < 0) {
+          return { success: false, error: "track_index must be a non-negative integer" };
+        }
+        if (!Number.isSafeInteger(audioTrackIndex) || audioTrackIndex < 0) {
+          return { success: false, error: "audio_track_index must be a non-negative integer" };
+        }
 
         const script = buildToolScript(`
           var seq = app.project.activeSequence;
           if (!seq) return __error("No active sequence");
-          
+
+          if (${trackIndex} >= seq.videoTracks.numTracks) {
+            return __error("Video track index ${trackIndex} is out of range: the sequence has " + seq.videoTracks.numTracks + " video track(s).");
+          }
+          if (${audioTrackIndex} >= seq.audioTracks.numTracks) {
+            return __error("Audio track index ${audioTrackIndex} is out of range: the sequence has " + seq.audioTracks.numTracks + " audio track(s).");
+          }
+          if (typeof seq.overwriteClip !== "function") {
+            return __error("Sequence.overwriteClip is unavailable on this Premiere build.");
+          }
+
           var item = __findProjectItem("${escapeForExtendScript(args.item_id)}");
           if (!item) return __error("Project item not found: ${escapeForExtendScript(args.item_id)}");
-          
+
           var startTicks = __secondsToTicks(${startSeconds}).toString();
-          seq.overwriteClip(item, startTicks, ${trackIndex}, ${audioTrackIndex});
-          
+          var wantedItemId = String(item.nodeId);
+          var wantedStartTicks = parseFloat(startTicks);
+          var frameTicks = seq.timebase ? parseFloat(seq.timebase) : NaN;
+          if (!frameTicks || isNaN(frameTicks)) frameTicks = TICKS_PER_SECOND / 24;
+
+          function __isPlacedOn(track) {
+            for (var clipIndex = 0; clipIndex < track.clips.numItems; clipIndex++) {
+              var clip = track.clips[clipIndex];
+              var sourceId = "";
+              try { sourceId = clip.projectItem ? String(clip.projectItem.nodeId) : ""; } catch (sourceError) {}
+              if (sourceId !== wantedItemId) continue;
+              var actualStartTicks = NaN;
+              try { actualStartTicks = parseFloat(clip.start.ticks); } catch (startError) {}
+              if (!isNaN(actualStartTicks) && Math.abs(actualStartTicks - wantedStartTicks) <= frameTicks) return true;
+            }
+            return false;
+          }
+
+          var videoWasPlaced = __isPlacedOn(seq.videoTracks[${trackIndex}]);
+          var audioWasPlaced = __isPlacedOn(seq.audioTracks[${audioTrackIndex}]);
+          try {
+            seq.overwriteClip(item, startTicks, ${trackIndex}, ${audioTrackIndex});
+          } catch (overwriteError) {
+            return __error("Sequence.overwriteClip failed: " + overwriteError.toString());
+          }
+
+          // The call can return without adding anything on Premiere 26.x. Read
+          // the target tracks back by source node ID and frame-snapped position
+          // instead of trusting the method's return value or a clip-count delta.
+          var videoPlaced = __isPlacedOn(seq.videoTracks[${trackIndex}]);
+          var audioPlaced = __isPlacedOn(seq.audioTracks[${audioTrackIndex}]);
+          if (!videoPlaced && !audioPlaced) {
+            return __error("overwrite_clip did not place project item " + item.name + " on either requested track at ${startSeconds}s. Premiere reported no verifiable timeline change.");
+          }
+          if ((videoPlaced && videoWasPlaced) && (audioPlaced && audioWasPlaced)) {
+            return __error("overwrite_clip produced no verifiable new placement: project item " + item.name + " was already present at ${startSeconds}s on the requested track(s).");
+          }
+
           return __result({
             overwritten: true,
+            verified: true,
             item: item.name,
             trackIndex: ${trackIndex},
-            startSeconds: ${startSeconds}
+            audioTrackIndex: ${audioTrackIndex},
+            startSeconds: ${startSeconds},
+            placedOnVideoTrack: videoPlaced,
+            placedOnAudioTrack: audioPlaced
           });
         `);
         return sendCommand(script, bridgeOptions);
@@ -831,7 +890,7 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
 
     add_tracks: {
       description:
-        "Add video and/or audio tracks to the active sequence. Uses QE DOM.",
+        "Add video and/or audio tracks through QE and verify the active sequence gained the exact requested counts",
       parameters: {
         type: "object" as const,
         properties: {
@@ -864,19 +923,59 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
         const a = args.audio_tracks ?? 0;
         const aMono = args.audio_mono_tracks ?? 0;
         const a51 = args.audio_51_tracks ?? 0;
+        const requested = [
+          ["video_tracks", v],
+          ["audio_tracks", a],
+          ["audio_mono_tracks", aMono],
+          ["audio_51_tracks", a51],
+        ] as const;
+        for (const [name, value] of requested) {
+          if (!Number.isSafeInteger(value) || value < 0) {
+            return { success: false, error: `${name} must be a non-negative integer` };
+          }
+        }
+        if (v + a + aMono + a51 === 0) {
+          return { success: false, error: "Request at least one video or audio track" };
+        }
 
         const script = buildToolScript(`
+          var seq = app.project.activeSequence;
+          if (!seq) return __error("No active sequence");
+          var beforeVideo = seq.videoTracks.numTracks;
+          var beforeAudio = seq.audioTracks.numTracks;
+          var expectedVideo = beforeVideo + ${v};
+          var expectedAudio = beforeAudio + ${a + aMono + a51};
+
+          if (typeof app.enableQE !== "function") return __error("QE is unavailable on this Premiere build; cannot add tracks.");
           app.enableQE();
+          if (typeof qe === "undefined" || !qe.project || typeof qe.project.getActiveSequence !== "function") {
+            return __error("QE active-sequence access is unavailable on this Premiere build; cannot add tracks.");
+          }
           var qeSeq = qe.project.getActiveSequence();
           if (!qeSeq) return __error("No active sequence (QE)");
-          
-          qeSeq.addTracks(${v}, ${a}, ${aMono}, ${a51});
+          if (typeof qeSeq.addTracks !== "function") return __error("QE addTracks is unavailable on this Premiere build.");
+
+          try {
+            qeSeq.addTracks(${v}, ${a}, ${aMono}, ${a51});
+          } catch (addTracksError) {
+            return __error("QE addTracks failed: " + addTracksError.toString());
+          }
+
+          var afterVideo = seq.videoTracks.numTracks;
+          var afterAudio = seq.audioTracks.numTracks;
+          if (afterVideo !== expectedVideo || afterAudio !== expectedAudio) {
+            return __error("QE addTracks did not add the requested tracks: video " + beforeVideo + " -> " + afterVideo + " (expected " + expectedVideo + "), audio " + beforeAudio + " -> " + afterAudio + " (expected " + expectedAudio + ").");
+          }
+
           return __result({
             added: true,
+            verified: true,
             videoTracks: ${v},
             audioTracks: ${a},
             audioMonoTracks: ${aMono},
-            audio51Tracks: ${a51}
+            audio51Tracks: ${a51},
+            totalVideoTracks: afterVideo,
+            totalAudioTracks: afterAudio
           });
         `);
         return sendCommand(script, bridgeOptions);

--- a/src/tools/audio.ts
+++ b/src/tools/audio.ts
@@ -109,7 +109,7 @@ export function invertToSegments(
 export function getAudioTools(bridgeOptions: BridgeOptions) {
   return {
     adjust_audio_levels: {
-      description: "Adjust the audio level (volume) of a clip in dB",
+      description: "Adjust a clip's Volume > Level in dB. Does not read or change Essential Sound Amplify automation.",
       parameters: {
         type: "object" as const,
         properties: {

--- a/src/tools/clipboard.ts
+++ b/src/tools/clipboard.ts
@@ -281,7 +281,7 @@ export function getClipboardTools(bridgeOptions: BridgeOptions) {
     },
 
     remove_effect_by_name: {
-      description: "Remove all instances of a specific effect from a clip by display name.",
+      description: "Remove all instances of a specific effect from a clip by display name. Returns a capability error when the host cannot remove individual components.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -302,17 +302,49 @@ export function getClipboardTools(bridgeOptions: BridgeOptions) {
           if (!result) return __error("Clip not found");
 
           var clip = result.clip;
-          var removed = 0;
-          // Iterate backwards to avoid index issues when removing
+          var effectName = "${escapeForExtendScript(args.effect_name)}";
+          var matches = [];
+          // Record matching indices from back to front. This both keeps indexes
+          // stable during removal and lets us preflight every match before any
+          // mutation, so an unsupported Amplify component cannot cause a partial
+          // all-matches removal.
           for (var i = clip.components.numItems - 1; i >= 0; i--) {
-            if (clip.components[i].displayName === "${escapeForExtendScript(args.effect_name)}") {
-              clip.components[i].remove();
-              removed++;
+            if (clip.components[i].displayName === effectName) {
+              matches.push(i);
             }
           }
 
-          if (removed === 0) return __error("Effect not found: ${escapeForExtendScript(args.effect_name)}");
-          return __result({ removed: removed, effect: "${escapeForExtendScript(args.effect_name)}", clip: clip.name });
+          if (matches.length === 0) return __error("Effect not found: " + effectName);
+
+          function canRemoveComponent(component) {
+            try {
+              return !!component && typeof component.remove === "function";
+            } catch (e) {
+              return false;
+            }
+          }
+
+          // QE offers only removeEffects(), which would also remove unrelated
+          // effects. Do not substitute that broad mutation for this targeted tool.
+          for (var j = 0; j < matches.length; j++) {
+            var component = clip.components[matches[j]];
+            if (!canRemoveComponent(component)) {
+              return __error("Premiere does not expose Component.remove() for \"" + effectName + "\". No matching components were removed. No safe targeted QE fallback exists; remove it manually in Effect Controls.");
+            }
+          }
+
+          var removed = 0;
+          for (var j = 0; j < matches.length; j++) {
+            var component = clip.components[matches[j]];
+            try {
+              component.remove();
+              removed++;
+            } catch (e) {
+              return __error("Premiere could not remove \"" + effectName + "\" after removing " + removed + " matching component(s): " + e.toString() + ". Inspect Effect Controls before retrying.");
+            }
+          }
+
+          return __result({ removed: removed, effect: effectName, clip: clip.name });
         `);
         return sendCommand(script, bridgeOptions);
       },

--- a/src/tools/effects.ts
+++ b/src/tools/effects.ts
@@ -107,7 +107,7 @@ export function getEffectsTools(bridgeOptions: BridgeOptions) {
     },
 
     remove_effect: {
-      description: "Remove an effect from a clip by its index or name",
+      description: "Remove an effect from a clip by its index or name. Returns a capability error when the host cannot remove an individual component.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -117,6 +117,7 @@ export function getEffectsTools(bridgeOptions: BridgeOptions) {
           },
           effect_index: {
             type: "number",
+            minimum: 0,
             description: "Index of the effect to remove (0-based). Use get_clip_properties to see effects list.",
           },
           effect_name: {
@@ -132,22 +133,46 @@ export function getEffectsTools(bridgeOptions: BridgeOptions) {
           if (!result) return __error("Clip not found");
           
           var clip = result.clip;
+          // Component.remove() is not present on every CEP Component object in
+          // Premiere 26.x (notably Essential Sound's Amplify component). QE only
+          // exposes an all-effects removal, which is not a safe fallback here.
+          function removeComponent(component, effectName) {
+            try {
+              if (!component || typeof component.remove !== "function") {
+                return {
+                  removed: false,
+                  error: "Premiere does not expose Component.remove() for \"" + effectName + "\". The effect was not removed. No safe targeted QE fallback exists; remove it manually in Effect Controls."
+                };
+              }
+              component.remove();
+              return { removed: true };
+            } catch (e) {
+              return {
+                removed: false,
+                error: "Premiere could not remove \"" + effectName + "\": " + e.toString() + ". The effect may still be present; inspect Effect Controls."
+              };
+            }
+          }
+
           ${args.effect_index !== undefined ? `
-          if (${args.effect_index} >= clip.components.numItems) return __error("Effect index out of range");
-          var effectName = clip.components[${args.effect_index}].displayName;
-          clip.components[${args.effect_index}].remove();
+          if (${args.effect_index} < 0 || ${args.effect_index} >= clip.components.numItems) return __error("Effect index out of range");
+          var component = clip.components[${args.effect_index}];
+          var effectName = component.displayName;
+          var removal = removeComponent(component, effectName);
+          if (!removal.removed) return __error(removal.error);
           return __result({ removed: true, effect: effectName });
           ` : `
           var effectName = "${escapeForExtendScript(args.effect_name || "")}";
-          var found = false;
+          var component = null;
           for (var i = clip.components.numItems - 1; i >= 0; i--) {
             if (clip.components[i].displayName === effectName) {
-              clip.components[i].remove();
-              found = true;
+              component = clip.components[i];
               break;
             }
           }
-          if (!found) return __error("Effect not found: " + effectName);
+          if (!component) return __error("Effect not found: " + effectName);
+          var removal = removeComponent(component, effectName);
+          if (!removal.removed) return __error(removal.error);
           return __result({ removed: true, effect: effectName });
           `}
         `);

--- a/src/tools/timeline.ts
+++ b/src/tools/timeline.ts
@@ -185,7 +185,8 @@ export function getTimelineTools(bridgeOptions: BridgeOptions) {
     },
 
     trim_clip: {
-      description: "Trim a clip's in or out point",
+      description:
+        "Trim exactly one source in/out point and verify the corresponding visible timeline edge. Refuses retimed clips and, by default, trims that would leave effect keyframes outside the visible clip.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -195,23 +196,56 @@ export function getTimelineTools(bridgeOptions: BridgeOptions) {
           },
           new_in_seconds: {
             type: "number",
-            description: "New in-point in seconds (relative to clip's source media)",
+            minimum: 0,
+            description:
+              "New source in-point in seconds (relative to the clip's source media). Specify exactly one edit point.",
           },
           new_out_seconds: {
             type: "number",
-            description: "New out-point in seconds (relative to clip's source media)",
+            minimum: 0,
+            description:
+              "New source out-point in seconds (relative to the clip's source media). Specify exactly one edit point.",
+          },
+          keyframe_policy: {
+            type: "string",
+            enum: ["reject", "preserve"],
+            description:
+              "How to handle effect keyframes beyond the trimmed visible range: reject (default) leaves the timeline unchanged; preserve explicitly keeps them and reports their count.",
           },
         },
         required: ["node_id"],
       },
-      handler: async (args: { node_id: string; new_in_seconds?: number; new_out_seconds?: number }) => {
-        // Both edit points are optional in the schema, so a call carrying only
-        // node_id would previously set nothing and still report trimmed: true.
-        if (args.new_in_seconds === undefined && args.new_out_seconds === undefined) {
+      handler: async (args: {
+        node_id: string;
+        new_in_seconds?: number;
+        new_out_seconds?: number;
+        keyframe_policy?: "reject" | "preserve";
+      }) => {
+        // The schema permits both optional edit points. Applying both requires
+        // two CEP writes and can leave a partially altered timeline when the
+        // second write silently fails, so this tool intentionally supports one
+        // verified edge per request.
+        if ((args.new_in_seconds === undefined) === (args.new_out_seconds === undefined)) {
           return {
             success: false,
             error:
-              "trim_clip requires new_in_seconds, new_out_seconds, or both — a call with neither would report success without changing the clip.",
+              "trim_clip requires exactly one of new_in_seconds or new_out_seconds so its visible timeline edge can be verified without a partial multi-write.",
+          };
+        }
+
+        const requestedSeconds = args.new_in_seconds ?? args.new_out_seconds;
+        if (requestedSeconds === undefined || !Number.isFinite(requestedSeconds) || requestedSeconds < 0) {
+          return {
+            success: false,
+            error: "trim_clip edit points must be finite, non-negative seconds.",
+          };
+        }
+
+        const keyframePolicy = args.keyframe_policy ?? "reject";
+        if (keyframePolicy !== "reject" && keyframePolicy !== "preserve") {
+          return {
+            success: false,
+            error: "keyframe_policy must be reject or preserve.",
           };
         }
 
@@ -230,11 +264,114 @@ export function getTimelineTools(bridgeOptions: BridgeOptions) {
           if (!frameTicks || isNaN(frameTicks)) frameTicks = TICKS_PER_SECOND / 24;
           var tolerance = __ticksToSeconds(frameTicks);
 
-          ${args.new_in_seconds !== undefined ? `clip.inPoint = __secondsToTicks(${args.new_in_seconds}).toString();` : ""}
-          ${args.new_out_seconds !== undefined ? `clip.outPoint = __secondsToTicks(${args.new_out_seconds}).toString();` : ""}
+          function __trimSeconds(timeValue) {
+            try { return __ticksToSeconds(timeValue.ticks); } catch(e) { return NaN; }
+          }
 
-          var actualIn = __ticksToSeconds(clip.inPoint.ticks);
-          var actualOut = __ticksToSeconds(clip.outPoint.ticks);
+          function __snapshotTrimGeometry(item) {
+            return {
+              inPoint: __trimSeconds(item.inPoint),
+              outPoint: __trimSeconds(item.outPoint),
+              start: __trimSeconds(item.start),
+              end: __trimSeconds(item.end),
+              duration: __trimSeconds(item.duration)
+            };
+          }
+
+          // ComponentParam keyframe times are relative to the clip start in
+          // this CEP interface. A bounded scan lets the default reject a trim
+          // before it creates keyframes that remain beyond the visible range.
+          function __findOutOfRangeKeyframes(item, visibleDuration) {
+            var scan = { outside: [], errors: [], inspected: 0 };
+            var limit = 10000;
+            try {
+              for (var ci = 0; ci < item.components.numItems; ci++) {
+                var component = item.components[ci];
+                for (var pi = 0; pi < component.properties.numItems; pi++) {
+                  var property = component.properties[pi];
+                  var isTimeVarying = false;
+                  try { isTimeVarying = property.isTimeVarying(); } catch(varyingError) {
+                    scan.errors.push("component " + ci + " property " + pi + " time-varying state: " + varyingError.toString());
+                    continue;
+                  }
+                  if (!isTimeVarying) continue;
+                  var keys;
+                  try { keys = property.getKeys(); } catch(keyError) {
+                    scan.errors.push("component " + ci + " property " + pi + " keys: " + keyError.toString());
+                    continue;
+                  }
+                  if (!keys) continue;
+                  for (var ki = 0; ki < keys.length; ki++) {
+                    scan.inspected++;
+                    if (scan.inspected > limit) {
+                      scan.errors.push("more than " + limit + " keyframes; refusing an unbounded inspection");
+                      return scan;
+                    }
+                    var keySeconds = __trimSeconds(keys[ki]);
+                    if (!isFinite(keySeconds)) {
+                      scan.errors.push("component " + ci + " property " + pi + " key " + ki + " has no readable time");
+                      continue;
+                    }
+                    if (keySeconds > visibleDuration + tolerance) {
+                      scan.outside.push({ component: ci, property: pi, seconds: keySeconds });
+                    }
+                  }
+                }
+              }
+            } catch(scanError) {
+              scan.errors.push(scanError.toString());
+            }
+            return scan;
+          }
+
+          var before = __snapshotTrimGeometry(clip);
+          if (!isFinite(before.inPoint) || !isFinite(before.outPoint) || !isFinite(before.start) || !isFinite(before.end) || !isFinite(before.duration)) {
+            return __error("Premiere did not provide readable source and timeline times for this clip; trim was not attempted.");
+          }
+          if (before.outPoint - before.inPoint < tolerance || before.end - before.start < tolerance) {
+            return __error("Clip has an empty or unreadable duration; trim was not attempted.");
+          }
+
+          // A source-point trim can only have an exact CEP postcondition when
+          // the source and visible durations agree. Retimed/reversed clips need
+          // host-specific semantics, so refusing them is safer than guessing.
+          if (Math.abs((before.end - before.start) - (before.outPoint - before.inPoint)) > tolerance) {
+            return __error("trim_clip does not support retimed or otherwise non-1x clips because CEP cannot prove the requested source trim maps to the correct timeline edge. Use a host-verified workflow instead.");
+          }
+
+          var requestedIn = ${args.new_in_seconds !== undefined ? args.new_in_seconds : "null"};
+          var requestedOut = ${args.new_out_seconds !== undefined ? args.new_out_seconds : "null"};
+          var targetIn = requestedIn === null ? before.inPoint : requestedIn;
+          var targetOut = requestedOut === null ? before.outPoint : requestedOut;
+          if (!isFinite(targetIn) || !isFinite(targetOut) || targetIn < 0 || targetOut - targetIn < tolerance) {
+            return __error("The requested source trim must leave at least one frame between in and out; trim was not attempted.");
+          }
+
+          var prospectiveDuration = targetOut - targetIn;
+          var beforeKeyframes = __findOutOfRangeKeyframes(clip, prospectiveDuration);
+          if (beforeKeyframes.errors.length && "${keyframePolicy}" === "reject") {
+            return __error("Could not inspect every time-varying effect property before trim (" + beforeKeyframes.errors.join("; ") + "); trim was not attempted so keyframe behavior is not guessed.");
+          }
+          if (beforeKeyframes.outside.length && "${keyframePolicy}" === "reject") {
+            return __error("Refusing trim before mutation: " + beforeKeyframes.outside.length + " effect keyframe(s) would remain outside the visible clip. Use keyframe_policy: preserve only if retaining those keyframes is intentional, or adjust them explicitly with the keyframe tools.");
+          }
+
+          ${args.new_in_seconds !== undefined ? `clip.inPoint = __secondsToTicks(${args.new_in_seconds}).toString();` : "clip.outPoint = __secondsToTicks(" + args.new_out_seconds + ").toString();"}
+
+          // Re-find the TrackItem after the write. Premiere can replace stale
+          // DOM references during an edit, especially for audio clips.
+          var afterResult = __findClip("${escapeForExtendScript(args.node_id)}");
+          if (!afterResult) return __error("Clip could not be found after the trim attempt; the timeline may have changed and the result is not verified.");
+          if (afterResult.trackType !== result.trackType || afterResult.trackIndex !== result.trackIndex) {
+            return __error("Clip moved tracks during the trim attempt; the result is not verified.");
+          }
+          var after = __snapshotTrimGeometry(afterResult.clip);
+          if (!isFinite(after.inPoint) || !isFinite(after.outPoint) || !isFinite(after.start) || !isFinite(after.end) || !isFinite(after.duration)) {
+            return __error("Premiere did not provide readable source and timeline times after trim; the result is not verified.");
+          }
+
+          var actualIn = after.inPoint;
+          var actualOut = after.outPoint;
 
           var drift = [];
           ${args.new_in_seconds !== undefined ? `
@@ -246,16 +383,49 @@ export function getTimelineTools(bridgeOptions: BridgeOptions) {
             drift.push("outPoint requested ${args.new_out_seconds}s, read back " + actualOut + "s");
           }` : ""}
 
+          var expectedStart = ${args.new_in_seconds !== undefined
+            ? "before.start + (actualIn - before.inPoint)"
+            : "before.start"};
+          var expectedEnd = ${args.new_in_seconds !== undefined
+            ? "before.end"
+            : "before.end + (actualOut - before.outPoint)"};
+          if (Math.abs(after.start - expectedStart) > tolerance) {
+            drift.push("timeline start expected " + expectedStart + "s, read back " + after.start + "s");
+          }
+          if (Math.abs(after.end - expectedEnd) > tolerance) {
+            drift.push("timeline end expected " + expectedEnd + "s, read back " + after.end + "s");
+          }
+          if (Math.abs(after.duration - (after.end - after.start)) > tolerance) {
+            drift.push("timeline duration " + after.duration + "s does not match visible span " + (after.end - after.start) + "s");
+          }
+          if (Math.abs((after.end - after.start) - (actualOut - actualIn)) > tolerance) {
+            drift.push("visible timeline duration does not match the applied source range");
+          }
+
           if (drift.length) {
-            return __error("Premiere did not apply the requested trim: " + drift.join("; ") + ". Structural clip edits are known to no-op on some Premiere Pro 26.x installations (confirmed on 26.2.2).");
+            return __error("Premiere did not apply a verified timeline trim: " + drift.join("; ") + ". The source metadata may have changed, but this is not reported as success. Structural clip edits are known to no-op on some Premiere Pro 26.x installations.");
+          }
+
+          var afterKeyframes = __findOutOfRangeKeyframes(afterResult.clip, after.end - after.start);
+          if (afterKeyframes.errors.length && "${keyframePolicy}" === "reject") {
+            return __error("The timeline trim may have applied, but keyframes could not be fully read back (" + afterKeyframes.errors.join("; ") + "). It is not reported as verified; inspect the clip or use Undo.");
+          }
+          if (afterKeyframes.outside.length && "${keyframePolicy}" === "reject") {
+            return __error("The timeline trim may have applied, but " + afterKeyframes.outside.length + " effect keyframe(s) remain outside its visible range. It is not reported as verified; inspect the clip or use Undo.");
           }
 
           return __result({
             trimmed: true,
             verified: true,
-            clipName: clip.name,
+            clipName: afterResult.clip.name,
             inPoint: actualIn,
-            outPoint: actualOut
+            outPoint: actualOut,
+            timelineStart: after.start,
+            timelineEnd: after.end,
+            timelineDuration: after.duration,
+            keyframePolicy: "${keyframePolicy}",
+            keyframesOutsideVisibleRange: afterKeyframes.outside.length,
+            keyframesVerified: afterKeyframes.errors.length === 0 && afterKeyframes.outside.length === 0
           });
         `);
         return sendCommand(script, bridgeOptions);
@@ -263,17 +433,20 @@ export function getTimelineTools(bridgeOptions: BridgeOptions) {
     },
 
     split_clip: {
-      description: "Split (razor) a clip at a specific time position. Requires QE DOM.",
+      description:
+        "Split every clip on one track that spans a timeline time, then verify both resulting boundaries. Requires QE DOM; effect-keyframe redistribution remains unverified.",
       parameters: {
         type: "object" as const,
         properties: {
           time_seconds: {
             type: "number",
-            description: "Time position in seconds where to split",
+            minimum: 0,
+            description: "Timeline time in seconds where clips on the selected track will split",
           },
           track_index: {
             type: "number",
-            description: "Track index (0-based)",
+            minimum: 0,
+            description: "Track index (0-based, default: 0)",
           },
           track_type: {
             type: "string",
@@ -284,27 +457,97 @@ export function getTimelineTools(bridgeOptions: BridgeOptions) {
         required: ["time_seconds"],
       },
       handler: async (args: { time_seconds: number; track_index?: number; track_type?: string }) => {
-        const trackType = args.track_type || "video";
+        if (!Number.isFinite(args.time_seconds) || args.time_seconds < 0) {
+          return { success: false, error: "time_seconds must be finite, non-negative seconds." };
+        }
+        if (args.track_index !== undefined && (!Number.isInteger(args.track_index) || args.track_index < 0)) {
+          return { success: false, error: "track_index must be a non-negative integer." };
+        }
+        const trackType = args.track_type ?? "video";
+        if (trackType !== "video" && trackType !== "audio") {
+          return { success: false, error: "track_type must be video or audio." };
+        }
         const trackIndex = args.track_index ?? 0;
 
         const script = buildToolScript(`
           app.enableQE();
+          var domSequence = app.project.activeSequence;
+          if (!domSequence) return __error("No active sequence");
           var seq = qe.project.getActiveSequence();
           if (!seq) return __error("No active sequence (QE)");
           
           var track = ${trackType === "video" ? `seq.getVideoTrackAt(${trackIndex})` : `seq.getAudioTrackAt(${trackIndex})`};
-          if (!track) return __error("Track not found");
+          if (!track) return __error("QE track not found");
 
-          var domTrack = ${trackType === "video" ? `app.project.activeSequence.videoTracks[${trackIndex}]` : `app.project.activeSequence.audioTracks[${trackIndex}]`};
+          var domTrack = ${trackType === "video" ? `domSequence.videoTracks[${trackIndex}]` : `domSequence.audioTracks[${trackIndex}]`};
+          if (!domTrack) return __error("DOM track not found");
+          var frameTicks = domSequence.timebase ? parseFloat(domSequence.timebase) : NaN;
+          if (!frameTicks || isNaN(frameTicks)) frameTicks = TICKS_PER_SECOND / 24;
+          var boundaryTolerance = frameTicks;
           var clipCountBefore = domTrack.clips.numItems;
-          var timeTicks = __secondsToTicks(${args.time_seconds}).toString();
-          track.razor(timeTicks);
+          var cutTicks = __secondsToTicks(${args.time_seconds});
+
+          function __eligibleClips(track, cut) {
+            var clips = [];
+            for (var i = 0; i < track.clips.numItems; i++) {
+              var item = track.clips[i];
+              var start = parseFloat(item.start.ticks);
+              var end = parseFloat(item.end.ticks);
+              if (!isFinite(start) || !isFinite(end)) continue;
+              if (cut > start && cut < end) {
+                clips.push({ start: start, end: end, nodeId: item.nodeId, name: item.name });
+              }
+            }
+            return clips;
+          }
+
+          function __hasSegment(track, wantedStart, wantedEnd) {
+            for (var i = 0; i < track.clips.numItems; i++) {
+              var item = track.clips[i];
+              var actualStart = parseFloat(item.start.ticks);
+              var actualEnd = parseFloat(item.end.ticks);
+              if (Math.abs(actualStart - wantedStart) <= boundaryTolerance && Math.abs(actualEnd - wantedEnd) <= boundaryTolerance) return true;
+            }
+            return false;
+          }
+
+          var eligibleBefore = __eligibleClips(domTrack, cutTicks);
+          if (!eligibleBefore.length) {
+            return __error("No clip on the requested ${trackType} track strictly spans ${args.time_seconds}s; no razor was attempted.");
+          }
+
+          try {
+            track.razor(cutTicks.toString());
+          } catch(razorError) {
+            return __error("QE razor rejected the request: " + razorError.toString() + ". No verified split was produced.");
+          }
 
           var clipCountAfter = domTrack.clips.numItems;
-          if (clipCountAfter <= clipCountBefore) {
-            return __error("Premiere reported razor but the track clip count did not change. Structural QE edits are known to no-op on some Premiere Pro 26.x installations (confirmed on 26.2.2).");
+          var expectedClipCount = clipCountBefore + eligibleBefore.length;
+          if (clipCountAfter !== expectedClipCount) {
+            return __error("Premiere razor changed the track clip count from " + clipCountBefore + " to " + clipCountAfter + ", expected " + expectedClipCount + " for " + eligibleBefore.length + " spanning clip(s). The timeline may be partially changed, but the split is not reported as verified. Structural QE edits are known to no-op on some Premiere Pro 26.x installations.");
           }
-          return __result({ split: true, verified: true, atSeconds: ${args.time_seconds}, trackIndex: ${trackIndex}, trackType: "${trackType}" });
+
+          var missingSegments = [];
+          for (var ei = 0; ei < eligibleBefore.length; ei++) {
+            var before = eligibleBefore[ei];
+            if (!__hasSegment(domTrack, before.start, cutTicks)) missingSegments.push(before.name + " left segment");
+            if (!__hasSegment(domTrack, cutTicks, before.end)) missingSegments.push(before.name + " right segment");
+          }
+          if (missingSegments.length) {
+            return __error("Premiere razor changed the clip count but did not create the requested cut boundary for " + missingSegments.join(", ") + ". The timeline may be partially changed, but the split is not reported as verified.");
+          }
+          return __result({
+            split: true,
+            verified: true,
+            timelineVerified: true,
+            atSeconds: __ticksToSeconds(cutTicks),
+            requestedSeconds: ${args.time_seconds},
+            trackIndex: ${trackIndex},
+            trackType: "${trackType}",
+            splitClipCount: eligibleBefore.length,
+            keyframeSemantics: "unverified"
+          });
         `);
         return sendCommand(script, bridgeOptions);
       },

--- a/src/tools/track-targeting.ts
+++ b/src/tools/track-targeting.ts
@@ -763,7 +763,7 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
     },
 
     set_clip_volume: {
-      description: "Set the volume level on an audio clip (in dB).",
+      description: "Set an audio clip's Volume > Level in dB. Does not read or change Essential Sound Amplify automation.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -809,7 +809,7 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
 
     get_clip_volume: {
       description:
-        "Read the volume level of an audio clip, returned in dB. Use this to verify a level actually applied - setValue() clamps silently.",
+        "Read an audio clip's Volume > Level in dB. Use this to verify a level actually applied - setValue() clamps silently. Does not report Essential Sound Amplify automation.",
       parameters: {
         type: "object" as const,
         properties: {

--- a/src/tools/tracks.ts
+++ b/src/tools/tracks.ts
@@ -1,10 +1,15 @@
 import { buildToolScript, escapeForExtendScript } from "../bridge/script-builder.js";
 import { sendCommand, BridgeOptions } from "../bridge/file-bridge.js";
 
+function isPositiveInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
 export function getTrackTools(bridgeOptions: BridgeOptions) {
   return {
     add_track: {
-      description: "Add a new video or audio track to the active sequence",
+      description:
+        "Add verified video or audio tracks to the active sequence. Returns an error if Premiere cannot add the exact requested count.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -22,23 +27,75 @@ export function getTrackTools(bridgeOptions: BridgeOptions) {
       },
       handler: async (args: { track_type: string; count?: number }) => {
         const count = args.count ?? 1;
+        if (args.track_type !== "video" && args.track_type !== "audio") {
+          return { success: false, error: "track_type must be either video or audio" };
+        }
+        if (!isPositiveInteger(count)) {
+          return { success: false, error: "count must be a positive integer" };
+        }
+
+        const isVideo = args.track_type === "video";
         const script = buildToolScript(`
           var seq = app.project.activeSequence;
           if (!seq) return __error("No active sequence");
-          
-          var before = ${args.track_type === "video" ? "seq.videoTracks.numTracks" : "seq.audioTracks.numTracks"};
-          
-          ${args.track_type === "video"
-            ? `seq.insertVideoTrackAt(before, ${count});`
-            : `seq.insertAudioTrackAt(before, ${count});`
+
+          var before = ${isVideo ? "seq.videoTracks.numTracks" : "seq.audioTracks.numTracks"};
+          var expected = before + ${count};
+          var method = "public DOM";
+          var publicFailure = "";
+
+          // Premiere 26.x can expose this public Sequence API but reject the
+          // call. Do not report the request as successful until the DOM count
+          // proves it happened. If the public call made no change, QE is a
+          // bounded fallback; a partially applied public call is never retried.
+          try {
+            if (typeof seq.${isVideo ? "insertVideoTrackAt" : "insertAudioTrackAt"} !== "function") {
+              publicFailure = "Sequence.${isVideo ? "insertVideoTrackAt" : "insertAudioTrackAt"} is unavailable";
+            } else {
+              ${isVideo
+                ? `seq.insertVideoTrackAt(before, ${count});`
+                : `seq.insertAudioTrackAt(before, ${count});`}
+            }
+          } catch (publicError) {
+            publicFailure = publicError.toString();
           }
-          
-          var after = ${args.track_type === "video" ? "seq.videoTracks.numTracks" : "seq.audioTracks.numTracks"};
-          
+
+          var afterPublic = ${isVideo ? "seq.videoTracks.numTracks" : "seq.audioTracks.numTracks"};
+          if (afterPublic !== expected && afterPublic !== before) {
+            return __error("Track add partially applied through the public DOM: requested ${count} ${args.track_type} track(s), had " + before + ", now has " + afterPublic + ". It was not retried.");
+          }
+
+          if (afterPublic !== expected) {
+            method = "QE fallback";
+            if (typeof app.enableQE !== "function") {
+              return __error("Could not add ${args.track_type} track(s): " + publicFailure + ". QE fallback is unavailable on this Premiere build.");
+            }
+            app.enableQE();
+            if (typeof qe === "undefined" || !qe.project || typeof qe.project.getActiveSequence !== "function") {
+              return __error("Could not add ${args.track_type} track(s): " + publicFailure + ". QE active-sequence access is unavailable on this Premiere build.");
+            }
+            var qeSeq = qe.project.getActiveSequence();
+            if (!qeSeq || typeof qeSeq.addTracks !== "function") {
+              return __error("Could not add ${args.track_type} track(s): " + publicFailure + ". QE addTracks is unavailable on this Premiere build.");
+            }
+            try {
+              qeSeq.addTracks(${isVideo ? count : 0}, ${isVideo ? 0 : count}, 0, 0);
+            } catch (qeError) {
+              return __error("Could not add ${args.track_type} track(s): public DOM failed (" + publicFailure + ") and QE addTracks failed (" + qeError.toString() + ").");
+            }
+          }
+
+          var after = ${isVideo ? "seq.videoTracks.numTracks" : "seq.audioTracks.numTracks"};
+          if (after !== expected) {
+            return __error("Premiere did not add the requested ${args.track_type} tracks: requested ${count}, had " + before + ", now has " + after + " (" + method + ").");
+          }
+
           return __result({
-            added: after - before,
+            added: ${count},
             trackType: "${args.track_type}",
-            totalTracks: after
+            totalTracks: after,
+            method: method,
+            verified: true
           });
         `);
         return sendCommand(script, bridgeOptions);

--- a/tests/tools/regressions.test.ts
+++ b/tests/tools/regressions.test.ts
@@ -15,6 +15,7 @@ import { getExportTools } from "../../src/tools/export.js";
 import { getUtilityTools } from "../../src/tools/utility.js";
 import { getTrackTargetingTools } from "../../src/tools/track-targeting.js";
 import { getEffectsTools } from "../../src/tools/effects.js";
+import { getClipboardTools } from "../../src/tools/clipboard.js";
 
 const mockedSendCommand = vi.mocked(sendCommand);
 const bridgeOptions: BridgeOptions = { tempDir: "/tmp/test-bridge", timeoutMs: 5000 };
@@ -217,6 +218,43 @@ describe("script-builder helpers used by the fixes are actually defined", () => 
     ]) {
       expect(script).toContain(helper);
     }
+  });
+});
+
+// https://github.com/leancoderkavy/premiere-pro-mcp/issues/129
+describe("issue #129 — CEP component removal is capability-gated", () => {
+  const effects = getEffectsTools(bridgeOptions);
+  const clipboard = getClipboardTools(bridgeOptions);
+
+  it.each([
+    ["index", { node_id: "clip1", effect_index: 3 }],
+    ["name", { node_id: "clip1", effect_name: "Amplify" }],
+  ])("remove_effect by %s guards an unavailable Component.remove()", async (_mode, args) => {
+    const code = await codeFor(effects.remove_effect, args);
+
+    expect(code).toContain('typeof component.remove !== "function"');
+    expect(code).toContain("No safe targeted QE fallback exists");
+    expect(code).toContain("return __error(removal.error)");
+    expect(code).not.toContain("qeClip.removeEffects()");
+  });
+
+  it("preflights every matching component before remove_effect_by_name mutates any", async () => {
+    const code = await codeFor(clipboard.remove_effect_by_name, {
+      node_id: "clip1",
+      effect_name: "Amplify",
+    });
+
+    expect(code).toContain("var matches = []");
+    expect(code).toContain("if (!canRemoveComponent(component))");
+    expect(code).toContain("No matching components were removed");
+    expect(code).not.toContain("qeClip.removeEffects()");
+    expect(code.indexOf("if (!canRemoveComponent(component))"))
+      .toBeLessThan(code.lastIndexOf("component.remove()"));
+  });
+
+  it("documents the capability boundary in each targeted removal tool", () => {
+    expect(effects.remove_effect.description).toContain("capability error");
+    expect(clipboard.remove_effect_by_name.description).toContain("capability error");
   });
 });
 

--- a/tests/tools/structural-verification.test.ts
+++ b/tests/tools/structural-verification.test.ts
@@ -8,12 +8,14 @@ import { sendCommand } from "../../src/bridge/file-bridge.js";
 import { getTimelineTools } from "../../src/tools/timeline.js";
 import { getTrackTargetingTools } from "../../src/tools/track-targeting.js";
 import { getAdvancedTools } from "../../src/tools/advanced.js";
+import { getTrackTools } from "../../src/tools/tracks.js";
 
 const mockedSendCommand = vi.mocked(sendCommand);
 const bridgeOptions = { tempDir: "/tmp/test", timeoutMs: 1000 };
 const timeline = getTimelineTools(bridgeOptions);
 const trackTargeting = getTrackTargetingTools(bridgeOptions);
 const advanced = getAdvancedTools(bridgeOptions);
+const tracks = getTrackTools(bridgeOptions);
 
 beforeEach(() => vi.clearAllMocks());
 
@@ -205,5 +207,92 @@ describe("move_clip_to_track verification", () => {
     expect(script).toContain("catch (moveErr)");
     expect(script).toContain("The clip was left untouched");
     expect(script).toContain("overwriteClip");
+  });
+});
+
+describe("track creation verification", () => {
+  it("rejects invalid add_track requests locally instead of generating unsafe host code", async () => {
+    const result = await tracks.add_track.handler({ track_type: "audio", count: 0 });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("positive integer");
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+  });
+
+  it("uses a bounded QE fallback only after a public add_track failure with no mutation", async () => {
+    await tracks.add_track.handler({ track_type: "audio", count: 2 });
+    const script = mockedSendCommand.mock.calls[0][0];
+
+    expect(script).toContain('typeof seq.insertAudioTrackAt !== "function"');
+    expect(script).toContain("afterPublic !== expected && afterPublic !== before");
+    expect(script).toContain("qeSeq.addTracks(0, 2, 0, 0)");
+    expect(script).toContain("if (after !== expected)");
+    expect(script).toContain("verified: true");
+  });
+
+  it("does not report QE add_tracks success until exact video and audio count readback", async () => {
+    await advanced.add_tracks.handler({
+      video_tracks: 1,
+      audio_tracks: 2,
+      audio_mono_tracks: 1,
+      audio_51_tracks: 1,
+    });
+    const script = mockedSendCommand.mock.calls[0][0];
+
+    expect(script).toContain("var beforeVideo = seq.videoTracks.numTracks");
+    expect(script).toContain("var expectedAudio = beforeAudio + 4");
+    expect(script).toContain("typeof qeSeq.addTracks !== \"function\"");
+    expect(script).toContain("afterVideo !== expectedVideo || afterAudio !== expectedAudio");
+    expect(script).toContain("verified: true");
+  });
+
+  it("rejects an empty add_tracks request locally rather than returning a successful no-op", async () => {
+    const result = await advanced.add_tracks.handler({});
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("at least one");
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+  });
+});
+
+describe("overwrite_clip verification", () => {
+  it("rejects invalid indices locally before they can be interpolated into ExtendScript", async () => {
+    const result = await advanced.overwrite_clip.handler({
+      item_id: "source-1",
+      audio_track_index: -1,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("audio_track_index");
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+  });
+
+  it("checks both target tracks and host capability before calling overwriteClip", async () => {
+    await advanced.overwrite_clip.handler({
+      item_id: "source-1",
+      track_index: 1,
+      audio_track_index: 2,
+      start_seconds: 5,
+    });
+    const script = mockedSendCommand.mock.calls[0][0];
+    const videoCheck = script.indexOf("Video track index 1 is out of range");
+    const audioCheck = script.indexOf("Audio track index 2 is out of range");
+    const call = script.indexOf("seq.overwriteClip(item");
+
+    expect(videoCheck).toBeGreaterThan(-1);
+    expect(audioCheck).toBeGreaterThan(-1);
+    expect(call).toBeGreaterThan(audioCheck);
+    expect(script).toContain('typeof seq.overwriteClip !== "function"');
+  });
+
+  it("proves the requested source landed on a target track and errors on no new placement", async () => {
+    await advanced.overwrite_clip.handler({ item_id: "source-1", start_seconds: 5 });
+    const script = mockedSendCommand.mock.calls[0][0];
+
+    expect(script).toContain("clip.projectItem ? String(clip.projectItem.nodeId)");
+    expect(script).toContain("Math.abs(actualStartTicks - wantedStartTicks) <= frameTicks");
+    expect(script).toContain("if (!videoPlaced && !audioPlaced)");
+    expect(script).toContain("produced no verifiable new placement");
+    expect(script).toContain("verified: true");
   });
 });

--- a/tests/tools/structural-verification.test.ts
+++ b/tests/tools/structural-verification.test.ts
@@ -20,20 +20,28 @@ const tracks = getTrackTools(bridgeOptions);
 beforeEach(() => vi.clearAllMocks());
 
 describe("trim_clip verification", () => {
-  it("refuses a call with neither edit point instead of reporting a no-op as success", async () => {
+  it("requires exactly one edit point instead of reporting a no-op or multi-write as success", async () => {
     const result = await timeline.trim_clip.handler({ node_id: "abc" });
     expect(result.success).toBe(false);
     expect(result.error).toContain("new_in_seconds");
     // The bridge must not be touched at all — there is nothing to apply.
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+
+    const multiple = await timeline.trim_clip.handler({
+      node_id: "abc",
+      new_in_seconds: 2,
+      new_out_seconds: 8,
+    });
+    expect(multiple.success).toBe(false);
     expect(mockedSendCommand).not.toHaveBeenCalled();
   });
 
   it("compares the read-back in point against the requested value", async () => {
     await timeline.trim_clip.handler({ node_id: "abc", new_in_seconds: 2 });
     const script = mockedSendCommand.mock.calls[0][0];
-    expect(script).toContain("var actualIn = __ticksToSeconds(clip.inPoint.ticks)");
+    expect(script).toContain("var actualIn = after.inPoint");
     expect(script).toContain("Math.abs(actualIn - 2) > tolerance");
-    expect(script).toContain("did not apply the requested trim");
+    expect(script).toContain("did not apply a verified timeline trim");
     expect(script).toContain("verified: true");
   });
 
@@ -43,11 +51,11 @@ describe("trim_clip verification", () => {
     expect(script).toContain("Math.abs(actualOut - 8) > tolerance");
   });
 
-  it("only checks the edit points that were actually requested", async () => {
+  it("only writes the edge that was actually requested", async () => {
     await timeline.trim_clip.handler({ node_id: "abc", new_in_seconds: 2 });
     const script = mockedSendCommand.mock.calls[0][0];
-    expect(script).toContain("Math.abs(actualIn - 2)");
-    expect(script).not.toContain("Math.abs(actualOut -");
+    expect(script).toContain("clip.inPoint = __secondsToTicks(2).toString();");
+    expect(script).not.toContain("clip.outPoint = __secondsToTicks(2).toString();");
   });
 
   it("derives its tolerance from the sequence timebase so frame snapping is not a failure", async () => {
@@ -56,6 +64,79 @@ describe("trim_clip verification", () => {
     expect(script).toContain("seq.timebase");
     expect(script).toContain("TICKS_PER_SECOND / 24");
     expect(script).toContain("var tolerance = __ticksToSeconds(frameTicks)");
+  });
+
+  it("refuses invalid numeric edit points before contacting Premiere", async () => {
+    const result = await timeline.trim_clip.handler({
+      node_id: "abc",
+      new_out_seconds: Number.NaN,
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("finite");
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+  });
+
+  it("verifies the visible timeline geometry as well as source metadata", async () => {
+    await timeline.trim_clip.handler({ node_id: "abc", new_out_seconds: 8 });
+    const script = mockedSendCommand.mock.calls[0][0];
+    expect(script).toContain("var afterResult = __findClip(\"abc\")");
+    expect(script).toContain("var expectedStart = before.start");
+    expect(script).toContain("var expectedEnd = before.end + (actualOut - before.outPoint)");
+    expect(script).toContain("visible timeline duration does not match the applied source range");
+    expect(script).toContain("source metadata may have changed, but this is not reported as success");
+  });
+
+  it("fails closed for retimed clips and unhandled out-of-range keyframes", async () => {
+    await timeline.trim_clip.handler({ node_id: "abc", new_out_seconds: 8 });
+    const script = mockedSendCommand.mock.calls[0][0];
+    expect(script).toContain("does not support retimed or otherwise non-1x clips");
+    expect(script).toContain("__findOutOfRangeKeyframes");
+    expect(script).toContain("keyframe_policy: preserve");
+    expect(script).toContain("keyframesOutsideVisibleRange");
+  });
+
+  it("allows explicit keyframe preservation while reporting that it was not fully verified", async () => {
+    await timeline.trim_clip.handler({
+      node_id: "abc",
+      new_out_seconds: 8,
+      keyframe_policy: "preserve",
+    });
+    const script = mockedSendCommand.mock.calls[0][0];
+    expect(script).toContain('keyframePolicy: "preserve"');
+    expect(script).toContain("keyframesVerified:");
+  });
+});
+
+describe("split_clip verification", () => {
+  it("refuses invalid local arguments before contacting Premiere", async () => {
+    const invalidTime = await timeline.split_clip.handler({ time_seconds: -1 });
+    expect(invalidTime.success).toBe(false);
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+
+    const invalidTrack = await timeline.split_clip.handler({
+      time_seconds: 4,
+      track_index: 1.5,
+    });
+    expect(invalidTrack.success).toBe(false);
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+  });
+
+  it("requires a clip to span the requested cut before attempting QE razor", async () => {
+    await timeline.split_clip.handler({ time_seconds: 4, track_type: "audio" });
+    const script = mockedSendCommand.mock.calls[0][0];
+    expect(script).toContain("function __eligibleClips");
+    expect(script).toContain("if (!eligibleBefore.length)");
+    expect(script).toContain("no razor was attempted");
+  });
+
+  it("verifies each left and right segment, not only a count increase", async () => {
+    await timeline.split_clip.handler({ time_seconds: 4 });
+    const script = mockedSendCommand.mock.calls[0][0];
+    expect(script).toContain("var expectedClipCount = clipCountBefore + eligibleBefore.length");
+    expect(script).toContain("function __hasSegment");
+    expect(script).toContain("left segment");
+    expect(script).toContain("right segment");
+    expect(script).toContain('keyframeSemantics: "unverified"');
   });
 });
 

--- a/tests/tools/tool-modules.test.ts
+++ b/tests/tools/tool-modules.test.ts
@@ -415,7 +415,8 @@ describe("Tool Handler Behavior", () => {
       vi.clearAllMocks();
       await (getTimelineTools(bridgeOptions).split_clip.handler as any)({ time_seconds: 2 });
       script = mockedSendCommand.mock.calls[0][0];
-      expect(script).toContain("clipCountAfter <= clipCountBefore");
+      expect(script).toContain("var expectedClipCount = clipCountBefore + eligibleBefore.length");
+      expect(script).toContain("function __hasSegment");
     });
 
     it("checks transition API availability and verifies track state", async () => {


### PR DESCRIPTION
## Summary

Fixes the five Premiere Pro 26.x CEP defects reported in #126, #127, #128, #129, and #130.

- verify visible timeline geometry and keyframe risk after `trim_clip`
- verify both resulting segments after QE-backed `split_clip`
- make `add_track` / `add_tracks` fail closed unless exact track-count postconditions hold
- reject nonexistent overwrite targets and verify the requested source was placed
- capability-check effect component removal, including Essential Sound Amplify components

## Root cause

The affected CEP paths trusted mutation calls or partial metadata changes as proof of success. Premiere 26.x can return without applying the visible timeline mutation, and some components do not expose `remove()`. The updated paths preflight capabilities and validate observable postconditions before reporting success.

## Validation

- `npm run check`
- lint passed
- TypeScript build passed
- generated supported-actions catalog is current
- 54 test files / 1,531 tests passed
- `git diff --check` passed

## Host boundary

These changes are covered by automated CEP/QE contracts. A licensed Premiere Pro 26.x host was not available in this environment, so real-host validation remains pending.

Fixes #126
Fixes #127
Fixes #128
Fixes #129
Fixes #130