### PR TITLE
Release v1.11.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "premiere-pro",
       "source": "./claude-plugins/premiere-pro",
       "description": "Inspect, edit, verify, and export local Premiere Pro projects through MCP.",
-      "version": "1.11.1",
+      "version": "1.11.2",
       "category": "creative",
       "tags": ["premiere-pro", "video-editing", "mcp"]
     }

--- a/.github/ISSUE_TEMPLATE/compatibility_report.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility_report.yml
@@ -14,7 +14,7 @@ body:
     id: versions
     attributes:
       label: Premiere Pro and MCP versions
-      placeholder: Premiere 26.3.0, Premiere Pro MCP 1.11.1
+      placeholder: Premiere 26.3.0, Premiere Pro MCP 1.11.2
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/tool_failure.yml
+++ b/.github/ISSUE_TEMPLATE/tool_failure.yml
@@ -17,7 +17,7 @@ body:
     id: package-version
     attributes:
       label: Premiere Pro MCP version
-      placeholder: 1.11.1
+      placeholder: 1.11.2
     validations:
       required: true
   - type: input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.11.2] - 2026-08-18
+
 ### Added
 
 - Added a durable local project-context engine with active-sequence capture,
@@ -31,12 +33,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `split_clip` now verifies that a clip spans the requested cut and that QE produced each expected
   left/right segment, rather than accepting any increase in track clip count. QE keyframe
   redistribution remains explicitly unverified.
+- `remove_effect` and `remove_effect_by_name` now preflight `Component.remove()` support before
+  mutation. Unsupported Premiere 26.x components such as Essential Sound's Amplify return an
+  actionable capability error without crashing or partially removing matched effects.
 
 ### Security
 
 - Native media paths are hashed before persistence, credential-like enrichment
   metadata is discarded, stale source/timeline enrichments are rejected, and
   context clearing remains an explicit filesystem-authorized action.
+
+### Validation
+
+- Added fail-closed CEP/QE contract coverage for trim, split, track creation, overwrite placement,
+  and component removal. Licensed Premiere Pro 26.x host confirmation remains a separate gate.
 
 ## [1.11.1] - 2026-08-16
 

--- a/README.md
+++ b/README.md
@@ -31,19 +31,18 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 
 The AI handles the entire workflow through 285 core tools spanning the supported ExtendScript, QE DOM, local media analysis, revisioned project-context retrieval, safe edit-planning, and connection-verification surfaces. A compatible, authenticated UXP panel adds 48 documented, capability-gated tools without replacing the production CEP bridge.
 
-### Latest release: 1.11.1
+### Latest release: 1.11.2
 
-- **Remote-server stability:** extensionless exported routes now resolve to `index.html`
-  instead of streaming a directory and crashing the Node process with `EISDIR` on Linux.
-- **Defense in depth:** static paths must remain inside the landing root and resolve to regular
-  files; asynchronous read failures are handled without terminating the server.
-- **v1.11 workflow set included:** host events, AME receipts, readiness gates, guarded project
-  sessions, growing-media leases, checkpoints, media health, track state, source trim and framing,
-  corrected batch volume controls, and evidence-gated acceleration remain available.
-- **Truthful compatibility:** CEP remains the production-compatible bridge, and automated UXP
-  contracts do not claim validation inside a real Premiere host.
+- **Honest timeline mutations:** trim, split, track creation, and overwrite placement now verify
+  observable postconditions instead of trusting Premiere 26.x calls that can silently no-op.
+- **Safe effect removal:** unsupported components such as Essential Sound's Amplify return an
+  actionable capability error instead of crashing or partially removing matched effects.
+- **Durable project context:** local, revision-aware context capture and retrieval adds bounded,
+  non-mutating edit-plan scaffolds while hashing persisted native media paths.
+- **Truthful compatibility:** the fixes have automated CEP/QE contract coverage; confirmation in
+  a licensed Premiere Pro 26.x host remains a separate validation boundary.
 
-See the [v1.11.1 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.11.1)
+See the [v1.11.2 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.11.2)
 for complete details. Live installation in Premiere Pro still requires host verification.
 
 ---
@@ -52,9 +51,9 @@ for complete details. Live installation in Premiere Pro still requires host veri
 
 ### Easiest supported path: Claude Desktop
 
-1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.11.1/premiere-pro-mcp-1.11.1.mcpb).
+1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.11.2/premiere-pro-mcp-1.11.2.mcpb).
 2. In Claude Desktop, open **Settings > Extensions > Advanced settings > Install Extension**, select the downloaded bundle, and restart Claude Desktop.
-3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.11.1/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
+3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.11.2/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
 4. Restart Premiere, open a project, then open **Window > Extensions > MCP Bridge**.
 5. In Claude, enter: `Safely check my Premiere connection with verify_premiere_connection. Make no changes.`
 
@@ -278,11 +277,11 @@ From a clone of this repository:
 ```bash
 codex plugin marketplace add .
 codex plugin add premiere-pro@premiere-pro-mcp
-npx -y premiere-pro-mcp@1.11.1 --install-cep
+npx -y premiere-pro-mcp@1.11.2 --install-cep
 ```
 
 Restart Premiere Pro and start a new Codex session after installation. The plugin
-launches `premiere-pro-mcp@1.11.1` through `npx`; the separate CEP installation is
+launches `premiere-pro-mcp@1.11.2` through `npx`; the separate CEP installation is
 required because the MCP server communicates with the running Premiere host through
 the local bridge.
 
@@ -302,7 +301,7 @@ For Claude Code, add this repository as a marketplace and install the plugin:
 Then install the Premiere bridge and start a new Claude Code session:
 
 ```bash
-npx -y premiere-pro-mcp@1.11.1 --install-cep
+npx -y premiere-pro-mcp@1.11.2 --install-cep
 ```
 
 The Claude Code package lives in

--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.11.1" ExtensionBundleName="MCP Bridge">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.11.2" ExtensionBundleName="MCP Bridge">
   <ExtensionList>
-    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.11.1"/>
-    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.11.1"/>
+    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.11.2"/>
+    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.11.2"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/cep-plugin/index.html
+++ b/cep-plugin/index.html
@@ -81,7 +81,7 @@
     <section class="update-section" aria-live="polite">
       <div class="update-copy">
         <span class="section-label">Connector updates</span>
-        <strong id="updateTitle">Version 1.11.1</strong>
+        <strong id="updateTitle">Version 1.11.2</strong>
         <span id="updateDetail">Checking for updates…</span>
       </div>
       <button id="btnUpdate" class="button button-update" onclick="handleUpdateClick()" type="button" disabled>

--- a/cep-plugin/updater.cjs
+++ b/cep-plugin/updater.cjs
@@ -7,7 +7,7 @@
 })(this, function () {
   "use strict";
 
-  var CURRENT_VERSION = "1.11.1";
+  var CURRENT_VERSION = "1.11.2";
   var LATEST_RELEASE_API =
     "https://api.github.com/repos/leancoderkavy/premiere-pro-mcp/releases/latest";
   var RELEASES_URL =

--- a/claude-desktop/manifest.json
+++ b/claude-desktop/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "premiere-pro-mcp",
   "display_name": "Premiere Pro MCP",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Control a local Adobe Premiere Pro project through MCP.",
   "long_description": "Inspect projects, assemble and modify timelines, manage media, effects, audio and captions, and export deliverables through a local bridge to Adobe Premiere Pro.",
   "author": {

--- a/claude-plugins/premiere-pro/.claude-plugin/plugin.json
+++ b/claude-plugins/premiere-pro/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "premiere-pro",
   "displayName": "Premiere Pro MCP",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Inspect, edit, verify, and export local Adobe Premiere Pro projects through MCP.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/claude-plugins/premiere-pro/.mcp.json
+++ b/claude-plugins/premiere-pro/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "premiere-pro": {
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.11.1"]
+      "args": ["-y", "premiere-pro-mcp@1.11.2"]
     }
   }
 }

--- a/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.11.1 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.11.2 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -5,6 +5,32 @@ import { product } from "@/lib/product"
 
 const releases = [
   {
+    version: "1.11.2",
+    date: "2026-08-18",
+    label: "Fail-closed Premiere 26.x timeline mutations",
+    groups: [
+      {
+        title: "Added",
+        items: [
+          "Added durable local project-context capture, bounded retrieval, enrichment, and non-mutating edit-plan scaffolds with independent source and timeline revisions.",
+        ],
+      },
+      {
+        title: "Fixed",
+        items: [
+          "Trim and split now verify visible timeline geometry; track creation and overwrite placement verify exact postconditions instead of accepting silent no-ops.",
+          "Effect removal now preflights Component.remove support, including safe handling for unsupported Essential Sound Amplify components.",
+        ],
+      },
+      {
+        title: "Validation",
+        items: [
+          "Automated CEP/QE contract coverage is included; licensed Premiere Pro 26.x host confirmation remains a separate gate.",
+        ],
+      },
+    ],
+  },
+  {
     version: "1.11.1",
     date: "2026-08-16",
     label: "Remote static-route stability hotfix",

--- a/landing/lib/product.ts
+++ b/landing/lib/product.ts
@@ -1,7 +1,7 @@
 export const product = {
   name: "Premiere Pro MCP",
-  version: "1.11.1",
-  releaseDate: "2026-08-16",
+  version: "1.11.2",
+  releaseDate: "2026-08-18",
   coreToolCount: 285,
   defaultProfileToolCount: 283,
   connectedUxpToolCount: 331,
@@ -10,10 +10,10 @@ export const product = {
   uxpMinimumVersion: "25.6",
   downloads: {
     claudeBundle:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.11.1/premiere-pro-mcp-1.11.1.mcpb",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.11.2/premiere-pro-mcp-1.11.2.mcpb",
     signedCepConnector:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.11.1/MCPBridgeCEP.zxp",
-    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.11.1",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.11.2/MCPBridgeCEP.zxp",
+    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.11.2",
   },
   links: {
     repository: "https://github.com/leancoderkavy/premiere-pro-mcp",

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -7,7 +7,7 @@ Documentation: https://premiere-pro-mcp.com/docs/
 Source: https://github.com/leancoderkavy/premiere-pro-mcp
 npm: https://www.npmjs.com/package/premiere-pro-mcp
 License: MIT
-Current release: 1.11.1
+Current release: 1.11.2
 
 ## What it does
 

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -24,7 +24,7 @@ The recommended setup runs the MCP server and CEP bridge locally. Project media 
 
 ## Verified facts
 
-- Current project release: 1.11.1.
+- Current project release: 1.11.2.
 - Tool surface: 285 core structured MCP tools are registered; the default profile exposes 283. With an authenticated compatible UXP panel, 48 additional capability-gated tools bring the connected surface to 331. The server also exposes 4 resources and 5 prompts.
 - Supported desktop platforms: Windows and macOS.
 - Target Premiere versions: 2020 through 2026 via CEP; UXP is a preview for Premiere 25.6 and newer.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "premiere-pro-mcp",
-      "version": "1.11.1",
+      "version": "1.11.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Adobe Premiere Pro MCP server with 285 core AI video editing tools and a capability-aware UXP bridge for supported Premiere workflows.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/premiere-pro/.codex-plugin/plugin.json
+++ b/plugins/premiere-pro/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "Plan, execute, verify, and export video edits in Adobe Premiere Pro through the Premiere Pro MCP server.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/plugins/premiere-pro/.mcp.json
+++ b/plugins/premiere-pro/.mcp.json
@@ -4,7 +4,7 @@
       "title": "Premiere Pro MCP",
       "description": "Inspect and edit a local Adobe Premiere Pro project through the Premiere Pro MCP bridge.",
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.11.1"]
+      "args": ["-y", "premiere-pro-mcp@1.11.2"]
     }
   }
 }

--- a/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.11.1 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.11.2 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.11.1",
+  "version": "1.11.2",
   "coreTools": 285,
   "defaultProfileTools": 283,
   "uxpAdditionalTools": 48,

--- a/uxp-plugin/manifest.json
+++ b/uxp-plugin/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.ppmcp.premiere.uxp",
   "name": "Premiere Pro MCP Bridge",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "main": "index.html",
   "host": { "app": "premierepro", "minVersion": "25.6.0" },
   "entrypoints": [


### PR DESCRIPTION
## Summary

Release Premiere Pro MCP v1.11.2 from the fixes and project-context work already merged to `main`.

- align package, CEP, UXP, Claude Desktop, Claude Code, Codex, marketplace, and landing metadata at `1.11.2`
- publish release notes for fail-closed trim, split, track creation, overwrite placement, and effect removal
- document the durable local project-context engine and its privacy boundaries
- update download links and pinned installation commands

## Validation

- `npm run check` — 54 files / 1,531 tests
- `npm run check:release-metadata`
- `npm pack --dry-run` — 162 files, 334.6 kB package
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- `landing: npm run lint`
- `landing: npm run build`
- `landing: npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- `git diff --check`

## Host boundary

Automated CEP/QE contracts pass. Licensed Premiere Pro 26.x host confirmation remains a separate validation boundary and is not claimed by this release.