### PR TITLE
Fix UXP 26.3 connection and transcript rough-cut planning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Added a revision-locked `plan_transcript_rough_cut_uxp` workflow that maps native transcript
+  deletion ranges to verified 1x sequence placements, orders cut instructions from the end of the
+  timeline, and requires duplicate-sequence and post-mutation verification safeguards.
+
+### Fixed
+
+- Premiere Pro 26.3 can reject a manifest list of loopback WebSocket domains with `Manifest entry
+  not found`. The UXP package now uses Adobe's compatible network permission while the panel keeps
+  enforcing the exact loopback-only `/uxp` endpoint at runtime.
+
 ## [1.11.2] - 2026-08-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Give compatible AI assistants structured control over supported Adobe Premiere Pro workflows.**
 
-285 core tools across 32 modules, 4 resources, and 5 guided workflows. A connected UXP host adds 48 capability-gated tools.
+285 core tools across 32 modules, 4 resources, and 6 guided workflows. A connected UXP host adds 49 capability-gated tools.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Node.js](https://img.shields.io/badge/Node.js-20.19%2B-green.svg)](https://nodejs.org)
@@ -29,7 +29,7 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 "Add the B-roll clips to V2, apply a cross dissolve between each, color correct them to match the A-roll, and export a 1080p ProRes."
 ```
 
-The AI handles the entire workflow through 285 core tools spanning the supported ExtendScript, QE DOM, local media analysis, revisioned project-context retrieval, safe edit-planning, and connection-verification surfaces. A compatible, authenticated UXP panel adds 48 documented, capability-gated tools without replacing the production CEP bridge.
+The AI handles the entire workflow through 285 core tools spanning the supported ExtendScript, QE DOM, local media analysis, revisioned project-context retrieval, safe edit-planning, and connection-verification surfaces. A compatible, authenticated UXP panel adds 49 documented, capability-gated tools without replacing the production CEP bridge.
 
 ### Latest release: 1.11.2
 
@@ -375,6 +375,11 @@ capability negotiation.
 - Frame.io needs a separately authenticated Frame.io API integration; an account
   entitlement alone does not make it callable through Premiere's DOM.
 - Transcript JSON import/export is documented in UXP. Starting Speech-to-Text is not.
+- `preview_transcript_edit_uxp` and `plan_transcript_rough_cut_uxp` provide a
+  revision-locked transcript-edit workflow. The planner maps selected transcript
+  ranges to verified 1x placements in a duplicate sequence and emits descending
+  split/remove instructions; it does not claim that Adobe exposes native transcript
+  text deletion or perform an unverified destructive edit.
 - The remaining AI operations are user-assisted or unsupported by documented
   public APIs. The tool explains what can be inspected after a user completes
   the operation and where artifact provenance cannot be established safely.
@@ -483,11 +488,11 @@ The file-based IPC bridge is simple, reliable, and works across macOS and Window
 
 ---
 
-## Tools (285 core total; 283 under the default profile; 331 with a connected UXP bridge)
+## Tools (285 core total; 283 under the default profile; 332 with a connected UXP bridge)
 
 The [complete supported-actions catalog](docs/supported-actions.md) lists every
 registered core tool, the two tools restricted behind explicit `unsafe-script`
-authority, and all 48 authenticated UXP additions with their current action or mode
+authority, and all 49 authenticated UXP additions with their current action or mode
 values. It is generated from the same MCP registration surface returned to clients;
 the tables below are a shorter workflow-oriented overview.
 

--- a/docs/marketing-assets.md
+++ b/docs/marketing-assets.md
@@ -20,7 +20,7 @@ Supporting proof:
 - Free and MIT licensed
 - Recommended local-first setup
 - 285 registered core tools; 283 in the default profile
-- 48 additional capability-gated tools with an authenticated compatible UXP host
+- 49 additional capability-gated tools with an authenticated compatible UXP host
 - Windows and macOS packaging for supported Premiere versions
 
 ## Claim boundaries

--- a/docs/supported-actions.md
+++ b/docs/supported-actions.md
@@ -11,8 +11,8 @@ descriptions, action enums, authority visibility, and counts stay aligned with t
 | Registered core actions | 285 | CEP/local server catalog; host and authority checks still apply |
 | Default-profile core actions | 283 | Advertised with `inspect,edit,export,filesystem` |
 | Restricted core actions | 2 | Require explicit `unsafe-script` authority |
-| Authenticated UXP additions | 48 | Advertised only while a compatible authenticated UXP panel is connected |
-| Default profile with UXP | 331 | 283 core plus 48 UXP tools |
+| Authenticated UXP additions | 49 | Advertised only while a compatible authenticated UXP panel is connected |
+| Default profile with UXP | 332 | 283 core plus 49 UXP tools |
 
 ## How to read support
 
@@ -366,6 +366,7 @@ authenticated and the connected host advertises the required command capabilitie
 | `manage_track_state_uxp` | Connected UXP | `inspect`, `set_mute` | Inspect audio, video, and caption track mute state or set one media type serially with stale-state preflight and per-track readback. Adobe exposes this as direct promises, so no undo transaction is claimed. |
 | `manage_workflow_checkpoints_uxp` | Connected UXP | `has`, `get`, `set`, `clear` | Read or transactionally write small, namespaced workflow checkpoints on the active project or a targeted sequence. Persistent values may sync with cloud projects; never store secrets, native paths, transcripts, or media names. |
 | `organize_project_items_uxp` | Connected UXP | `inspect_bin`, `create_bin`, `create_smart_bin`, `rename`, `move`, `set_color`, `remove` | Inspect a bin or transactionally create, rename, move, color-label, and remove project items with stable-ID guards. |
+| `plan_transcript_rough_cut_uxp` | Connected UXP | Single operation | Build a revision-locked, non-mutating rough-cut plan from Premiere's native transcript and verified 1x sequence placements. The plan orders cuts from the end of the timeline, requires a duplicate sequence, and requires re-query after every mutation. |
 | `preflight_production_storage_uxp` | Connected UXP | `preflight`, `configure_project` | Inspect project/Production scratch disks and ingest state, or set supported project scratch categories to Premiere's symbolic destinations in one undoable transaction. |
 | `preview_transcript_edit_uxp` | Connected UXP | Single operation | Validate and merge source-time ranges selected from Premiere's native transcript. Returns a confirmation token and never changes the timeline. Automatic timeline application remains withheld until the source-to-sequence mapping is live-host verified. |
 | `relink_offline_media_uxp` | Connected UXP | Single operation | Relink one offline clip to a workspace-contained media path after stale-path and capability checks. This Premiere API is non-undoable and requires explicit confirmation. |

--- a/docs/uxp-stable-workflows.md
+++ b/docs/uxp-stable-workflows.md
@@ -97,7 +97,9 @@ how Premiere resolves symlinks and Windows reparse points. Operators should not 
 links to unrelated data inside an approved workspace.
 
 The panel's bridge URL is separately restricted to `ws://127.0.0.1:<port>/uxp` or
-`ws://localhost:<port>/uxp`, matching the manifest's loopback-only network policy.
+`ws://localhost:<port>/uxp`. The manifest uses Adobe's compatible `domains: "all"` declaration
+because Premiere 26.3 rejects the narrower WebSocket list; the panel's runtime validator is the
+loopback-only authority and rejects remote hosts, credentials, fragments, and non-`/uxp` paths.
 
 ## Public action contracts
 

--- a/landing/lib/product.ts
+++ b/landing/lib/product.ts
@@ -4,7 +4,7 @@ export const product = {
   releaseDate: "2026-08-18",
   coreToolCount: 285,
   defaultProfileToolCount: 283,
-  connectedUxpToolCount: 331,
+  connectedUxpToolCount: 332,
   nodeVersion: "20.19",
   premiereCompatibility: "2020–2026",
   uxpMinimumVersion: "25.6",

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -11,7 +11,7 @@ Current release: 1.11.2
 
 ## What it does
 
-The server registers 285 core tools for project inspection, timeline editing, media import and organization, clip selection, effects, Lumetri color, audio, silence detection, revisioned project-context retrieval, keyframes, markers, captions, transitions, playback, metadata, proxies, connection verification, and Adobe Media Encoder export. The default profile exposes 283. An authenticated compatible UXP panel adds 48 capability-gated tools for 331 connected tools. It also exposes four MCP resources and five workflow prompts.
+The server registers 285 core tools for project inspection, timeline editing, media import and organization, clip selection, effects, Lumetri color, audio, silence detection, revisioned project-context retrieval, keyframes, markers, captions, transitions, playback, metadata, proxies, connection verification, and Adobe Media Encoder export. The default profile exposes 283. An authenticated compatible UXP panel adds 49 capability-gated tools for 332 connected tools. It also exposes four MCP resources and six workflow prompts.
 
 ## How it connects
 

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -2,7 +2,7 @@
 
 > Open-source, local-first Model Context Protocol server for AI-assisted editing and automation in Adobe Premiere Pro.
 
-Premiere Pro MCP registers 285 core structured tools for timeline editing, effects, Lumetri color, keyframes, media management, silence detection, revisioned project-context retrieval, project organization, connection verification, and export. The default profile exposes 283 tools. An authenticated compatible UXP host adds 48 capability-gated tools for 331 connected tools. Current releases target Adobe Premiere Pro 2020–2026 on macOS and Windows.
+Premiere Pro MCP registers 285 core structured tools for timeline editing, effects, Lumetri color, keyframes, media management, silence detection, revisioned project-context retrieval, project organization, connection verification, and export. The default profile exposes 283 tools. An authenticated compatible UXP host adds 49 capability-gated tools for 332 connected tools. Current releases target Adobe Premiere Pro 2020–2026 on macOS and Windows.
 
 ## Canonical resources
 
@@ -25,7 +25,7 @@ The recommended setup runs the MCP server and CEP bridge locally. Project media 
 ## Verified facts
 
 - Current project release: 1.11.2.
-- Tool surface: 285 core structured MCP tools are registered; the default profile exposes 283. With an authenticated compatible UXP panel, 48 additional capability-gated tools bring the connected surface to 331. The server also exposes 4 resources and 5 prompts.
+- Tool surface: 285 core structured MCP tools are registered; the default profile exposes 283. With an authenticated compatible UXP panel, 49 additional capability-gated tools bring the connected surface to 332. The server also exposes 4 resources and 6 prompts.
 - Supported desktop platforms: Windows and macOS.
 - Target Premiere versions: 2020 through 2026 via CEP; UXP is a preview for Premiere 25.6 and newer.
 - License: MIT.

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -2,11 +2,11 @@
   "version": "1.11.2",
   "coreTools": 285,
   "defaultProfileTools": 283,
-  "uxpAdditionalTools": 48,
-  "defaultProfileWithUxpTools": 331,
+  "uxpAdditionalTools": 49,
+  "defaultProfileWithUxpTools": 332,
   "toolModules": 32,
   "resources": 4,
-  "guidedWorkflows": 5,
+  "guidedWorkflows": 6,
   "premiereVersions": "2020–2026",
   "uxpMinimumVersion": "25.6.0"
 }

--- a/scripts/validate-distribution.mjs
+++ b/scripts/validate-distribution.mjs
@@ -8,12 +8,6 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 
 const MCPB_SCHEMA =
   "https://raw.githubusercontent.com/modelcontextprotocol/mcpb/main/schemas/mcpb-manifest-v0.4.schema.json";
-const LOOPBACK_DOMAINS = new Set([
-  "http://127.0.0.1",
-  "http://localhost",
-  "ws://127.0.0.1",
-  "ws://localhost",
-]);
 const SEMVER = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 const ADOBE_VERSION = /^\d+\.\d+\.\d+$/;
 
@@ -129,10 +123,9 @@ export function validateUxpManifest(manifest, packageJson, { expectedId } = {}) 
     "UXP package must use operator-requested local file access",
   );
   const domains = manifest.requiredPermissions?.network?.domains;
-  assert(Array.isArray(domains) && domains.length > 0, "UXP package must declare its loopback network access");
   assert(
-    domains.every((domain) => LOOPBACK_DOMAINS.has(domain)),
-    "UXP package may only declare the reviewed loopback HTTP/WebSocket domains",
+    domains === "all",
+    "UXP package must use Adobe's compatible network permission; runtime code remains the loopback-only authority",
   );
 }
 

--- a/src/security/capabilities.ts
+++ b/src/security/capabilities.ts
@@ -60,6 +60,7 @@ const INSPECT_TOOL_NAMES = new Set([
   "get_capabilities",
   "preview_edit_plan",
   "preview_transcript_edit_uxp",
+  "plan_transcript_rough_cut_uxp",
   "create_context_edit_plan",
 ]);
 // detect_silence reads a media file from disk and shells out to ffmpeg. It

--- a/src/tools/transcript-edits.ts
+++ b/src/tools/transcript-edits.ts
@@ -13,6 +13,34 @@ export interface TranscriptEditPreview {
   applied: false;
 }
 
+export interface TranscriptPlacement {
+  placement_id: string;
+  track_type: "video" | "audio";
+  track_index: number;
+  source_in_seconds: number;
+  source_out_seconds: number;
+  timeline_start_seconds: number;
+  timeline_end_seconds: number;
+}
+
+export interface TranscriptRoughCutStep {
+  placement_id: string;
+  track_type: "video" | "audio";
+  track_index: number;
+  source_range: TranscriptDeletionRange;
+  timeline_range: TranscriptDeletionRange;
+  instructions: readonly [string, string, string, string];
+}
+
+export interface TranscriptRoughCutPlan extends TranscriptEditPreview {
+  planVersion: 1;
+  requiresDuplicateSequence: true;
+  requiresPostMutationRequery: true;
+  ripple: boolean;
+  steps: TranscriptRoughCutStep[];
+  unmappedDeletionRanges: TranscriptDeletionRange[];
+}
+
 const MAX_DELETION_RANGES = 100;
 
 export function transcriptRevision(json: string): string {
@@ -85,5 +113,92 @@ export function previewTranscriptEdit(
     deletedSeconds: roundSeconds(deletionRanges.reduce((total, range) => total + range.end_seconds - range.start_seconds, 0)),
     confirmationToken: createHash("sha256").update(canonical).digest("hex"),
     applied: false,
+  };
+}
+
+function finite(value: unknown, label: string): number {
+  if (!Number.isFinite(value)) throw new Error(`${label} must be a finite number`);
+  return Number(value);
+}
+
+export function planTranscriptRoughCut(
+  preview: TranscriptEditPreview,
+  placementsValue: unknown,
+  ripple = true,
+): TranscriptRoughCutPlan {
+  if (!Array.isArray(placementsValue) || placementsValue.length === 0) {
+    throw new Error("placements must contain at least one verified 1x sequence placement");
+  }
+  if (placementsValue.length > 256) throw new Error("transcript rough cuts are limited to 256 placements");
+
+  const placements = placementsValue.map((value, index): TranscriptPlacement => {
+    if (!value || typeof value !== "object") throw new Error(`placement ${index} must be an object`);
+    const item = value as Partial<TranscriptPlacement>;
+    if (typeof item.placement_id !== "string" || !item.placement_id.trim() || item.placement_id.length > 512) {
+      throw new Error(`placement ${index} placement_id must be 1-512 characters`);
+    }
+    if (item.track_type !== "video" && item.track_type !== "audio") {
+      throw new Error(`placement ${index} track_type must be video or audio`);
+    }
+    if (!Number.isInteger(item.track_index) || Number(item.track_index) < 0) {
+      throw new Error(`placement ${index} track_index must be a non-negative integer`);
+    }
+    const sourceIn = finite(item.source_in_seconds, `placement ${index} source_in_seconds`);
+    const sourceOut = finite(item.source_out_seconds, `placement ${index} source_out_seconds`);
+    const timelineStart = finite(item.timeline_start_seconds, `placement ${index} timeline_start_seconds`);
+    const timelineEnd = finite(item.timeline_end_seconds, `placement ${index} timeline_end_seconds`);
+    if (sourceIn < 0 || timelineStart < 0 || sourceOut <= sourceIn || timelineEnd <= timelineStart) {
+      throw new Error(`placement ${index} must contain increasing non-negative source and timeline ranges`);
+    }
+    if (Math.abs((sourceOut - sourceIn) - (timelineEnd - timelineStart)) > 0.001) {
+      throw new Error(`placement ${index} is retimed or has an unverified source-to-timeline mapping`);
+    }
+    return {
+      placement_id: item.placement_id,
+      track_type: item.track_type,
+      track_index: Number(item.track_index),
+      source_in_seconds: sourceIn,
+      source_out_seconds: sourceOut,
+      timeline_start_seconds: timelineStart,
+      timeline_end_seconds: timelineEnd,
+    };
+  });
+
+  const mapped = new Set<number>();
+  const steps: TranscriptRoughCutStep[] = [];
+  for (const placement of placements) {
+    for (let rangeIndex = 0; rangeIndex < preview.deletionRanges.length; rangeIndex++) {
+      const deletion = preview.deletionRanges[rangeIndex];
+      const start = Math.max(deletion.start_seconds, placement.source_in_seconds);
+      const end = Math.min(deletion.end_seconds, placement.source_out_seconds);
+      if (end <= start) continue;
+      mapped.add(rangeIndex);
+      const timelineStart = roundSeconds(placement.timeline_start_seconds + start - placement.source_in_seconds);
+      const timelineEnd = roundSeconds(placement.timeline_start_seconds + end - placement.source_in_seconds);
+      steps.push({
+        placement_id: placement.placement_id,
+        track_type: placement.track_type,
+        track_index: placement.track_index,
+        source_range: { start_seconds: roundSeconds(start), end_seconds: roundSeconds(end) },
+        timeline_range: { start_seconds: timelineStart, end_seconds: timelineEnd },
+        instructions: [
+          `Split ${placement.track_type} track ${placement.track_index} at ${timelineEnd}s.`,
+          `Split ${placement.track_type} track ${placement.track_index} at ${timelineStart}s.`,
+          "Re-query the sequence and identify the segment enclosed by those verified boundaries.",
+          `Remove only that segment${ripple ? " with ripple enabled" : " without ripple"}, then re-query and verify the resulting structure.`,
+        ],
+      });
+    }
+  }
+  steps.sort((left, right) => right.timeline_range.start_seconds - left.timeline_range.start_seconds);
+
+  return {
+    ...preview,
+    planVersion: 1,
+    requiresDuplicateSequence: true,
+    requiresPostMutationRequery: true,
+    ripple,
+    steps,
+    unmappedDeletionRanges: preview.deletionRanges.filter((_, index) => !mapped.has(index)),
   };
 }

--- a/src/tools/uxp.ts
+++ b/src/tools/uxp.ts
@@ -1,5 +1,5 @@
 import type { UxpWebSocketBridge } from "../bridge/uxp-websocket-bridge.js";
-import { previewTranscriptEdit, transcriptRevision } from "./transcript-edits.js";
+import { planTranscriptRoughCut, previewTranscriptEdit, transcriptRevision } from "./transcript-edits.js";
 import { getUxpAdvancedWorkflowTools } from "./uxp-advanced-workflows.js";
 import { getUxpNextWorkflowTools } from "./uxp-next-workflows.js";
 import { getUxpWorkflowTools } from "./uxp-workflows.js";
@@ -171,6 +171,65 @@ export function getUxpTools(bridge: UxpWebSocketBridge) {
             projectItemId: exported.projectItemId,
             projectItemName: exported.projectItemName,
             ...preview,
+          } } };
+        } catch (error) {
+          return { success: false, error: error instanceof Error ? error.message : String(error) };
+        }
+      },
+    },
+    plan_transcript_rough_cut_uxp: {
+      description: "Build a revision-locked, non-mutating rough-cut plan from Premiere's native transcript and verified 1x sequence placements. The plan orders cuts from the end of the timeline, requires a duplicate sequence, and requires re-query after every mutation.",
+      parameters: {
+        type: "object" as const,
+        properties: {
+          project_item_id: { type: "string", maxLength: 512 },
+          project_item_name: { type: "string", maxLength: 255 },
+          transcript_revision: { type: "string", pattern: "^sha256:[a-f0-9]{64}$" },
+          deletions: {
+            type: "array", minItems: 1, maxItems: 100,
+            items: {
+              type: "object", additionalProperties: false,
+              properties: {
+                start_seconds: { type: "number", minimum: 0 },
+                end_seconds: { type: "number", exclusiveMinimum: 0 },
+              },
+              required: ["start_seconds", "end_seconds"],
+            },
+          },
+          placements: {
+            type: "array", minItems: 1, maxItems: 256,
+            description: "Verified 1x placements of this source in the target duplicate sequence.",
+            items: {
+              type: "object", additionalProperties: false,
+              properties: {
+                placement_id: { type: "string", minLength: 1, maxLength: 512 },
+                track_type: { type: "string", enum: ["video", "audio"] },
+                track_index: { type: "integer", minimum: 0 },
+                source_in_seconds: { type: "number", minimum: 0 },
+                source_out_seconds: { type: "number", exclusiveMinimum: 0 },
+                timeline_start_seconds: { type: "number", minimum: 0 },
+                timeline_end_seconds: { type: "number", exclusiveMinimum: 0 },
+              },
+              required: ["placement_id", "track_type", "track_index", "source_in_seconds", "source_out_seconds", "timeline_start_seconds", "timeline_end_seconds"],
+            },
+          },
+          handle_seconds: { type: "number", minimum: 0, maximum: 10 },
+          ripple: { type: "boolean", description: "Whether the resulting instructions should ripple removals; defaults to true." },
+        },
+        required: ["transcript_revision", "deletions", "placements"],
+      },
+      handler: async (args: { project_item_id?: string; project_item_name?: string; transcript_revision: string; deletions: unknown; placements: unknown; handle_seconds?: number; ripple?: boolean }) => {
+        try {
+          const exported = await bridge.request("transcript.export", {
+            ...(args.project_item_id ? { projectItemId: args.project_item_id } : {}),
+            ...(args.project_item_name ? { projectItemName: args.project_item_name } : {}),
+          }) as { json?: unknown; projectItemId?: unknown; projectItemName?: unknown };
+          if (typeof exported?.json !== "string") throw new Error("Premiere returned an empty transcript");
+          const preview = previewTranscriptEdit(exported.json, args.transcript_revision, args.deletions, args.handle_seconds);
+          return { success: true, data: { backend: "uxp", result: {
+            projectItemId: exported.projectItemId,
+            projectItemName: exported.projectItemName,
+            ...planTranscriptRoughCut(preview, args.placements, args.ripple ?? true),
           } } };
         } catch (error) {
           return { success: false, error: error instanceof Error ? error.message : String(error) };

--- a/src/workflows/catalog.ts
+++ b/src/workflows/catalog.ts
@@ -31,6 +31,12 @@ export const WORKFLOW_CATALOG = [
     summary: "Capture reusable project context, retrieve only evidence relevant to the edit intent, create a revision-guarded plan, then preview before applying.",
     recommendedTools: ["manage_project_context", "search_project_context", "create_context_edit_plan", "preview_edit_plan", "apply_edit_plan"],
   },
+  {
+    id: "transcript-rough-cut",
+    title: "Plan a transcript-driven rough cut",
+    summary: "Export Premiere's native transcript, select revision-locked source ranges, map them to verified 1x placements in a duplicate sequence, then execute the descending cut plan with re-query verification.",
+    recommendedTools: ["get_clip_transcript_uxp", "search_clip_transcript_uxp", "preview_transcript_edit_uxp", "plan_transcript_rough_cut_uxp", "manage_sequences_uxp", "split_clip", "get_sequence_structure"],
+  },
 ] as const;
 
 export const WORKFLOW_RESOURCE = JSON.stringify(

--- a/tests/mcp-modernization.test.ts
+++ b/tests/mcp-modernization.test.ts
@@ -19,7 +19,7 @@ describe("modern MCP surface", () => {
   it("exposes a machine-readable workflow resource", () => {
     const resource = JSON.parse(WORKFLOW_RESOURCE);
     expect(resource.version).toBe(1);
-    expect(resource.workflows).toHaveLength(5);
+    expect(resource.workflows).toHaveLength(6);
     expect(resource.workflows[0].recommendedTools).toContain("get_premiere_state");
   });
 

--- a/tests/security-capabilities.test.ts
+++ b/tests/security-capabilities.test.ts
@@ -42,6 +42,7 @@ describe("capability profiles", () => {
     expect(capabilityForTool("manage_markers_uxp")).toBe("edit");
     expect(capabilityForTool("get_project_info")).toBe("inspect");
     expect(capabilityForTool("preview_transcript_edit_uxp")).toBe("inspect");
+    expect(capabilityForTool("plan_transcript_rough_cut_uxp")).toBe("inspect");
     expect(capabilityForTool("create_context_edit_plan")).toBe("inspect");
     expect(capabilityForTool("search_project_context")).toBe("inspect");
     expect(capabilityForTool("ping")).toBe("inspect");

--- a/tests/tools/adobe-26-3-uxp-catalog.test.ts
+++ b/tests/tools/adobe-26-3-uxp-catalog.test.ts
@@ -44,7 +44,7 @@ describe("Adobe Premiere 26.3 UXP public MCP catalog", () => {
       expect(listed.tools.map((tool) => tool.name)).toEqual(
         expect.arrayContaining(ADOBE_26_3_TOOLS),
       );
-      expect(listed.tools).toHaveLength(331);
+      expect(listed.tools).toHaveLength(332);
     } finally {
       await client.close();
       await server.close();

--- a/tests/tools/transcript-edits.test.ts
+++ b/tests/tools/transcript-edits.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { UxpWebSocketBridge } from "../../src/bridge/uxp-websocket-bridge.js";
 import {
   normalizeTranscriptDeletionRanges,
+  planTranscriptRoughCut,
   previewTranscriptEdit,
   transcriptRevision,
 } from "../../src/tools/transcript-edits.js";
@@ -43,6 +44,48 @@ describe("transcript edit planning", () => {
     expect(first).toMatchObject({ deletedSeconds: 2.5, applied: false });
     expect(first.confirmationToken).toBe(second.confirmationToken);
     expect(() => previewTranscriptEdit(json, transcriptRevision("different"), [{ start_seconds: 1, end_seconds: 2 }])).toThrow("does not match");
+  });
+
+  it("maps transcript deletions to descending verified 1x timeline cut instructions", () => {
+    const json = '{"segments":[]}';
+    const preview = previewTranscriptEdit(json, transcriptRevision(json), [
+      { start_seconds: 2, end_seconds: 4 },
+      { start_seconds: 8, end_seconds: 12 },
+    ]);
+    const plan = planTranscriptRoughCut(preview, [{
+      placement_id: "clip-1",
+      track_type: "video",
+      track_index: 0,
+      source_in_seconds: 0,
+      source_out_seconds: 10,
+      timeline_start_seconds: 20,
+      timeline_end_seconds: 30,
+    }]);
+    expect(plan).toMatchObject({
+      applied: false,
+      requiresDuplicateSequence: true,
+      requiresPostMutationRequery: true,
+      ripple: true,
+      unmappedDeletionRanges: [],
+    });
+    expect(plan.steps.map((step) => step.timeline_range)).toEqual([
+      { start_seconds: 28, end_seconds: 30 },
+      { start_seconds: 22, end_seconds: 24 },
+    ]);
+  });
+
+  it("rejects retimed placements instead of guessing source-to-timeline mapping", () => {
+    const json = '{"segments":[]}';
+    const preview = previewTranscriptEdit(json, transcriptRevision(json), [{ start_seconds: 1, end_seconds: 2 }]);
+    expect(() => planTranscriptRoughCut(preview, [{
+      placement_id: "retimed",
+      track_type: "video",
+      track_index: 0,
+      source_in_seconds: 0,
+      source_out_seconds: 10,
+      timeline_start_seconds: 0,
+      timeline_end_seconds: 5,
+    }])).toThrow("retimed");
   });
 });
 
@@ -89,6 +132,32 @@ describe("transcript UXP MCP tools", () => {
     expect(result).toMatchObject({
       success: true,
       data: { result: { projectItemId: "clip-1", deletedSeconds: 2, applied: false } },
+    });
+  });
+
+  it("builds a transcript rough-cut plan without mutating Premiere", async () => {
+    const json = '{"segments":[{"text":"cut this"}]}';
+    const request = vi.fn().mockResolvedValue({ projectItemId: "clip-1", projectItemName: "Interview", json });
+    const bridge = { request, getState: vi.fn() } as unknown as UxpWebSocketBridge;
+    const result = await getUxpTools(bridge).plan_transcript_rough_cut_uxp.handler({
+      project_item_id: "clip-1",
+      transcript_revision: transcriptRevision(json),
+      deletions: [{ start_seconds: 2, end_seconds: 4 }],
+      placements: [{
+        placement_id: "timeline-clip-1",
+        track_type: "video",
+        track_index: 0,
+        source_in_seconds: 0,
+        source_out_seconds: 10,
+        timeline_start_seconds: 20,
+        timeline_end_seconds: 30,
+      }],
+    });
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith("transcript.export", { projectItemId: "clip-1" });
+    expect(result).toMatchObject({
+      success: true,
+      data: { result: { applied: false, requiresDuplicateSequence: true, steps: [{ timeline_range: { start_seconds: 22, end_seconds: 24 } }] } },
     });
   });
 });

--- a/tests/tools/transcript-edits.test.ts
+++ b/tests/tools/transcript-edits.test.ts
@@ -87,6 +87,28 @@ describe("transcript edit planning", () => {
       timeline_end_seconds: 5,
     }])).toThrow("retimed");
   });
+
+  it("fails closed for malformed placements and reports unmapped non-ripple ranges", () => {
+    const json = '{"segments":[]}';
+    const preview = previewTranscriptEdit(json, transcriptRevision(json), [{ start_seconds: 20, end_seconds: 21 }]);
+    const valid = {
+      placement_id: "clip-1", track_type: "audio", track_index: 0,
+      source_in_seconds: 0, source_out_seconds: 10,
+      timeline_start_seconds: 0, timeline_end_seconds: 10,
+    } as const;
+
+    expect(() => planTranscriptRoughCut(preview, [])).toThrow("at least one");
+    expect(() => planTranscriptRoughCut(preview, Array(257).fill(valid))).toThrow("limited to 256");
+    expect(() => planTranscriptRoughCut(preview, [null])).toThrow("must be an object");
+    expect(() => planTranscriptRoughCut(preview, [{ ...valid, placement_id: "" }])).toThrow("1-512");
+    expect(() => planTranscriptRoughCut(preview, [{ ...valid, track_type: "caption" }])).toThrow("video or audio");
+    expect(() => planTranscriptRoughCut(preview, [{ ...valid, track_index: -1 }])).toThrow("non-negative integer");
+    expect(() => planTranscriptRoughCut(preview, [{ ...valid, source_out_seconds: Number.NaN }])).toThrow("finite number");
+    expect(() => planTranscriptRoughCut(preview, [{ ...valid, source_out_seconds: 0 }])).toThrow("increasing");
+
+    const plan = planTranscriptRoughCut(preview, [valid], false);
+    expect(plan).toMatchObject({ ripple: false, steps: [], unmappedDeletionRanges: preview.deletionRanges });
+  });
 });
 
 describe("transcript UXP MCP tools", () => {

--- a/tests/tools/uxp-handler-coverage.test.ts
+++ b/tests/tools/uxp-handler-coverage.test.ts
@@ -10,6 +10,11 @@ const values: Record<string, unknown> = {
   name: "Coverage Name", query: "coverage", preset_path: "/tmp/preset.sqpreset",
   output_file_path: "/tmp/output.otio", project_item_id: "item-1", track_index: 0,
   start_seconds: 1, end_seconds: 2, transcript_revision: `sha256:${"a".repeat(64)}`,
+  placements: [{
+    placement_id: "coverage-placement", track_type: "video", track_index: 0,
+    source_in_seconds: 0, source_out_seconds: 10,
+    timeline_start_seconds: 20, timeline_end_seconds: 30,
+  }],
 };
 
 function valueFor(schema: Schema, field: string, all: boolean): unknown {

--- a/tests/tools/uxp-tools.test.ts
+++ b/tests/tools/uxp-tools.test.ts
@@ -101,6 +101,7 @@ describe("UXP MCP tools", () => {
           "get_clip_transcript_uxp",
           "search_clip_transcript_uxp",
           "preview_transcript_edit_uxp",
+          "plan_transcript_rough_cut_uxp",
           "detect_object_masks_uxp",
           "configure_encoder_uxp",
           "rename_track_uxp",
@@ -116,7 +117,7 @@ describe("UXP MCP tools", () => {
       // transcript workflow and documented Premiere 26.3 tools add nineteen,
       // and the two stable workflow expansions add twenty-one consolidated UXP tools;
       // connection verification adds one default-profile core tool.
-      expect(tools.tools).toHaveLength(331);
+      expect(tools.tools).toHaveLength(332);
     } finally {
       await client.close();
       await server.close();

--- a/tests/uxp/workspace.test.ts
+++ b/tests/uxp/workspace.test.ts
@@ -1,4 +1,6 @@
 import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 
 const require = createRequire(import.meta.url);
@@ -30,6 +32,12 @@ function storageFixture() {
 }
 
 describe("least-privilege UXP workspace broker", () => {
+  it("uses Adobe's compatible manifest permission while retaining a loopback runtime boundary", () => {
+    const manifest = JSON.parse(readFileSync(join(process.cwd(), "uxp-plugin", "manifest.json"), "utf8"));
+    expect(manifest.requiredPermissions.network.domains).toBe("all");
+    expect(Workspace.validateLoopbackBridgeUrl("ws://127.0.0.1:7777/uxp").hostname).toBe("127.0.0.1");
+    expect(() => Workspace.validateLoopbackBridgeUrl("ws://example.com:7777/uxp")).toThrow("Bridge URL must");
+  });
   it("normalizes absolute paths without allowing root traversal", () => {
     expect(Workspace.parseAbsolutePath("D:\\Projects\\Film\\media\\..\\clip.mov", "path")).toMatchObject({
       normalized: "D:/Projects/Film/clip.mov",

--- a/uxp-plugin/DISTRIBUTION.md
+++ b/uxp-plugin/DISTRIBUTION.md
@@ -25,7 +25,9 @@ The builder uses a fixed ZIP timestamp, lexical file order, and stored entries,
 then reads the generated central directory and checks every entry and CRC. The
 result is reproducible for identical source bytes. It also rejects symlinks,
 requires the UXP v5 Premiere manifest, checks the version against
-`package.json`, and permits only the reviewed loopback network domains.
+`package.json`. Adobe's Premiere 26.3 runtime requires the compatible `domains: "all"`
+manifest form for the WebSocket connection; `workspace.cjs` remains the enforced authority and
+accepts only `ws://127.0.0.1:<port>/uxp` or `ws://localhost:<port>/uxp`.
 
 For an Adobe Creative Cloud Marketplace submission, Adobe Developer
 Distribution must first create the Marketplace plugin ID. Build a separate

--- a/uxp-plugin/manifest.json
+++ b/uxp-plugin/manifest.json
@@ -17,6 +17,6 @@
   ],
   "requiredPermissions": {
     "localFileSystem": "request",
-    "network": { "domains": ["http://127.0.0.1", "ws://127.0.0.1", "http://localhost", "ws://localhost"] }
+    "network": { "domains": "all" }
   }
 }


### PR DESCRIPTION
## Summary
- use Adobe's Premiere 26.3-compatible UXP network permission while retaining strict runtime loopback URL validation
- add a revision-locked, non-mutating transcript rough-cut planner for verified 1x sequence placements
- update capabilities, workflows, counts, generated docs, and regression coverage

Closes #132
Closes #77

## Validation
- npm run check (54 files, 1,537 tests)
- contract coverage confirms the manifest permission and runtime rejection of remote WebSocket URLs

## Host boundary
The exact packaged build has not been exercised in a licensed Premiere host in this environment. Issue #132 includes reporter evidence that Premiere 26.3.2 accepts the adopted manifest declaration. Transcript planning remains non-mutating because Adobe's public Transcript API exposes export/import/search state, not transcript-text deletion.