### PR TITLE
Research MRTR confirmation for consequential edits

### DIFF
--- a/docs/recommendations/2026-08-18-round-2/22-mrtr-confirmation.md
+++ b/docs/recommendations/2026-08-18-round-2/22-mrtr-confirmation.md
@@ -1,0 +1,21 @@
+# Recommendation 22: MRTR confirmation for consequential edits
+
+## Evidence
+
+MCP 2026-07-28 introduces `InputRequiredResult` so a server can request user input during an active call and the client can retry with `inputResponses`.
+
+- [MCP key changes](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
+- [MCP release candidate details](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate)
+
+## Proposed improvement
+
+Use MRTR for overwrite, delete, relink, and export-overwrite confirmations when the client advertises support. Bind the response to a canonical operation digest, project revision, expiry, and authenticated principal.
+
+## Acceptance criteria
+
+- A changed plan, project revision, principal, or expired prompt invalidates the response.
+- Clients without MRTR receive the existing explicit-token flow.
+- Retries are idempotent before the host commit boundary.
+- Tests cover approve, decline, replay, mismatch, and disconnect.
+
+MRTR is a confirmation transport, not evidence that a human understood the edit.


### PR DESCRIPTION
## What
- adds recommendation 22 from the 2026-08-18 second research round
- records official-source evidence, a repo-specific proposal, acceptance criteria, and an explicit host-validation boundary

## Why
This is an independently reviewable recommendation derived from current Adobe Premiere UXP and MCP documentation and checked against the existing implementation and prior recommendation batch.

## Impact
Documentation/research only. No runtime capability or live-host support claim is added.

## Checks
- npm run check (54 files, 1,538 tests passed)
- git diff --cached --check