### PR TITLE
Research MCP routing-header integrity

### DIFF
--- a/docs/recommendations/2026-08-18-round-2/23-routing-header-integrity.md
+++ b/docs/recommendations/2026-08-18-round-2/23-routing-header-integrity.md
@@ -1,0 +1,21 @@
+# Recommendation 23: MCP routing-header integrity
+
+## Evidence
+
+MCP 2026-07-28 adds `Mcp-Method` and `Mcp-Name` headers for routing without parsing request bodies and defines `HeaderMismatchError` when they disagree with the JSON-RPC payload.
+
+- [MCP key changes](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
+- [MCP SDK release overview](https://blog.modelcontextprotocol.io/posts/sdk-betas-2026-07-28)
+
+## Proposed improvement
+
+Validate routing headers against the parsed body before authentication scope selection or dispatch. Treat headers as bounded routing hints, never as independent authorization facts, and redact sensitive resource names from access logs.
+
+## Acceptance criteria
+
+- Missing, duplicate, oversized, and mismatched headers have deterministic outcomes.
+- Proxies cannot authorize one tool while dispatching another.
+- Header values use strict byte and character limits.
+- Compatibility tests cover clients from both protocol generations.
+
+This complements exact HTTP route admission; it addresses semantic routing after admission.


### PR DESCRIPTION
## What
- adds recommendation 23 from the 2026-08-18 second research round
- records official-source evidence, a repo-specific proposal, acceptance criteria, and an explicit host-validation boundary

## Why
This is an independently reviewable recommendation derived from current Adobe Premiere UXP and MCP documentation and checked against the existing implementation and prior recommendation batch.

## Impact
Documentation/research only. No runtime capability or live-host support claim is added.

## Checks
- npm run check (54 files, 1,538 tests passed)
- git diff --cached --check