### PR TITLE
Research per-request MCP capability envelopes

### DIFF
--- a/docs/recommendations/2026-08-18-round-2/24-request-capability-envelope.md
+++ b/docs/recommendations/2026-08-18-round-2/24-request-capability-envelope.md
@@ -1,0 +1,21 @@
+# Recommendation 24: per-request capability envelope
+
+## Evidence
+
+In stateless MCP, every request carries protocol version and client capabilities in `_meta`; servers publish their identity and capabilities through discovery and result metadata.
+
+- [SEP-2575: Make MCP Stateless](https://modelcontextprotocol.io/seps/2575-stateless-mcp)
+- [MCP 2026-07-28 release](https://blog.modelcontextprotocol.io/posts/2026-07-28)
+
+## Proposed improvement
+
+Create one validated request envelope used by tool, prompt, and resource handlers. It should normalize protocol version, client capabilities, client identity, auth scope, request ID, and advertised response features before business logic runs.
+
+## Acceptance criteria
+
+- Missing required capabilities fail before any bridge call.
+- Unknown optional capabilities are ignored and recorded with bounded cardinality.
+- Result metadata reports the actual server version handling the call.
+- Fuzz tests cover malformed and adversarial `_meta` objects.
+
+Client metadata is self-asserted unless independently authenticated.


### PR DESCRIPTION
## What
- adds recommendation 24 from the 2026-08-18 second research round
- records official-source evidence, a repo-specific proposal, acceptance criteria, and an explicit host-validation boundary

## Why
This is an independently reviewable recommendation derived from current Adobe Premiere UXP and MCP documentation and checked against the existing implementation and prior recommendation batch.

## Impact
Documentation/research only. No runtime capability or live-host support claim is added.

## Checks
- npm run check (54 files, 1,538 tests passed)
- git diff --cached --check