### PR TITLE
Research formal MCP extension negotiation

### DIFF
--- a/docs/recommendations/2026-08-18-round-2/25-extension-negotiation.md
+++ b/docs/recommendations/2026-08-18-round-2/25-extension-negotiation.md
@@ -1,0 +1,21 @@
+# Recommendation 25: formal MCP extension negotiation
+
+## Evidence
+
+MCP 2026-07-28 establishes a formal extensions framework so optional features can evolve without silently changing the protocol core.
+
+- [MCP 2026-07-28 release](https://blog.modelcontextprotocol.io/posts/2026-07-28)
+- [MCP release candidate](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate)
+
+## Proposed improvement
+
+Add a single extension registry describing supported versions, stability, required client capabilities, configuration gates, and fallback behavior. Route Tasks and future UI integrations through it instead of scattered feature flags.
+
+## Acceptance criteria
+
+- Unknown or incompatible extensions never alter core tool behavior.
+- Experimental extensions are disabled by default and labeled in discovery.
+- Registry snapshots are contract-tested across releases.
+- Each extension documents downgrade and removal behavior.
+
+Advertising an extension means protocol support only, not Premiere host support.


### PR DESCRIPTION
## What
- adds recommendation 25 from the 2026-08-18 second research round
- records official-source evidence, a repo-specific proposal, acceptance criteria, and an explicit host-validation boundary

## Why
This is an independently reviewable recommendation derived from current Adobe Premiere UXP and MCP documentation and checked against the existing implementation and prior recommendation batch.

## Impact
Documentation/research only. No runtime capability or live-host support claim is added.

## Checks
- npm run check (54 files, 1,538 tests passed)
- git diff --cached --check