### PR TITLE
Research a protocol deprecation ledger

### DIFF
--- a/docs/recommendations/2026-08-18-round-2/27-protocol-deprecation-ledger.md
+++ b/docs/recommendations/2026-08-18-round-2/27-protocol-deprecation-ledger.md
@@ -1,0 +1,21 @@
+# Recommendation 27: protocol deprecation ledger
+
+## Evidence
+
+The 2026-07-28 MCP revision removes the initialization handshake, protocol sessions, `logging/setLevel`, and top-level `roots/list`, while establishing a formal deprecation policy.
+
+- [MCP 2026-07-28 changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
+- [SEP-2575](https://modelcontextprotocol.io/seps/2575-stateless-mcp)
+
+## Proposed improvement
+
+Maintain a machine-readable ledger for every deprecated protocol behavior: first warning version, replacement, telemetry signal, planned removal, compatibility tests, and operator override.
+
+## Acceptance criteria
+
+- CI fails when deprecated code lacks an owner or removal condition.
+- Release notes are generated from the ledger without overstating compatibility.
+- Usage telemetry is aggregate and privacy-safe.
+- Removing a path requires zero observed use or an explicit breaking release decision.
+
+The ledger governs server compatibility, not Adobe API deprecations unless separately listed.


### PR DESCRIPTION
## What
- adds recommendation 27 from the 2026-08-18 second research round
- records official-source evidence, a repo-specific proposal, acceptance criteria, and an explicit host-validation boundary

## Why
This is an independently reviewable recommendation derived from current Adobe Premiere UXP and MCP documentation and checked against the existing implementation and prior recommendation batch.

## Impact
Documentation/research only. No runtime capability or live-host support claim is added.

## Checks
- npm run check (54 files, 1,538 tests passed)
- git diff --cached --check