### PR TITLE
Research an MCP error taxonomy

### DIFF
--- a/docs/recommendations/2026-08-18-round-2/28-mcp-error-taxonomy.md
+++ b/docs/recommendations/2026-08-18-round-2/28-mcp-error-taxonomy.md
@@ -1,0 +1,20 @@
+# Recommendation 28: MCP error taxonomy and allocation
+
+## Evidence
+
+MCP 2026-07-28 reserves JSON-RPC server error codes `-32020` through `-32099` for the specification and defines typed errors for header mismatch, missing capability, and unsupported version.
+
+- [MCP key changes](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
+
+## Proposed improvement
+
+Create a central error registry that keeps protocol-reserved errors separate from Premiere, bridge, validation, authentication, and internal failures. Map errors to retryability, mutation certainty, safe client text, and telemetry class.
+
+## Acceptance criteria
+
+- No implementation-defined error uses the protocol-reserved range.
+- Every bridge failure states whether a host mutation may have committed.
+- Stack traces and private paths never reach clients.
+- Snapshot tests lock codes, shapes, and backward-compatible text fallbacks.
+
+A structured error reports uncertainty; it must not convert unknown host state into failure or success.


### PR DESCRIPTION
## What
- adds recommendation 28 from the 2026-08-18 second research round
- records official-source evidence, a repo-specific proposal, acceptance criteria, and an explicit host-validation boundary

## Why
This is an independently reviewable recommendation derived from current Adobe Premiere UXP and MCP documentation and checked against the existing implementation and prior recommendation batch.

## Impact
Documentation/research only. No runtime capability or live-host support claim is added.

## Checks
- npm run check (54 files, 1,538 tests passed)
- git diff --cached --check