### PR TITLE
Research UXP filesystem token lifecycle

### DIFF
--- a/docs/recommendations/2026-08-18-round-2/34-filesystem-token-lifecycle.md
+++ b/docs/recommendations/2026-08-18-round-2/34-filesystem-token-lifecycle.md
@@ -1,0 +1,21 @@
+# Recommendation 34: UXP filesystem token lifecycle
+
+## Evidence
+
+UXP local filesystem access is permission-gated and user-selected entries may be represented by persistent tokens rather than unrestricted native paths.
+
+- [Adobe UXP manifest](https://developer.adobe.com/premiere-pro/uxp/plugins/concepts/manifest/)
+- [Adobe UXP file-system recipes](https://developer.adobe.com/premiere-pro/uxp/resources/recipes/)
+
+## Proposed improvement
+
+Introduce a token broker that records purpose, project binding, creation time, last use, and revocation without exposing raw tokens to MCP clients. Re-prompt when a token is stale or no longer resolves.
+
+## Acceptance criteria
+
+- Tokens are encrypted at rest or remain solely in UXP-managed storage.
+- Logs and tool results never contain token values.
+- Revocation, moved files, and denied reauthorization fail deterministically.
+- Cleanup is bounded by age and count with explicit user controls.
+
+A valid token authorizes filesystem access only; it does not validate media contents.


### PR DESCRIPTION
## What
- adds recommendation 34 from the 2026-08-18 second research round
- records official-source evidence, a repo-specific proposal, acceptance criteria, and an explicit host-validation boundary

## Why
This is an independently reviewable recommendation derived from current Adobe Premiere UXP and MCP documentation and checked against the existing implementation and prior recommendation batch.

## Impact
Documentation/research only. No runtime capability or live-host support claim is added.

## Checks
- npm run check (54 files, 1,538 tests passed)
- git diff --cached --check