### PR TITLE
Research versioned UXP bridge protocol

### DIFF
--- a/docs/recommendations/2026-08-18-round-2/35-bridge-protocol-versioning.md
+++ b/docs/recommendations/2026-08-18-round-2/35-bridge-protocol-versioning.md
@@ -1,0 +1,21 @@
+# Recommendation 35: versioned UXP bridge protocol
+
+## Evidence
+
+Adobe’s UXP runtime and Premiere API surface evolve independently, while this project connects the panel through an authenticated loopback WebSocket.
+
+- [Understanding UXP APIs](https://developer.adobe.com/premiere-pro/uxp/resources/fundamentals/apis)
+- [Adobe UXP changelog](https://developer.adobe.com/premiere-pro/uxp/changelog)
+
+## Proposed improvement
+
+Version the panel/server hello, command envelope, event envelope, error shape, and feature flags. Negotiate the highest mutually supported bridge version and reject ambiguous downgrade.
+
+## Acceptance criteria
+
+- Cross-version fixtures cover the current and previous supported bridge version.
+- Unknown commands and fields have documented forward-compatibility behavior.
+- Downgrade cannot bypass authentication or capability checks.
+- Fuzz tests bound nesting, arrays, strings, and numeric values after frame parsing.
+
+Bridge negotiation is distinct from MCP protocol and Adobe host-version negotiation.


### PR DESCRIPTION
## What
- adds recommendation 35 from the 2026-08-18 second research round
- records official-source evidence, a repo-specific proposal, acceptance criteria, and an explicit host-validation boundary

## Why
This is an independently reviewable recommendation derived from current Adobe Premiere UXP and MCP documentation and checked against the existing implementation and prior recommendation batch.

## Impact
Documentation/research only. No runtime capability or live-host support claim is added.

## Checks
- npm run check (54 files, 1,538 tests passed)
- git diff --cached --check