### PR TITLE
Research privacy-safe context retention

### DIFF
--- a/docs/recommendations/2026-08-18-round-2/36-context-retention-policy.md
+++ b/docs/recommendations/2026-08-18-round-2/36-context-retention-policy.md
@@ -1,0 +1,20 @@
+# Recommendation 36: privacy-safe context retention policy
+
+## Evidence
+
+Stateless MCP permits explicit application handles for state that must survive calls; it does not require indefinite application storage.
+
+- [MCP stateless release candidate](https://blog.modelcontextprotocol.io/posts/2026-07-28-release-candidate)
+
+## Proposed improvement
+
+Add per-project TTL, byte quota, transcript opt-in, field-level redaction, compaction receipts, and delete/export controls to the project-context store. Keep operational state separate from model-ready summaries.
+
+## Acceptance criteria
+
+- Raw transcript text is disabled by default for persistent context.
+- Quota enforcement is deterministic and never evicts an active write silently.
+- Delete removes primary and derived records with an audit receipt that contains no content.
+- Tests cover crash recovery, clock skew, corruption, and concurrent compaction.
+
+Retention policy reduces stored data; it does not make model inference private by itself.


### PR DESCRIPTION
## What
- adds recommendation 36 from the 2026-08-18 second research round
- records official-source evidence, a repo-specific proposal, acceptance criteria, and an explicit host-validation boundary

## Why
This is an independently reviewable recommendation derived from current Adobe Premiere UXP and MCP documentation and checked against the existing implementation and prior recommendation batch.

## Impact
Documentation/research only. No runtime capability or live-host support claim is added.

## Checks
- npm run check (54 files, 1,538 tests passed)
- git diff --cached --check