### PR TITLE
Research transcript round-trip integrity

### DIFF
--- a/docs/recommendations/2026-08-18-round-2/37-transcript-roundtrip-integrity.md
+++ b/docs/recommendations/2026-08-18-round-2/37-transcript-roundtrip-integrity.md
@@ -1,0 +1,20 @@
+# Recommendation 37: transcript round-trip integrity
+
+## Evidence
+
+Adobe’s stable UXP `Transcript` API can export transcript JSON, import JSON into text segments, create an import action, query supported languages, and test transcript presence.
+
+- [Adobe Transcript reference](https://developer.adobe.com/premiere-pro/uxp/ppro-reference/classes/transcript)
+
+## Proposed improvement
+
+Add a dry-run transcript importer that validates schema, language metadata, time ordering, clip identity, and a canonical content digest before constructing an Adobe action. Verify post-commit presence and bounded export equivalence.
+
+## Acceptance criteria
+
+- Malformed, overlapping, out-of-range, and wrong-clip segments fail before mutation.
+- Confirmation binds the canonical digest and project revision.
+- Readback reports semantic differences without leaking transcript text into logs.
+- Real-host fixtures cover supported languages and large transcripts.
+
+JSON equivalence does not prove word-level alignment or transcription accuracy.


### PR DESCRIPTION
## What
- adds recommendation 37 from the 2026-08-18 second research round
- records official-source evidence, a repo-specific proposal, acceptance criteria, and an explicit host-validation boundary

## Why
This is an independently reviewable recommendation derived from current Adobe Premiere UXP and MCP documentation and checked against the existing implementation and prior recommendation batch.

## Impact
Documentation/research only. No runtime capability or live-host support claim is added.

## Checks
- npm run check (54 files, 1,538 tests passed)
- git diff --cached --check