### PR TITLE
Research a metadata batch planner

### DIFF
--- a/docs/recommendations/2026-08-18-round-2/38-metadata-batch-planner.md
+++ b/docs/recommendations/2026-08-18-round-2/38-metadata-batch-planner.md
@@ -1,0 +1,20 @@
+# Recommendation 38: metadata batch planner
+
+## Evidence
+
+Adobe’s production-style metadata sample supports column copy/exchange, batch prefix/suffix/numbering, metadata export, and clip-marker export.
+
+- [Adobe Premiere UXP samples](https://github.com/AdobeDocs/uxp-premiere-pro-samples)
+
+## Proposed improvement
+
+Create a bounded metadata plan/preview/apply workflow with explicit namespaces, typed coercion, per-item expected values, conflict detection, and chunked transactions. Default to exporting a rollback artifact before changes.
+
+## Acceptance criteria
+
+- Preview identifies writable fields, collisions, truncation, and no-op edits.
+- Apply requires exact project revision and plan digest.
+- Partial batches return per-item certainty and never retry unknown commits.
+- Sensitive metadata fields are excluded unless explicitly allowlisted.
+
+Adobe’s sample demonstrates a workflow pattern; real project schemas still require host validation.


### PR DESCRIPTION
## What
- adds recommendation 38 from the 2026-08-18 second research round
- records official-source evidence, a repo-specific proposal, acceptance criteria, and an explicit host-validation boundary

## Why
This is an independently reviewable recommendation derived from current Adobe Premiere UXP and MCP documentation and checked against the existing implementation and prior recommendation batch.

## Impact
Documentation/research only. No runtime capability or live-host support claim is added.

## Checks
- npm run check (54 files, 1,538 tests passed)
- git diff --cached --check