### PR TITLE
Research export artifact reconciliation

### DIFF
--- a/docs/recommendations/2026-08-18-round-2/40-export-reconciliation.md
+++ b/docs/recommendations/2026-08-18-round-2/40-export-reconciliation.md
@@ -1,0 +1,21 @@
+# Recommendation 40: export artifact reconciliation
+
+## Evidence
+
+Adobe’s stable `EncoderManager` supports Premiere and AME export workflows, and its events distinguish queue, progress, completion, error, and cancellation.
+
+- [Adobe EncoderManager reference](https://developer.adobe.com/premiere-pro/uxp/ppro-reference/classes/encodermanager/)
+- [Adobe UXP changelog](https://developer.adobe.com/premiere-pro/uxp/changelog)
+
+## Proposed improvement
+
+Add an export reconciler that joins operation receipts, encoder events, expected destination, artifact stat/hash, and optional media probe into one state machine. On restart, recover only from durable evidence and never re-submit an uncertain job automatically.
+
+## Acceptance criteria
+
+- States distinguish queued, rendering, cancelled, failed, completed-no-artifact, and verified-artifact.
+- Event gaps and duplicate events produce explicit uncertainty.
+- Overwrite policy and artifact identity are bound to the original confirmation.
+- Windows/macOS live-host runs cover Premiere and AME paths.
+
+An artifact hash proves file identity, not visual or editorial correctness.


### PR DESCRIPTION
## What
- adds recommendation 40 from the 2026-08-18 second research round
- records official-source evidence, a repo-specific proposal, acceptance criteria, and an explicit host-validation boundary

## Why
This is an independently reviewable recommendation derived from current Adobe Premiere UXP and MCP documentation and checked against the existing implementation and prior recommendation batch.

## Impact
Documentation/research only. No runtime capability or live-host support claim is added.

## Checks
- npm run check (54 files, 1,538 tests passed)
- git diff --cached --check