### PR TITLE
Fix Claude MCPB UXP token injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- The Claude Desktop MCPB now prompts for a sensitive Premiere UXP token and maps it to
+  `PREMIERE_UXP_TOKEN` in the bundled server process, allowing the authenticated loopback UXP
+  listener to start when Claude Desktop does not inherit login-shell environment variables.
+
 ## [1.11.3] - 2026-08-18
 
 ### Added

--- a/claude-desktop/README.md
+++ b/claude-desktop/README.md
@@ -40,6 +40,13 @@ directory listing or an organization allowlist is controlled by Anthropic and
 is outside this repository's CI; the workflow never submits or publishes a
 bundle there.
 
+During installation, Claude Desktop prompts for a sensitive **Premiere UXP
+Token**. Enter a random value of at least 16 characters, then enter that same
+value in the Premiere UXP panel. The MCPB maps the saved value to
+`PREMIERE_UXP_TOKEN` for the child server process; setting a Windows or macOS
+login-shell environment variable alone is not reliable because Claude Desktop
+controls the extension process environment.
+
 The CI artifact is structurally validated but unsigned. A release owner must
 provide and protect an appropriate signing certificate and private key before
 adding MCPB signing to the release process. Do not use a throwaway self-signed

--- a/claude-desktop/manifest.json
+++ b/claude-desktop/manifest.json
@@ -22,7 +22,19 @@
     "entry_point": "server/dist/index.js",
     "mcp_config": {
       "command": "node",
-      "args": ["${__dirname}/server/dist/index.js"]
+      "args": ["${__dirname}/server/dist/index.js"],
+      "env": {
+        "PREMIERE_UXP_TOKEN": "${user_config.premiere_uxp_token}"
+      }
+    }
+  },
+  "user_config": {
+    "premiere_uxp_token": {
+      "type": "string",
+      "title": "Premiere UXP Token",
+      "description": "Shared secret used to authenticate the local Premiere UXP bridge. Use the same value in the Premiere panel (minimum 16 characters).",
+      "sensitive": true,
+      "required": true
     }
   },
   "tools_generated": true,

--- a/scripts/validate-distribution.mjs
+++ b/scripts/validate-distribution.mjs
@@ -64,6 +64,18 @@ export function validateClaudeManifest(manifest, packageJson) {
       JSON.stringify(["${__dirname}/server/dist/index.js"]),
     "Claude bundle command arguments must use a bundle-relative entry point",
   );
+  const tokenConfig = manifest.user_config?.premiere_uxp_token;
+  assert(
+    tokenConfig?.type === "string" &&
+      tokenConfig?.sensitive === true &&
+      tokenConfig?.required === true,
+    "Claude bundle must require a sensitive Premiere UXP token configuration",
+  );
+  assert(
+    manifest.server?.mcp_config?.env?.PREMIERE_UXP_TOKEN ===
+      "${user_config.premiere_uxp_token}",
+    "Claude bundle must map the configured Premiere UXP token into the server environment",
+  );
   assert(
     Array.isArray(manifest.compatibility?.platforms) &&
       manifest.compatibility.platforms.length === 2 &&

--- a/tests/codex-plugin.test.ts
+++ b/tests/codex-plugin.test.ts
@@ -124,5 +124,13 @@ describe("Claude distributions", () => {
     expect(manifest.server.mcp_config.args).toContain(
       "${__dirname}/server/dist/index.js",
     );
+    expect(manifest.user_config.premiere_uxp_token).toMatchObject({
+      type: "string",
+      sensitive: true,
+      required: true,
+    });
+    expect(manifest.server.mcp_config.env).toEqual({
+      PREMIERE_UXP_TOKEN: "${user_config.premiere_uxp_token}",
+    });
   });
 });


### PR DESCRIPTION
## What changed
- add a required sensitive `premiere_uxp_token` field to the Claude Desktop MCPB manifest
- map that value to `PREMIERE_UXP_TOKEN` in the bundled server process
- make distribution validation fail if either side of the mapping is removed
- document the Claude Desktop setup and add regression assertions

## Root cause
Claude Desktop controls the MCPB child-process environment and does not reliably inherit a Windows or macOS login-shell variable. The stock bundle had no `user_config` field or `mcp_config.env` mapping, so the server saw no token and did not initialize its authenticated UXP listener.

## Impact
Installing the rebuilt MCPB prompts for the shared secret and starts the loopback UXP listener when the same token is configured in the Premiere panel.

## Validation
- `npm run check` (54 files, 1,538 tests)
- `node scripts/validate-distribution.mjs --claude`
- `npm run build:claude`
- MCPB v0.4 schema validation passes

Closes #176