### PR TITLE
Research resource annotations and context budgets

### DIFF
--- a/docs/recommendations/2026-08-19-round-3/44-resource-context-annotations.md
+++ b/docs/recommendations/2026-08-19-round-3/44-resource-context-annotations.md
@@ -1,0 +1,21 @@
+# Recommendation 44: resource annotations and context budgets
+
+## Evidence
+
+MCP resources and content blocks may declare `audience`, `priority`, and `lastModified` annotations so clients can filter, rank, and reason about freshness.
+
+- [MCP resources](https://modelcontextprotocol.io/specification/2026-07-28/server/resources)
+- [MCP tools and embedded resources](https://modelcontextprotocol.io/specification/2026-07-28/server/tools)
+
+## Proposed improvement
+
+Annotate supported-actions, workflow, diagnostics, and project-context resources from a centralized policy. Pair annotations with explicit byte/token budgets, deterministic truncation, and freshness derived from revisioned source data.
+
+## Acceptance criteria
+
+- Priority is policy-defined and cannot be raised by project content.
+- `lastModified` reflects the source revision rather than response generation time.
+- Audience filtering never substitutes for authorization.
+- Budget and truncation behavior is stable across pagination and cache hits.
+
+Annotations are client hints, not mandatory context inclusion or a security boundary.


### PR DESCRIPTION
## What
- adds recommendation 44 from the 2026-08-19 third research round
- records official-source evidence, a repository-specific proposal, acceptance criteria, and a host-validation boundary

## Why
This independently reviewable recommendation comes from current Adobe Premiere UXP and MCP documentation and was checked against the implemented tools and prior 40 recommendations.

## Impact
Documentation and research only. No runtime capability or live-host support claim is added.

## Checks
- npm run check (54 files, 1,538 tests passed)
- git diff --cached --check