### PR TITLE
Research prompt and resource injection boundaries

### DIFF
--- a/docs/recommendations/2026-08-19-round-3/45-prompt-resource-injection-boundary.md
+++ b/docs/recommendations/2026-08-19-round-3/45-prompt-resource-injection-boundary.md
@@ -1,0 +1,20 @@
+# Recommendation 45: prompt and resource injection boundary
+
+## Evidence
+
+The MCP prompt specification requires implementations to validate prompt inputs and outputs to prevent injection and unauthorized resource access. Premiere metadata and transcripts are untrusted project content.
+
+- [MCP prompts security](https://modelcontextprotocol.io/specification/2026-07-28/server/prompts)
+
+## Proposed improvement
+
+Represent project-derived text as labeled data blocks with provenance, size limits, and escaping rather than concatenating it into trusted workflow instructions. Separate server-authored instructions, user arguments, and Premiere-derived content in every prompt renderer.
+
+## Acceptance criteria
+
+- Adversarial clip names, markers, metadata, and transcripts cannot add server instructions.
+- Resource links are independently authorized before rendering.
+- Truncation preserves provenance and cannot splice delimiters ambiguously.
+- A corpus tests injection, Unicode controls, nested markup, and oversized content.
+
+Containment reduces instruction confusion but cannot guarantee model behavior.


### PR DESCRIPTION
## What
- adds recommendation 45 from the 2026-08-19 third research round
- records official-source evidence, a repository-specific proposal, acceptance criteria, and a host-validation boundary

## Why
This independently reviewable recommendation comes from current Adobe Premiere UXP and MCP documentation and was checked against the implemented tools and prior 40 recommendations.

## Impact
Documentation and research only. No runtime capability or live-host support claim is added.

## Checks
- npm run check (54 files, 1,538 tests passed)
- git diff --cached --check