### PR TITLE
Research layered MCP end-to-end ping

### DIFF
--- a/docs/recommendations/2026-08-19-round-3/46-mcp-end-to-end-ping.md
+++ b/docs/recommendations/2026-08-19-round-3/46-mcp-end-to-end-ping.md
@@ -1,0 +1,20 @@
+# Recommendation 46: layered MCP end-to-end ping
+
+## Evidence
+
+MCP clients and servers can use `ping()` to verify that the protocol peer still answers independently of application operations.
+
+- [MCP TypeScript client calls](https://ts.sdk.modelcontextprotocol.io/v2/clients/calling.html)
+
+## Proposed improvement
+
+Expose separate transport, authenticated-server, UXP-panel, and Premiere-readiness liveness levels. Use MCP ping only for the first two levels and keep bounded Adobe read probes behind explicit diagnostics.
+
+## Acceptance criteria
+
+- Ping performs no project mutation and returns no project content.
+- Timeouts distinguish network, server event-loop, bridge, modal-host, and no-project states.
+- Rate limits prevent ping amplification or telemetry-cardinality abuse.
+- Tests prove a successful MCP ping cannot mark the Premiere host ready.
+
+This complements the UXP heartbeat; the two signals measure different hops.


### PR DESCRIPTION
## What
- adds recommendation 46 from the 2026-08-19 third research round
- records official-source evidence, a repository-specific proposal, acceptance criteria, and a host-validation boundary

## Why
This independently reviewable recommendation comes from current Adobe Premiere UXP and MCP documentation and was checked against the implemented tools and prior 40 recommendations.

## Impact
Documentation and research only. No runtime capability or live-host support claim is added.

## Checks
- npm run check (54 files, 1,538 tests passed)
- git diff --cached --check