### PR TITLE
Research a UXP external-launch policy

### DIFF
--- a/docs/recommendations/2026-08-19-round-3/49-external-launch-policy.md
+++ b/docs/recommendations/2026-08-19-round-3/49-external-launch-policy.md
@@ -1,0 +1,21 @@
+# Recommendation 49: UXP external-launch policy
+
+## Evidence
+
+Adobe UXP requires explicit `launchProcess` manifest permissions for external schemes and file extensions, distinguishes `openPath()` from `openExternal()`, and reports user denial through return values.
+
+- [Adobe UXP external-process recipe](https://developer.adobe.com/premiere-pro/uxp/resources/recipes/external-process)
+- [Adobe Premiere UXP manifest](https://developer.adobe.com/premiere-pro/uxp/plugins/concepts/manifest/)
+
+## Proposed improvement
+
+If the panel adds “open export,” “reveal artifact,” or documentation links, route them through one allowlisted launch broker. Require a user gesture, canonical destination, scheme/extension policy, and explicit denial handling.
+
+## Acceptance criteria
+
+- Production permissions contain only reviewed schemes and extensions.
+- Arguments, custom commands, UNC paths, and untrusted URLs are rejected.
+- Launch failures never become export failures or success claims.
+- Windows and macOS packaging tests verify the exact manifest.
+
+This recommendation does not add process execution to the current production panel.


### PR DESCRIPTION
## What
- adds recommendation 49 from the 2026-08-19 third research round
- records official-source evidence, a repository-specific proposal, acceptance criteria, and a host-validation boundary

## Why
This independently reviewable recommendation comes from current Adobe Premiere UXP and MCP documentation and was checked against the implemented tools and prior 40 recommendations.

## Impact
Documentation and research only. No runtime capability or live-host support claim is added.

## Checks
- npm run check (54 files, 1,538 tests passed)
- git diff --cached --check