### PR TITLE
fix: harden Premiere 26.3 capability boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- macOS Adobe Media Encoder preset discovery now scans application-bundle resources under
+  `Contents/MediaIO/systempresets`, and preset filtering normalizes names such as `H.264` and
+  `H264`.
+- `add_to_timeline` now validates its arguments and verifies that a single requested item landed
+  on each affected target track, returning an error instead of a false success when Premiere
+  creates an unexpected residual fragment at an exact insert boundary.
+- Removed calls to unsupported or incorrectly signed speed and raw-text caption APIs. Speed
+  requests and `add_text_overlay` now return actionable errors before mutating Premiere.
+- `add_keyframe` now verifies stored parameter readback and explicitly labels render output as
+  unverified; `create_caption_track` likewise labels its result as structural rather than
+  render verification.
+
 ## [1.11.4] - 2026-08-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -533,9 +533,10 @@ the tables below are a shorter workflow-oriented overview.
 | `ripple_delete` | Remove clip and close gap (QE) |
 | `roll_edit` / `slide_edit` / `slip_edit` | Professional trim modes (QE) |
 | `move_clip_to_track` | Move between tracks (QE) |
-| `set_clip_speed_qe` / `reverse_clip` | Speed/reverse (QE) |
+| `reverse_clip` | Reverse direction (QE, host-dependent) |
+| `speed_change` / `set_clip_speed_qe` | Unavailable: Premiere has no supported scripting API for changing clip speed |
 | `split_clip` / `trim_clip` / `move_clip` | Basic edits; trim verifies source points and visible timeline edges |
-| `set_clip_properties` | Opacity, scale, rotation, position |
+| `set_clip_properties` | Opacity, scale, rotation, position (speed requests fail before mutation) |
 | `link_selection` / `unlink_selection` | Link/unlink A/V |
 
 > **Premiere Pro 26.3 compatibility:** some installations silently ignore QE structural edits
@@ -545,6 +546,16 @@ the tables below are a shorter workflow-oriented overview.
 > `add_to_timeline`. Native transitions are unavailable when the host does not expose
 > `qeTrack.addTransition`; overlay clips remain a workaround for transitions that do not need
 > to blend adjacent source frames. See [issue #21](https://github.com/leancoderkavy/premiere-pro-mcp/issues/21).
+
+> **Speed, caption, and visual-keyframe boundaries:** Premiere Pro 26.3 exposes no supported
+> scripting setter or Time Remapping component for timeline-clip speed. `speed_change`,
+> `set_clip_speed_qe`, and `set_clip_properties` with `speed` now stop before host mutation;
+> use the Speed/Duration UI or pre-render retimed media. `add_text_overlay` likewise stops
+> before mutation because a raw-text-to-caption API is not exposed; import an `.srt`/`.vtt`
+> and use `create_caption_track`, or use a MOGRT/PNG overlay. Keyframe and caption-track
+> responses can prove parameter/structure readback only—not rendered pixels—so verify playback
+> or exported frames before delivery. On macOS, AME preset discovery scans each installed app
+> bundle's `Contents/MediaIO/systempresets`; prefer a Match Source preset for vertical projects.
 
 > **Verified track edits:** `add_track` and `add_tracks` validate requested counts and
 > return success only when the active sequence's track counts exactly match the request.

--- a/docs/supported-actions.md
+++ b/docs/supported-actions.md
@@ -37,12 +37,12 @@ operation” when the tool has no enum-based mode.
 | `add_adjustment_layer` | Default profile | Single operation | Add an adjustment layer to the active sequence via QE DOM. The layer is added at the playhead position on the specified track. |
 | `add_audio_keyframes` | Default profile | Single operation | Add audio level keyframes to create fades or level changes |
 | `add_custom_metadata_field` | Default profile | Single operation | Add a custom metadata field to the project's metadata schema |
-| `add_keyframe` | Default profile | Single operation | Add a keyframe to an effect property at a specific time |
+| `add_keyframe` | Default profile | Single operation | Add and read back a keyframe on an effect property. This verifies stored parameter data only; render/playback verification remains host-dependent. |
 | `add_marker` | Default profile | Single operation | Add a marker to the active sequence or a clip |
 | `add_marker_to_project_item` | Default profile | `type`: `Comment`, `Chapter`, `Segmentation`, `WebLink` | Add a marker to a project item (source clip marker). |
-| `add_text_overlay` | Default profile | `caption_format`: `608`, `708`, `subtitle`, `teletext` | Add a subtitle-style text overlay to the active sequence. Note: Premiere's ExtendScript API does not expose Essential-Graphics title creation, so this routes through the Captions/Subtitle API. Text appears on a caption track at the platform-default subtitle position. For freeform titles, render a PNG and import_media it instead. |
+| `add_text_overlay` | Default profile | `caption_format`: `608`, `708`, `subtitle`, `teletext` | Unavailable: Premiere does not expose a supported scripting API to create caption clips directly from raw text. Import an .srt/.vtt and use create_caption_track, or use a MOGRT/PNG overlay for title graphics. |
 | `add_to_render_queue` | Default profile | Single operation | Add the active sequence to the Adobe Media Encoder render queue |
-| `add_to_timeline` | Default profile | Single operation | Add a project item (clip) to the timeline at a specific position |
+| `add_to_timeline` | Default profile | Single operation | Insert a project item at a timeline position and verify Premiere added no unexpected same-track fragments. |
 | `add_track` | Default profile | `track_type`: `video`, `audio` | Add verified video or audio tracks to the active sequence. Returns an error if Premiere cannot add the exact requested count. |
 | `add_tracks` | Default profile | Single operation | Add video and/or audio tracks through QE and verify the active sequence gained the exact requested counts |
 | `add_transition` | Default profile | Single operation | Add a video transition between two clips at a cut point. Uses QE DOM. |
@@ -73,7 +73,7 @@ operation” when the tool has no enum-based mode.
 | `copy_effects_between_clips` | Default profile | Single operation | Copy all effects (or a specific effect) from one clip to another. Does not copy intrinsic properties like Motion/Opacity unless specified. |
 | `create_bars_and_tone` | Default profile | Single operation | Create a Bars and Tone synthetic media item in the project (useful for leader/calibration) |
 | `create_bin` | Default profile | Single operation | Create a new bin (folder) in the project panel |
-| `create_caption_track` | Default profile | Single operation | Create a caption/subtitle track in the active sequence from an imported caption file (e.g., .srt, .vtt) |
+| `create_caption_track` | Default profile | Single operation | Create a caption/subtitle track in the active sequence from an imported caption file (e.g., .srt, .vtt). Creation is structural only; verify playback or exported frames before delivery. |
 | `create_context_edit_plan` | Default profile | `strategy`: `rough_cut`, `select_ranges`, `review` | Create a non-mutating, evidence-backed edit-plan scaffold from indexed Premiere context. It returns ranked source/time candidates and stale-state guards; the model must review them and use preview_edit_plan before any mutation. |
 | `create_project` | Default profile | Single operation | Create a new Premiere Pro project at the specified path |
 | `create_sequence` | Default profile | Single operation | Create a new sequence in the project |
@@ -255,11 +255,11 @@ operation” when the tool has no enum-based mode.
 | `set_clip_opacity` | Default profile | Single operation | Set the opacity of a video clip (0-100). |
 | `set_clip_pan` | Default profile | Single operation | Set the pan (left/right balance) on an audio clip. |
 | `set_clip_position` | Default profile | Single operation | Set the Position property on a video clip's Motion effect. Values are in pixels. |
-| `set_clip_properties` | Default profile | Single operation | Set properties on a clip (opacity, speed, etc.) |
+| `set_clip_properties` | Default profile | Single operation | Set supported clip properties (opacity, scale, position, rotation). Clip speed is unsupported and fails before mutation. |
 | `set_clip_rotation` | Default profile | Single operation | Set the Rotation property on a video clip's Motion effect. |
 | `set_clip_scale` | Default profile | Single operation | Set the Scale property on a video clip's Motion effect. |
 | `set_clip_selection` | Default profile | Single operation | Select or deselect a clip in the active sequence |
-| `set_clip_speed_qe` | Default profile | Single operation | Set clip playback speed using QE DOM (more reliable than ExtendScript). Supports reverse. |
+| `set_clip_speed_qe` | Default profile | Single operation | Unavailable: Premiere does not expose a supported scripting API for changing a timeline clip's speed. |
 | `set_clip_start_time` | Default profile | Single operation | Set the start time (timecode offset) of a project item. This shifts where timecode begins for the source media. |
 | `set_clip_volume` | Default profile | Single operation | Set an audio clip's Volume > Level in dB. Does not read or change Essential Sound Amplify automation. |
 | `set_clips_volume` | Default profile | Single operation | Set the volume (in dB) on every audio clip of a track, or on a list of clip indices. One round trip instead of one call per clip - essential for sequences with dozens of clips. |
@@ -303,7 +303,7 @@ operation” when the tool has no enum-based mode.
 | `set_zero_point` | Default profile | Single operation | Set the starting timecode (zero point) of a sequence |
 | `slide_edit` | Default profile | Single operation | Perform a slide edit on a clip (moves clip without changing its duration, adjusting adjacent clips). Uses QE DOM. |
 | `slip_edit` | Default profile | Single operation | Perform a slip edit on a clip (changes source in/out points without moving clip on timeline). Uses QE DOM. |
-| `speed_change` | Default profile | Single operation | Change the playback speed of a clip |
+| `speed_change` | Default profile | Single operation | Unavailable: Premiere does not expose a supported scripting API for changing a timeline clip's speed. |
 | `split_clip` | Default profile | `track_type`: `video`, `audio` | Split every clip on one track that spans a timeline time, then verify both resulting boundaries. Requires QE DOM; effect-keyframe redistribution remains unverified. |
 | `stabilize_clip` | Default profile | `method`: `Subspace Warp`, `Position`, `Position, Scale, Rotation` | Apply the Warp Stabilizer effect to a clip for video stabilization. Uses QE DOM. |
 | `start_batch_encode` | Default profile | Single operation | Start encoding all items in the Adobe Media Encoder render queue |

--- a/src/bridge/script-builder.ts
+++ b/src/bridge/script-builder.ts
@@ -197,18 +197,25 @@ function __collectEprFiles(folder, out) {
   return out;
 }
 
+// macOS applications are bundles: AME/Premiere resources live below Contents,
+// whereas the Windows installers put the same folders directly below the app root.
+function __adobeApplicationResourceFolder(appFolder, relativePath) {
+  var prefix = appFolder.fsName + (__isMacOS() ? "/Contents/" : "/");
+  return new Folder(prefix + relativePath);
+}
+
 // All export presets AME ships, plus the user's own saved presets.
 function __collectAllPresets() {
   var roots = [];
 
   var ame = __adobeAppFolders("Adobe Media Encoder");
   for (var i = 0; i < ame.length; i++) {
-    roots.push(new Folder(ame[i].fsName + "/MediaIO/systempresets"));
+    roots.push(__adobeApplicationResourceFolder(ame[i], "MediaIO/systempresets"));
   }
 
   var ppro = __adobeAppFolders("Adobe Premiere Pro");
   for (var j = 0; j < ppro.length; j++) {
-    roots.push(new Folder(ppro[j].fsName + "/Settings/IngestPresets"));
+    roots.push(__adobeApplicationResourceFolder(ppro[j], "Settings/IngestPresets"));
   }
 
   // User-saved presets live under the Documents tree on both platforms.
@@ -235,6 +242,10 @@ function __collectAllPresets() {
   return presets;
 }
 
+function __presetSearchText(value) {
+  return String(value || "").toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
 // Default export preset. "48323634" is hex for "H264" — the folder name AME uses
 // for the H.264 format bucket on disk.
 function __findH264Preset() {
@@ -257,7 +268,7 @@ function __findH264Preset() {
 function __findProxyPreset() {
   var ppro = __adobeAppFolders("Adobe Premiere Pro");
   for (var i = 0; i < ppro.length; i++) {
-    var proxyDir = new Folder(ppro[i].fsName + "/Settings/IngestPresets/Proxy");
+    var proxyDir = __adobeApplicationResourceFolder(ppro[i], "Settings/IngestPresets/Proxy");
     var eprs = __collectEprFiles(proxyDir, []);
     if (eprs.length) {
       eprs.sort(function(a, b) { return a.displayName < b.displayName ? -1 : 1; });

--- a/src/resources/extendscript-reference.ts
+++ b/src/resources/extendscript-reference.ts
@@ -194,7 +194,7 @@ export const EXTENDSCRIPT_REFERENCE = [
   "qeClip.roll(offsetTicks)",
   "qeClip.slide(offsetTicks)",
   "qeClip.slip(offsetTicks)",
-  "qeClip.setSpeed(percent)              - e.g., 200 for 2x",
+  "No supported scripting API changes a timeline clip's speed; do not call qeClip.setSpeed().",
   "qeClip.setReverse(bool)",
   "qeClip.setFrameBlend(bool)",
   "qeClip.setTimeInterpolationType(type) - 0=sampling, 1=blending, 2=optical flow",

--- a/src/server.ts
+++ b/src/server.ts
@@ -99,7 +99,7 @@ KEYFRAMES:
 QE DOM TOOLS:
 - Tools marked "Uses QE DOM" use an undocumented API. They are powerful but may behave unexpectedly.
 - ripple_delete, roll_edit, slide_edit, slip_edit are QE-based advanced trim tools.
-- set_clip_speed_qe is more reliable than the ExtendScript speed method.
+- Premiere does not expose a supported scripting API for changing timeline-clip speed; speed tools fail before mutation.
 
 CLIPS & SELECTION:
 - Use set_clip_selection to select clips before operations that work on selection (link, unlink, scene_edit_detection).

--- a/src/tools/advanced.ts
+++ b/src/tools/advanced.ts
@@ -287,7 +287,7 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
 
     set_clip_speed_qe: {
       description:
-        "Set clip playback speed using QE DOM (more reliable than ExtendScript). Supports reverse.",
+        "Unavailable: Premiere does not expose a supported scripting API for changing a timeline clip's speed.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -312,31 +312,12 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
         speed_percent: number;
         reverse?: boolean;
       }) => {
-        const script = buildToolScript(`
-          app.enableQE();
-          var qeSeq = qe.project.getActiveSequence();
-          if (!qeSeq) return __error("No active sequence (QE)");
-          
-          var result = __findClip("${escapeForExtendScript(args.node_id)}");
-          if (!result) return __error("Clip not found");
-          
-          var qeTrack = result.trackType === "video"
-            ? qeSeq.getVideoTrackAt(result.trackIndex)
-            : qeSeq.getAudioTrackAt(result.trackIndex);
-          var qeClip = qeTrack.getItemAt(result.clipIndex);
-          if (!qeClip) return __error("QE clip not found");
-          
-          qeClip.setSpeed(${args.speed_percent});
-          ${args.reverse ? `qeClip.setReverse(true);` : ""}
-          
-          return __result({
-            speedSet: true,
-            clipName: result.clip.name,
-            speed: ${args.speed_percent},
-            reverse: ${!!args.reverse}
-          });
-        `);
-        return sendCommand(script, bridgeOptions);
+        void args;
+        return {
+          success: false,
+          error:
+            "Changing a timeline clip's speed is not exposed by Premiere's supported ExtendScript or UXP APIs. No mutation was attempted. Use Premiere's Speed/Duration UI or pre-render retimed media before import.",
+        };
       },
     },
 

--- a/src/tools/captions.ts
+++ b/src/tools/captions.ts
@@ -5,7 +5,7 @@ export function getCaptionTools(bridgeOptions: BridgeOptions) {
   return {
     create_caption_track: {
       description:
-        "Create a caption/subtitle track in the active sequence from an imported caption file (e.g., .srt, .vtt)",
+        "Create a caption/subtitle track in the active sequence from an imported caption file (e.g., .srt, .vtt). Creation is structural only; verify playback or exported frames before delivery.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -55,7 +55,14 @@ export function getCaptionTools(bridgeOptions: BridgeOptions) {
           
           var result = seq.createCaptionTrack(item, ${startSeconds}, ${format});
           if (!result) return __error("Failed to create caption track");
-          return __result({ created: true, item: item.name, startSeconds: ${startSeconds}, format: "${args.caption_format || "subtitle"}" });
+          return __result({
+            created: true,
+            renderVerified: false,
+            verificationScope: "Premiere accepted the caption-track creation; verify playback or exported frames before delivery.",
+            item: item.name,
+            startSeconds: ${startSeconds},
+            format: "${args.caption_format || "subtitle"}"
+          });
         `);
         return sendCommand(script, bridgeOptions);
       },

--- a/src/tools/keyframes.ts
+++ b/src/tools/keyframes.ts
@@ -199,7 +199,8 @@ export function getKeyframeTools(bridgeOptions: BridgeOptions) {
     },
 
     add_keyframe: {
-      description: "Add a keyframe to an effect property at a specific time",
+      description:
+        "Add and read back a keyframe on an effect property. This verifies stored parameter data only; render/playback verification remains host-dependent.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -255,6 +256,9 @@ export function getKeyframeTools(bridgeOptions: BridgeOptions) {
             }
           }
           if (!prop) return __error("Property not found");
+          try {
+            if (!prop.areKeyframesSupported()) return __error("Property does not support keyframes");
+          } catch(eSupports) {}
           
           // Enable keyframes if not already
           try {
@@ -267,13 +271,25 @@ export function getKeyframeTools(bridgeOptions: BridgeOptions) {
           time.ticks = __secondsToTicks(${args.time_seconds}).toString();
           prop.addKey(time);
           prop.setValueAtKey(time, ${args.value}, true);
+          var readBack = null;
+          try { readBack = prop.getValueAtKey(time); } catch(eReadBack) {}
+          if (readBack === null || readBack === undefined) {
+            return __error("Premiere did not return the keyframe value after writing it; storage is not reported as verified.");
+          }
+          if (typeof readBack === "number" && Math.abs(readBack - ${args.value}) > 0.0001) {
+            return __error("Premiere returned " + readBack + " after writing keyframe value ${args.value}; storage is not reported as verified.");
+          }
           
           return __result({
             added: true,
+            stored: true,
+            renderVerified: false,
+            verificationScope: "Premiere parameter readback only; verify playback or exported frames before relying on visual output.",
             effect: "${escapeForExtendScript(args.effect_name)}",
             property: "${escapeForExtendScript(args.property_name)}",
             time: ${args.time_seconds},
-            value: ${args.value}
+            value: ${args.value},
+            readBackValue: readBack
           });
         `);
         return sendCommand(script, bridgeOptions);

--- a/src/tools/text.ts
+++ b/src/tools/text.ts
@@ -5,10 +5,8 @@ export function getTextTools(bridgeOptions: BridgeOptions) {
   return {
     add_text_overlay: {
       description:
-        "Add a subtitle-style text overlay to the active sequence. " +
-        "Note: Premiere's ExtendScript API does not expose Essential-Graphics title creation, " +
-        "so this routes through the Captions/Subtitle API. Text appears on a caption track at " +
-        "the platform-default subtitle position. For freeform titles, render a PNG and import_media it instead.",
+        "Unavailable: Premiere does not expose a supported scripting API to create caption clips directly from raw text. " +
+        "Import an .srt/.vtt and use create_caption_track, or use a MOGRT/PNG overlay for title graphics.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -38,55 +36,12 @@ export function getTextTools(bridgeOptions: BridgeOptions) {
         duration_seconds?: number;
         caption_format?: string;
       }) => {
-        const startSeconds = args.start_seconds ?? 0;
-        const durationSeconds = args.duration_seconds ?? 5;
-        const formatMap: Record<string, number> = {
-          // Premiere Caption format constants (Sequence.captionFormat)
-          subtitle: 3,
-          "608": 1,
-          "708": 2,
-          teletext: 4,
+        void args;
+        return {
+          success: false,
+          error:
+            "Premiere does not expose a supported scripting API to create a caption clip from raw text. No mutation was attempted. Import an .srt or .vtt first, then use create_caption_track; use a MOGRT or pre-rendered PNG overlay for title graphics.",
         };
-        const formatNum = formatMap[args.caption_format ?? "subtitle"] ?? 3;
-
-        const script = buildToolScript(`
-          var seq = app.project.activeSequence;
-          if (!seq) return __error("No active sequence");
-
-          var startTicks = __secondsToTicks(${startSeconds});
-          var endTicks = __secondsToTicks(${startSeconds + durationSeconds});
-          var textContent = "${escapeForExtendScript(args.text)}";
-
-          // createCaptionTrack(captionFormat:Number) -> Track. Reuse first
-          // matching track if it exists; otherwise create one.
-          var captionTrack = null;
-          try {
-            captionTrack = seq.createCaptionTrack(${formatNum});
-          } catch(eCT) {
-            return __error("createCaptionTrack failed: " + eCT.toString());
-          }
-          if (!captionTrack) return __error("Could not create caption track");
-
-          var newCap = null;
-          try {
-            // Modern signature: addCaption(startTime:Time, endTime:Time)
-            newCap = captionTrack.addCaption(startTicks, endTicks);
-            if (newCap) {
-              try { newCap.text = textContent; } catch(eT) {}
-            }
-          } catch(eAdd) {
-            return __error("addCaption failed: " + eAdd.toString());
-          }
-
-          return __result({
-            added: true,
-            text: textContent,
-            captionFormat: ${formatNum},
-            startSeconds: ${startSeconds},
-            durationSeconds: ${durationSeconds}
-          });
-        `);
-        return sendCommand(script, bridgeOptions);
       },
     },
 

--- a/src/tools/timeline.ts
+++ b/src/tools/timeline.ts
@@ -4,7 +4,8 @@ import { sendCommand, BridgeOptions } from "../bridge/file-bridge.js";
 export function getTimelineTools(bridgeOptions: BridgeOptions) {
   return {
     add_to_timeline: {
-      description: "Add a project item (clip) to the timeline at a specific position",
+      description:
+        "Insert a project item at a timeline position and verify Premiere added no unexpected same-track fragments.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -24,29 +25,90 @@ export function getTimelineTools(bridgeOptions: BridgeOptions) {
             type: "number",
             description: "Audio track index for the audio portion (default: 0)",
           },
-        },
-        required: ["item_id"],
+      },
+      required: ["item_id"],
       },
       handler: async (args: { item_id: string; track_index?: number; start_seconds?: number; audio_track_index?: number }) => {
         const trackIndex = args.track_index ?? 0;
         const startSeconds = args.start_seconds ?? 0;
         const audioTrackIndex = args.audio_track_index ?? 0;
+        if (!Number.isInteger(trackIndex) || trackIndex < 0 ||
+            !Number.isInteger(audioTrackIndex) || audioTrackIndex < 0 ||
+            !Number.isFinite(startSeconds) || startSeconds < 0) {
+          return {
+            success: false,
+            error: "track_index and audio_track_index must be non-negative integers, and start_seconds must be a finite non-negative number.",
+          };
+        }
 
         const script = buildToolScript(`
           var seq = app.project.activeSequence;
           if (!seq) return __error("No active sequence");
+          var videoTrack = seq.videoTracks[${trackIndex}];
+          if (!videoTrack) return __error("Video track index ${trackIndex} is out of range");
+          var audioTrack = seq.audioTracks[${audioTrackIndex}];
           
           var item = __findProjectItem("${escapeForExtendScript(args.item_id)}");
           if (!item) return __error("Project item not found: ${escapeForExtendScript(args.item_id)}");
           
+          var beforeVideoCount = videoTrack.clips.numItems;
+          var beforeAudioCount = audioTrack ? audioTrack.clips.numItems : 0;
+          var beforeVideoIds = {};
+          var beforeAudioIds = {};
+          var i;
+          for (i = 0; i < beforeVideoCount; i++) beforeVideoIds[videoTrack.clips[i].nodeId] = true;
+          if (audioTrack) {
+            for (i = 0; i < beforeAudioCount; i++) beforeAudioIds[audioTrack.clips[i].nodeId] = true;
+          }
+
           var startTicks = __secondsToTicks(${startSeconds}).toString();
           seq.insertClip(item, startTicks, ${trackIndex}, ${audioTrackIndex});
+
+          var afterVideoCount = videoTrack.clips.numItems;
+          var afterAudioCount = audioTrack ? audioTrack.clips.numItems : 0;
+          if (afterVideoCount > beforeVideoCount + 1 || (audioTrack && afterAudioCount > beforeAudioCount + 1)) {
+            return __error("Premiere inserted more than one clip on a targeted track. This can leave a residual frame fragment at an exact boundary; the insertion may be partial, but is not reported as verified.");
+          }
+
+          var inserted = [];
+          for (i = 0; i < afterVideoCount; i++) {
+            var videoClip = videoTrack.clips[i];
+            if (!beforeVideoIds[videoClip.nodeId]) inserted.push({ clip: videoClip, trackType: "video" });
+          }
+          if (audioTrack) {
+            for (i = 0; i < afterAudioCount; i++) {
+              var audioClip = audioTrack.clips[i];
+              if (!beforeAudioIds[audioClip.nodeId]) inserted.push({ clip: audioClip, trackType: "audio" });
+            }
+          }
+          if (!inserted.length) {
+            return __error("Premiere did not add a new track item at the requested insertion point.");
+          }
+
+          var frameTicks = parseFloat(seq.timebase);
+          if (!frameTicks || isNaN(frameTicks)) frameTicks = TICKS_PER_SECOND / 24;
+          var tolerance = __ticksToSeconds(frameTicks);
+          var matchedItem = false;
+          for (i = 0; i < inserted.length; i++) {
+            var insertedClip = inserted[i].clip;
+            if (insertedClip.projectItem && insertedClip.projectItem.nodeId === item.nodeId) {
+              matchedItem = true;
+              if (Math.abs(__ticksToSeconds(insertedClip.start.ticks) - ${startSeconds}) > tolerance) {
+                return __error("Premiere added the requested item but not at the requested timeline frame; the insertion is not reported as verified.");
+              }
+            }
+          }
+          if (!matchedItem) {
+            return __error("Premiere changed the target track but the requested project item was not found after insertion.");
+          }
           
           return __result({
             added: true,
+            verified: true,
             item: item.name,
             trackIndex: ${trackIndex},
-            startSeconds: ${startSeconds}
+            startSeconds: ${startSeconds},
+            insertedTrackItems: inserted.length
           });
         `);
         return sendCommand(script, bridgeOptions);
@@ -616,7 +678,8 @@ export function getTimelineTools(bridgeOptions: BridgeOptions) {
     },
 
     set_clip_properties: {
-      description: "Set properties on a clip (opacity, speed, etc.)",
+      description:
+        "Set supported clip properties (opacity, scale, position, rotation). Clip speed is unsupported and fails before mutation.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -630,7 +693,7 @@ export function getTimelineTools(bridgeOptions: BridgeOptions) {
           },
           speed: {
             type: "number",
-            description: "Playback speed multiplier (1.0 = normal, 2.0 = double speed)",
+            description: "Unsupported by Premiere's public scripting APIs. Supplying this returns an actionable error without mutating the clip.",
           },
           scale: {
             type: "number",
@@ -660,6 +723,13 @@ export function getTimelineTools(bridgeOptions: BridgeOptions) {
         position_y?: number;
         rotation?: number;
       }) => {
+        if (args.speed !== undefined) {
+          return {
+            success: false,
+            error:
+              "Changing a timeline clip's speed is not exposed by Premiere's supported ExtendScript or UXP APIs. No mutation was attempted. Use Premiere's Speed/Duration UI or pre-render retimed media before import.",
+          };
+        }
         const script = buildToolScript(`
           var result = __findClip("${escapeForExtendScript(args.node_id)}");
           if (!result) return __error("Clip not found: ${escapeForExtendScript(args.node_id)}");
@@ -680,11 +750,6 @@ export function getTimelineTools(bridgeOptions: BridgeOptions) {
               }
             }
           }
-          ` : ""}
-          
-          ${args.speed !== undefined ? `
-          clip.setSpeed(${args.speed * 100});
-          changes.speed = ${args.speed};
           ` : ""}
           
           ${args.scale !== undefined || args.position_x !== undefined || args.position_y !== undefined || args.rotation !== undefined ? `
@@ -779,7 +844,8 @@ export function getTimelineTools(bridgeOptions: BridgeOptions) {
     },
 
     speed_change: {
-      description: "Change the playback speed of a clip",
+      description:
+        "Unavailable: Premiere does not expose a supported scripting API for changing a timeline clip's speed.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -799,22 +865,12 @@ export function getTimelineTools(bridgeOptions: BridgeOptions) {
         required: ["node_id", "speed_percent"],
       },
       handler: async (args: { node_id: string; speed_percent: number; reverse?: boolean }) => {
-        const script = buildToolScript(`
-          app.enableQE();
-          var qeSeq = qe.project.getActiveSequence();
-          if (!qeSeq) return __error("No active sequence (QE)");
-          
-          var result = __findClip("${escapeForExtendScript(args.node_id)}");
-          if (!result) return __error("Clip not found");
-          
-          var clip = result.clip;
-          var speed = "${args.speed_percent}";
-          ${args.reverse ? 'speed = "-" + speed;' : ""}
-          
-          clip.setSpeed(speed);
-          return __result({ speedChanged: true, clipName: clip.name, speed: ${args.speed_percent}, reverse: ${!!args.reverse} });
-        `);
-        return sendCommand(script, bridgeOptions);
+        void args;
+        return {
+          success: false,
+          error:
+            "Changing a timeline clip's speed is not exposed by Premiere's supported ExtendScript or UXP APIs. No mutation was attempted. Use Premiere's Speed/Duration UI or pre-render retimed media before import.",
+        };
       },
     },
   };

--- a/src/tools/track-targeting.ts
+++ b/src/tools/track-targeting.ts
@@ -1206,11 +1206,11 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
 
           ${
             args.format
-              ? `var needle = "${escapeForExtendScript(args.format)}".toLowerCase();
+              ? `var needle = __presetSearchText("${escapeForExtendScript(args.format)}");
                var filtered = [];
                for (var i = 0; i < presets.length; i++) {
                  var p = presets[i];
-                 if (p.name.toLowerCase().indexOf(needle) !== -1 || p.format.toLowerCase().indexOf(needle) !== -1) {
+                 if (__presetSearchText(p.name).indexOf(needle) !== -1 || __presetSearchText(p.format).indexOf(needle) !== -1) {
                    filtered.push(p);
                  }
                }

--- a/tests/tools/large-tool-handler-coverage.test.ts
+++ b/tests/tools/large-tool-handler-coverage.test.ts
@@ -157,18 +157,28 @@ describe("large tool handler coverage", () => {
             it(`${toolName} handles ${field}=${String(enumValue)}`, async () => {
               const args = argsFor(tool.parameters, true);
               args[field] = enumValue;
-              await tool.handler(args);
-              expect(mockedSendCommand.mock.calls.length + mockedSendRawCommand.mock.calls.length)
-                .toBeGreaterThan(0);
+              const commandCount = mockedSendCommand.mock.calls.length + mockedSendRawCommand.mock.calls.length;
+              const result = await tool.handler(args);
+              const nextCommandCount = mockedSendCommand.mock.calls.length + mockedSendRawCommand.mock.calls.length;
+              if (nextCommandCount === commandCount) {
+                expect(result).toMatchObject({ success: false });
+                return;
+              }
+              expect(nextCommandCount).toBeGreaterThan(commandCount);
             });
           }
           if (property.type === "boolean") {
             it(`${toolName} handles ${field}=false`, async () => {
               const args = argsFor(tool.parameters, true);
               args[field] = false;
-              await tool.handler(args);
-              expect(mockedSendCommand.mock.calls.length + mockedSendRawCommand.mock.calls.length)
-                .toBeGreaterThan(0);
+              const commandCount = mockedSendCommand.mock.calls.length + mockedSendRawCommand.mock.calls.length;
+              const result = await tool.handler(args);
+              const nextCommandCount = mockedSendCommand.mock.calls.length + mockedSendRawCommand.mock.calls.length;
+              if (nextCommandCount === commandCount) {
+                expect(result).toMatchObject({ success: false });
+                return;
+              }
+              expect(nextCommandCount).toBeGreaterThan(commandCount);
             });
           }
         }

--- a/tests/tools/regressions.test.ts
+++ b/tests/tools/regressions.test.ts
@@ -16,6 +16,11 @@ import { getUtilityTools } from "../../src/tools/utility.js";
 import { getTrackTargetingTools } from "../../src/tools/track-targeting.js";
 import { getEffectsTools } from "../../src/tools/effects.js";
 import { getClipboardTools } from "../../src/tools/clipboard.js";
+import { getTimelineTools } from "../../src/tools/timeline.js";
+import { getAdvancedTools } from "../../src/tools/advanced.js";
+import { getTextTools } from "../../src/tools/text.js";
+import { getKeyframeTools } from "../../src/tools/keyframes.js";
+import { getCaptionTools } from "../../src/tools/captions.js";
 
 const mockedSendCommand = vi.mocked(sendCommand);
 const bridgeOptions: BridgeOptions = { tempDir: "/tmp/test-bridge", timeoutMs: 5000 };
@@ -218,6 +223,80 @@ describe("script-builder helpers used by the fixes are actually defined", () => 
     ]) {
       expect(script).toContain(helper);
     }
+  });
+});
+
+// https://github.com/leancoderkavy/premiere-pro-mcp/issues/189
+describe("issue #189 — Premiere 26.3 capability boundaries and macOS presets", () => {
+  const trackTargeting = getTrackTargetingTools(bridgeOptions);
+  const timeline = getTimelineTools(bridgeOptions);
+  const advanced = getAdvancedTools(bridgeOptions);
+  const text = getTextTools(bridgeOptions);
+  const keyframes = getKeyframeTools(bridgeOptions);
+  const captions = getCaptionTools(bridgeOptions);
+
+  it("searches resources inside macOS application bundles and normalizes H.264 filters", async () => {
+    const helpers = getHelpersSource();
+    const code = await codeFor(trackTargeting.get_encoder_presets, { format: "H.264" });
+
+    expect(helpers).toContain("function __adobeApplicationResourceFolder(");
+    expect(helpers).toContain('"/Contents/"');
+    expect(helpers).toContain('"MediaIO/systempresets"');
+    expect(code).toContain('__presetSearchText("H.264")');
+    expect(code).toContain("__presetSearchText(p.name)");
+  });
+
+  it("never calls unsupported speed setters", async () => {
+    const variants = [
+      timeline.speed_change.handler({ node_id: "clip-1", speed_percent: 65 }),
+      advanced.set_clip_speed_qe.handler({ node_id: "clip-1", speed_percent: 65 }),
+      timeline.set_clip_properties.handler({ node_id: "clip-1", speed: 0.65 }),
+    ];
+
+    await expect(Promise.all(variants)).resolves.toEqual([
+      expect.objectContaining({ success: false, error: expect.stringContaining("No mutation was attempted") }),
+      expect.objectContaining({ success: false, error: expect.stringContaining("No mutation was attempted") }),
+      expect.objectContaining({ success: false, error: expect.stringContaining("No mutation was attempted") }),
+    ]);
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+  });
+
+  it("fails raw-text caption creation before it can call an unsupported signature", async () => {
+    const result = await text.add_text_overlay.handler({ text: "TREINO UPPER" });
+
+    expect(result).toEqual(expect.objectContaining({
+      success: false,
+      error: expect.stringContaining("No mutation was attempted"),
+    }));
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+  });
+
+  it("labels keyframe and caption results as storage or structure verification, not rendered output", async () => {
+    const keyframeScript = await scriptFor(keyframes.add_keyframe, {
+      node_id: "clip-1", effect_name: "Opacity", property_name: "Opacity", time_seconds: 0, value: 0,
+    });
+    expect(keyframeScript).toContain("getValueAtKey(time)");
+    expect(keyframeScript).toContain("renderVerified: false");
+    expect(keyframeScript).toContain("Premiere parameter readback only");
+
+    const captionScript = await scriptFor(captions.create_caption_track, { item_id: "captions.srt" });
+    expect(captionScript).toContain("renderVerified: false");
+    expect(captionScript).toContain("verify playback or exported frames");
+  });
+
+  it("validates and structurally verifies timeline insertion instead of trusting insertClip", async () => {
+    const invalid = await timeline.add_to_timeline.handler({ item_id: "clip-1", start_seconds: -1 });
+    expect(invalid).toEqual(expect.objectContaining({ success: false }));
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+
+    const script = await scriptFor(timeline.add_to_timeline, {
+      item_id: "clip-1", track_index: 0, audio_track_index: 0, start_seconds: 3.4,
+    });
+    expect(script).toContain("beforeVideoCount");
+    expect(script).toContain("afterVideoCount > beforeVideoCount + 1");
+    expect(script).toContain("residual frame fragment");
+    expect(script).toContain("matchedItem");
+    expect(script).toContain("verified: true");
   });
 });
 


### PR DESCRIPTION
## Summary
- scan Adobe Media Encoder and Premiere resource paths inside macOS application bundles, and normalize preset filters such as `H.264`
- make unsupported clip-speed and raw-text caption paths fail locally before a Premiere mutation instead of calling undocumented/wrong signatures
- verify `add_to_timeline` count, item identity, and frame placement so unexpected boundary fragments are reported as unverified
- label keyframe and imported-caption results as parameter/structure readback rather than rendered-output verification

## Validation
- `npm run check` — 54 files, 1,543 tests

## Scope boundary
This fixes repository-controlled API calls and reporting. It cannot prove opacity rendering or caption compositing in a licensed Premiere 26.3 host; results now state that boundary explicitly.

Closes #189