### PR TITLE
feat(landing): add reviewed workflow and SEO guides

### DIFF
--- a/.agents/product-marketing.md
+++ b/.agents/product-marketing.md
@@ -1,13 +1,13 @@
 # Product Marketing Context
 
-**Document version:** v2
-**Last updated:** 2026-08-15
+**Document version:** v4
+**Last updated:** 2026-08-20
 
 ## Product Overview
 
 **One-liner:** Premiere Pro MCP gives compatible AI assistants a structured, local-first way to inspect projects, plan edits, automate supported timeline work, and export through Adobe Premiere Pro.
 
-**What it does:** A local MCP server connects an AI client to Premiere through the production CEP bridge. It exposes 280 core tools across project inspection, editing, effects, color, audio, media management, diagnostics, and export; an authenticated compatible UXP host adds 29 capability-gated tools for a 307-tool connected surface.
+**What it does:** A local MCP server connects an AI client to Premiere through the production CEP bridge. It exposes 285 core tools across project inspection, editing, effects, color, audio, media management, diagnostics, and export; an authenticated compatible UXP host adds 49 capability-gated tools for a 332-tool connected surface.
 
 **Product category:** Premiere Pro automation, MCP server, AI-assisted video-editing infrastructure.
 
@@ -74,10 +74,12 @@
 - Local-first recommended architecture
 - Broad structured tool surface with capability and authority metadata
 - Read-only connection verification and diagnostic paths
+- Opt-in local project context with evidence retrieval and stale-state guards
+- Preview-confirmed compound edit plans with exact target revalidation
 - Production CEP compatibility plus capability-gated UXP expansion
 - Open-source client bundles, connectors, and release artifacts
 
-**How we do it differently:** The server presents explicit tools and verification boundaries instead of asking an AI to guess at Premiere's interface.
+**How we do it differently:** The server presents explicit tools, client choice, local project context, and verification boundaries instead of asking an AI to guess at Premiere's interface. Its project-context workflow captures bounded evidence locally, generates a non-mutating plan, and requires an exact preview confirmation before a compound edit can apply.
 
 **Why that's better:** Users can inspect support, preview risk, and evaluate returned state or diagnostics before relying on an operation.
 
@@ -138,7 +140,7 @@
 
 ## Proof Points
 
-**Metrics:** 280 registered core tools; 278 exposed by the default authority profile; 29 additional capability-gated tools with an authenticated compatible UXP host; 307 connected tools total; 31 core modules; 3 MCP resources; 4 guided workflows.
+**Metrics:** 285 registered core tools; 283 exposed by the default authority profile; 49 additional capability-gated tools with an authenticated compatible UXP host; 332 connected tools total; 32 core modules; 4 MCP resources; 6 guided workflows.
 
 **Customers:** No approved customer-logo claims are currently documented.
 
@@ -161,9 +163,13 @@
 
 **Current metrics:** Public discovery and distribution signals exist, but current activation counts must be queried from the production PostHog project before being reported.
 
+**Organic acquisition strategy:** Publish practical, intent-specific guides that answer what an MCP server is, how it fits a Premiere workflow, and how to automate repetitive work without promising autonomous editing or universal host compatibility. Each guide should lead to the read-only connection check as the measurable next action.
+
 ## Changelog
 
 *Newest first. One line per revision: what changed and why.*
 
+- v4 (2026-08-20) — Added the project-context review workflow and client-choice differentiation after Adobe AI Assistant comparison.
+- v3 (2026-08-19) — Updated proof counts for v1.11.4 and added the organic article strategy and activation path.
 - v2 (2026-08-15) — Expanded audience, differentiation, objections, brand voice, proof, and activation goals; aligned the current 280-core and 307-connected tool surfaces.
 - v1 (2026-07-27) — Initial context derived from the product README, package requirements, compatibility guidance, and usage-measurement work.

--- a/design-qa.md
+++ b/design-qa.md
@@ -1,0 +1,30 @@
+# Landing-page design QA
+
+## Visual reference
+
+- **Selected visual target:** `C:\Users\kavyr\.codex\generated_images\01a01ad5-9dbc-7b90-b12e-769808bfde9c\exec-9d3c1ac2-9811-4c61-ad43-ddfb93beec10.png`
+- **Implementation preview:** `http://127.0.0.1:4173/`
+- **Scope:** the landing-page hero and the interactive project-context proof panel.
+
+## Fidelity review
+
+The implementation preserves the selected target's dark editorial layout, compact top navigation, purple-to-pink emphasis, proof-oriented hero, and inspectable four-step workflow. The implementation deliberately substitutes real MCP tool names and stated boundaries for the reference's illustrative fictional edit details; it identifies the panel as an illustration rather than live Premiere evidence.
+
+## Functional and accessibility checks
+
+- Desktop preview: the hero and workflow panel render with the selected visual hierarchy.
+- Mobile, 390 x 844: no horizontal overflow (`scrollWidth: 375`, `viewportWidth: 390`); navigation and primary CTAs remain visible.
+- Interaction: selecting **Find evidence** updates the active state and detail panel; Space activates the focused workflow button.
+- Semantics: the workflow has four native buttons, `aria-pressed` state, `aria-controls`, and an `aria-live="polite"` detail region.
+- Documentation CTA: `/docs/#project-context-heading` resolves to **Project context: a reviewable editing workflow**.
+- Browser console: no error-level messages in the local preview.
+
+## Build checks
+
+- `npm run lint` in `landing/` passed.
+- `npm run build` in `landing/` passed (14 generated routes).
+- `git diff --check` passed.
+
+## Final result
+
+Passed. No P0, P1, or P2 visual, responsive, interaction, or accessibility issues remain in the implemented scope.

--- a/docs/marketing/seo-launch-kit.md
+++ b/docs/marketing/seo-launch-kit.md
@@ -1,0 +1,84 @@
+# Premiere Pro MCP Organic Launch Kit
+
+Published guides:
+
+- `https://premiere-pro-mcp.com/blog/what-is-a-premiere-pro-mcp-server/`
+- `https://premiere-pro-mcp.com/blog/ai-video-editing-with-premiere-pro/`
+- `https://premiere-pro-mcp.com/blog/premiere-pro-workflow-automation/`
+
+## Positioning
+
+Premiere Pro MCP gives compatible AI assistants a structured, local-first way to inspect Premiere projects, plan supported edits, automate repeatable work, and return observable results—without replacing the editor’s creative decision.
+
+## Launch post
+
+I published three practical guides for editors and workflow teams who want to use AI with Adobe Premiere Pro without handing over creative control:
+
+1. What a Premiere Pro MCP server actually does
+2. A reviewable workflow for AI-assisted editing
+3. How to automate repeatable Premiere work without automating editorial judgment
+
+Premiere Pro MCP is free, MIT licensed, and local-first. Start with a read-only connection check, then inspect your active sequence before requesting an edit.
+
+Read the guides: https://premiere-pro-mcp.com/blog/
+
+## Short social variants
+
+### LinkedIn
+
+AI video editing should make repetitive Premiere work easier to review—not make creative decisions in a black box.
+
+I published three practical guides on using a local MCP workflow with Adobe Premiere Pro: what the server does, how to keep the editor in control, and which workflows are worth automating first.
+
+Start with the safe, read-only connection check: https://premiere-pro-mcp.com/blog/
+
+### X / Bluesky
+
+New: a practical guide series for AI-assisted Adobe Premiere Pro workflows.
+
+Learn what a Premiere Pro MCP server does, how to verify edits instead of trusting a prompt, and which repetitive tasks to automate first.
+
+Free, MIT licensed, local-first: https://premiere-pro-mcp.com/blog/
+
+### Community post
+
+I built an open-source MCP server for structured, local-first Adobe Premiere Pro workflows. The goal is not autonomous editing: it is making repetitive work inspectable, bounded, and easier to verify.
+
+I wrote a no-hype guide to the connection model, a workflow guide, and an automation guide. Feedback on capability boundaries, install friction, and real editor workflows is especially welcome: https://premiere-pro-mcp.com/blog/
+
+## Outreach email
+
+**Subject:** A practical, local-first guide to AI workflows in Premiere Pro
+
+Hi [name],
+
+I published a short guide series for editors and post-production teams exploring AI-assisted Adobe Premiere Pro workflows. It focuses on a gap that gets missed in “AI video editing” coverage: how to inspect a project, constrain an automation, and verify a result instead of treating a prompt as proof.
+
+Premiere Pro MCP is a free, MIT-licensed local MCP server. The guides are useful even for readers who are comparing approaches, because they explain a clear safety and review model.
+
+If it is relevant to your audience, the hub is here: https://premiere-pro-mcp.com/blog/
+
+Thanks,
+Premiere Pro MCP contributors
+
+## 30-day distribution cadence
+
+| Week | Primary action | Success signal |
+| --- | --- | --- |
+| 1 | Announce the guide hub on owned social channels and GitHub Discussions; link to the “what is” guide. | Referral visits and completed setup-guide clicks. |
+| 2 | Share a concrete inspect-plan-apply-verify example; link to the AI workflow guide. | Time on article and safe-check copy or docs clicks. |
+| 3 | Publish one short workflow recipe from a real, approved use case; link to the automation guide. | Qualified feedback and issue/discussion quality. |
+| 4 | Reach out individually to relevant editor, MCP, and post-production publications or newsletters. | Earned links and branded search impressions. |
+
+## Measurement
+
+- Tag each owned social link with a channel-specific UTM source and campaign such as `utm_source=linkedin&utm_medium=organic_social&utm_campaign=guides_launch`.
+- Treat a completed installation, `verify_premiere_connection`, and first successful supported tool call as stronger outcomes than impressions, likes, stars, or downloads.
+- Review Search Console query/impression data after enough crawl and ranking time; do not rewrite a guide solely because early rankings are sparse.
+
+## Boundaries
+
+- Do not characterize simulated UI/video assets as live Premiere proof.
+- Do not claim a tool works in every Premiere build; direct readers to the read-only connection check and capability inspection.
+- Do not imply that the local-first server changes the privacy terms of a chosen AI client.
+- This kit is for organic distribution. Paid campaigns are intentionally not activated: they need a defined budget, audience, destination, and conversion measurement plan.

--- a/landing/app/blog/[slug]/page.tsx
+++ b/landing/app/blog/[slug]/page.tsx
@@ -1,0 +1,188 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { articleBySlug, articles } from "@/lib/articles"
+
+type ArticlePageProps = {
+  params: Promise<{ slug: string }>
+}
+
+export const dynamic = "force-static"
+
+export function generateStaticParams() {
+  return articles.map(({ slug }) => ({ slug }))
+}
+
+export async function generateMetadata({ params }: ArticlePageProps): Promise<Metadata> {
+  const { slug } = await params
+  const article = articleBySlug.get(slug)
+
+  if (!article) {
+    return {}
+  }
+
+  return {
+    title: article.title,
+    description: article.description,
+    keywords: article.keywords,
+    alternates: { canonical: `/blog/${article.slug}/` },
+    openGraph: {
+      title: article.title,
+      description: article.description,
+      url: `/blog/${article.slug}/`,
+      type: "article",
+      publishedTime: article.publishedAt,
+      modifiedTime: article.modifiedAt,
+      authors: ["Premiere Pro MCP contributors"],
+    },
+  }
+}
+
+export default async function ArticlePage({ params }: ArticlePageProps) {
+  const { slug } = await params
+  const article = articleBySlug.get(slug)
+
+  if (!article) {
+    notFound()
+  }
+
+  const relatedArticles = articles.filter((candidate) => candidate.slug !== article.slug).slice(0, 2)
+  const articleUrl = `https://premiere-pro-mcp.com/blog/${article.slug}/`
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Article",
+        "@id": `${articleUrl}#article`,
+        headline: article.title,
+        description: article.description,
+        url: articleUrl,
+        datePublished: article.publishedAt,
+        dateModified: article.modifiedAt,
+        inLanguage: "en-US",
+        author: {
+          "@type": "Organization",
+          name: "Premiere Pro MCP contributors",
+          url: "https://github.com/leancoderkavy/premiere-pro-mcp",
+        },
+        publisher: { "@id": "https://premiere-pro-mcp.com/#organization" },
+        mainEntityOfPage: articleUrl,
+        keywords: article.keywords.join(", "),
+      },
+      {
+        "@type": "FAQPage",
+        "@id": `${articleUrl}#faq`,
+        mainEntity: article.faqs.map((faq) => ({
+          "@type": "Question",
+          name: faq.question,
+          acceptedAnswer: { "@type": "Answer", text: faq.answer },
+        })),
+      },
+      {
+        "@type": "BreadcrumbList",
+        "@id": `${articleUrl}#breadcrumb`,
+        itemListElement: [
+          { "@type": "ListItem", position: 1, name: "Premiere Pro MCP", item: "https://premiere-pro-mcp.com/" },
+          { "@type": "ListItem", position: 2, name: "Guides", item: "https://premiere-pro-mcp.com/blog/" },
+          { "@type": "ListItem", position: 3, name: article.title, item: articleUrl },
+        ],
+      },
+    ],
+  }
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+      <main id="main-content" className="min-h-screen bg-black px-5 py-12 text-zinc-100 sm:py-20">
+        <article className="mx-auto max-w-3xl">
+          <nav aria-label="Breadcrumb" className="text-sm text-zinc-500">
+            <Link href="/" className="hover:text-purple-200">Premiere Pro MCP</Link>{" "}
+            <span aria-hidden="true">/</span>{" "}
+            <Link href="/blog/" className="hover:text-purple-200">Guides</Link>{" "}
+            <span aria-hidden="true">/</span> <span className="text-zinc-400">{article.eyebrow}</span>
+          </nav>
+
+          <header className="border-b border-zinc-800 pb-10 pt-10 sm:pb-14 sm:pt-14">
+            <p className="font-mono text-sm font-medium uppercase tracking-[0.15em] text-purple-300">{article.eyebrow}</p>
+            <h1 className="mt-5 text-balance text-4xl font-bold tracking-tight text-white sm:text-6xl">{article.title}</h1>
+            <p className="mt-6 text-lg leading-8 text-zinc-400">{article.description}</p>
+            <div className="mt-7 flex items-center gap-3 text-sm text-zinc-500">
+              <time dateTime={article.publishedAt}>Published August 19, 2026</time>
+              <span aria-hidden="true">·</span>
+              <span>{article.readingTime}</span>
+            </div>
+          </header>
+
+          <div className="py-10 sm:py-14">
+            {article.sections.map((section) => (
+              <section key={section.heading} className="border-b border-zinc-900 py-9 first:pt-0 last:border-b-0">
+                <h2 className="text-2xl font-semibold tracking-tight text-white sm:text-3xl">{section.heading}</h2>
+                <div className="mt-5 space-y-5 text-[1.0625rem] leading-8 text-zinc-300">
+                  {section.paragraphs.map((paragraph) => <p key={paragraph}>{paragraph}</p>)}
+                </div>
+                {section.bullets ? (
+                  <ul className="mt-6 list-disc space-y-3 pl-5 leading-7 text-zinc-300 marker:text-purple-300">
+                    {section.bullets.map((item) => <li key={item}>{item}</li>)}
+                  </ul>
+                ) : null}
+              </section>
+            ))}
+          </div>
+
+          <section className="border-y border-zinc-800 py-10" aria-labelledby="faq-heading">
+            <h2 id="faq-heading" className="text-2xl font-semibold tracking-tight text-white">Questions editors ask</h2>
+            <div className="mt-6 divide-y divide-zinc-800">
+              {article.faqs.map((faq) => (
+                <details key={faq.question} className="group py-5">
+                  <summary className="cursor-pointer list-none pr-8 font-medium text-zinc-100 marker:content-none group-open:text-purple-200">
+                    {faq.question}
+                  </summary>
+                  <p className="mt-3 leading-7 text-zinc-400">{faq.answer}</p>
+                </details>
+              ))}
+            </div>
+          </section>
+
+          <section className="py-10" aria-labelledby="resources-heading">
+            <h2 id="resources-heading" className="text-2xl font-semibold tracking-tight text-white">Keep learning</h2>
+            <ul className="mt-5 space-y-3">
+              {article.resources.map((resource) => (
+                <li key={resource.href}>
+                  <a href={resource.href} className="font-medium text-purple-200 hover:text-white">
+                    {resource.label} <span aria-hidden="true">→</span>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="border border-purple-300/40 bg-purple-300/10 p-7 sm:p-9" aria-labelledby="start-heading">
+            <p className="font-mono text-xs font-medium uppercase tracking-[0.15em] text-purple-200">A practical next step</p>
+            <h2 id="start-heading" className="mt-3 text-2xl font-semibold tracking-tight text-white">Start with a safe Premiere connection check.</h2>
+            <p className="mt-3 max-w-2xl leading-7 text-zinc-300">
+              Connect your assistant, verify the local bridge without changing a project, then inspect the active sequence before requesting a supported edit.
+            </p>
+            <Link href="/docs/" className="mt-6 inline-flex bg-purple-300 px-5 py-3 font-medium text-black transition-colors hover:bg-white">
+              Read the setup guide <span aria-hidden="true" className="ml-2">→</span>
+            </Link>
+          </section>
+
+          <aside className="border-t border-zinc-800 py-10" aria-labelledby="related-heading">
+            <h2 id="related-heading" className="text-xl font-semibold text-white">Related guides</h2>
+            <div className="mt-5 grid gap-4 sm:grid-cols-2">
+              {relatedArticles.map((related) => (
+                <Link key={related.slug} href={`/blog/${related.slug}/`} className="border border-zinc-800 p-5 transition-colors hover:border-purple-400/60">
+                  <p className="font-mono text-xs uppercase tracking-[0.12em] text-purple-300">{related.eyebrow}</p>
+                  <p className="mt-3 font-semibold text-zinc-100">{related.title}</p>
+                </Link>
+              ))}
+            </div>
+          </aside>
+        </article>
+      </main>
+    </>
+  )
+}

--- a/landing/app/blog/page.tsx
+++ b/landing/app/blog/page.tsx
@@ -1,0 +1,95 @@
+import type { Metadata } from "next"
+import Link from "next/link"
+import { articles } from "@/lib/articles"
+
+export const metadata: Metadata = {
+  title: "Premiere Pro AI Editing & Automation Guides",
+  description:
+    "Practical guides to AI-assisted video editing, Premiere Pro workflow automation, and using a local MCP server without giving up creative control.",
+  alternates: { canonical: "/blog/" },
+  openGraph: {
+    title: "Premiere Pro AI Editing & Automation Guides",
+    description:
+      "Practical, local-first guides to AI-assisted video editing and Adobe Premiere Pro workflow automation.",
+    url: "/blog/",
+    type: "website",
+  },
+}
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "CollectionPage",
+  "@id": "https://premiere-pro-mcp.com/blog/#collection",
+  name: "Premiere Pro MCP Guides",
+  description:
+    "Practical guides to AI-assisted video editing, Premiere Pro automation, and local MCP workflows.",
+  url: "https://premiere-pro-mcp.com/blog/",
+  isPartOf: { "@id": "https://premiere-pro-mcp.com/#website" },
+  mainEntity: {
+    "@type": "ItemList",
+    itemListElement: articles.map((article, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      url: `https://premiere-pro-mcp.com/blog/${article.slug}/`,
+      name: article.title,
+    })),
+  },
+}
+
+export default function BlogPage() {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+      <main id="main-content" className="min-h-screen bg-black px-5 py-16 text-zinc-100 sm:py-24">
+        <div className="mx-auto max-w-6xl">
+          <nav aria-label="Breadcrumb" className="text-sm text-zinc-500">
+            <Link href="/" className="hover:text-purple-200">Premiere Pro MCP</Link>{" "}
+            <span aria-hidden="true">/</span> Guides
+          </nav>
+          <header className="max-w-3xl border-b border-zinc-800 pb-12 pt-10 sm:pb-16">
+            <p className="font-mono text-sm font-medium tracking-[0.16em] text-purple-300">PREMIERE PRO MCP GUIDES</p>
+            <h1 className="mt-5 text-balance text-4xl font-bold tracking-tight text-white sm:text-6xl">
+              Practical guides for AI-assisted Premiere workflows.
+            </h1>
+            <p className="mt-6 text-lg leading-8 text-zinc-400">
+              Learn where an AI assistant can help, how structured MCP tools fit into Adobe Premiere Pro,
+              and how to keep every workflow local-first, bounded, and reviewable.
+            </p>
+          </header>
+
+          <section className="grid gap-6 py-12 md:grid-cols-3" aria-label="Premiere Pro MCP guides">
+            {articles.map((article, index) => (
+              <article key={article.slug} className="flex min-h-full flex-col border border-zinc-800 bg-zinc-950 p-6 transition-colors hover:border-purple-400/60 sm:p-7">
+                <p className="font-mono text-xs font-medium uppercase tracking-[0.14em] text-purple-300">0{index + 1} · {article.eyebrow}</p>
+                <h2 className="mt-5 text-2xl font-semibold tracking-tight text-white">
+                  <Link href={`/blog/${article.slug}/`} className="hover:text-purple-200">{article.title}</Link>
+                </h2>
+                <p className="mt-4 flex-1 leading-7 text-zinc-400">{article.description}</p>
+                <div className="mt-7 flex items-center justify-between border-t border-zinc-800 pt-5 text-sm">
+                  <time dateTime={article.publishedAt} className="text-zinc-500">August 19, 2026</time>
+                  <Link href={`/blog/${article.slug}/`} className="font-medium text-purple-200 hover:text-white">
+                    Read guide <span aria-hidden="true">→</span>
+                  </Link>
+                </div>
+              </article>
+            ))}
+          </section>
+
+          <section className="border-t border-zinc-800 py-12 sm:py-16">
+            <p className="font-mono text-sm tracking-[0.14em] text-purple-300">READY TO TRY A BOUNDED WORKFLOW?</p>
+            <h2 className="mt-4 text-3xl font-semibold tracking-tight text-white sm:text-4xl">Start with a read-only Premiere connection check.</h2>
+            <p className="mt-4 max-w-2xl leading-7 text-zinc-400">
+              Install the local server and connector, verify the live bridge without changing a project, then inspect your first sequence.
+            </p>
+            <Link href="/docs/" className="mt-6 inline-flex border border-purple-300 bg-purple-300 px-5 py-3 font-medium text-black transition-colors hover:bg-white">
+              Read the setup guide <span aria-hidden="true" className="ml-2">→</span>
+            </Link>
+          </section>
+        </div>
+      </main>
+    </>
+  )
+}

--- a/landing/app/docs/page.tsx
+++ b/landing/app/docs/page.tsx
@@ -124,6 +124,25 @@ export default function DocsPage() {
           </p>
         </section>
 
+        <section className="border-t border-zinc-800 py-12" aria-labelledby="project-context-heading">
+          <h2 id="project-context-heading" className="text-3xl font-semibold">Project context: a reviewable editing workflow</h2>
+          <p className="mt-5 leading-8 text-zinc-400">
+            The opt-in local project-context engine is designed for repeatable work that needs more evidence than a conversational request. It never captures context until the MCP client asks for it, and it does not send an entire Premiere project or customer footage into every model turn.
+          </p>
+          <ol className="mt-6 list-decimal space-y-3 pl-6 leading-7 text-zinc-300">
+            <li>Use <code className="rounded bg-zinc-900 px-2 py-1 text-purple-200">manage_project_context</code> to capture a bounded active-sequence snapshot locally.</li>
+            <li>Use <code className="rounded bg-zinc-900 px-2 py-1 text-purple-200">search_project_context</code> to retrieve only relevant evidence and stable identities.</li>
+            <li>Use <code className="rounded bg-zinc-900 px-2 py-1 text-purple-200">create_context_edit_plan</code> to generate a non-mutating candidate scaffold with stale-state guards.</li>
+            <li>Use <code className="rounded bg-zinc-900 px-2 py-1 text-purple-200">preview_edit_plan</code> before <code className="rounded bg-zinc-900 px-2 py-1 text-purple-200">apply_edit_plan</code>. Apply requires the exact preview confirmation token and current target validation.</li>
+          </ol>
+          <p className="mt-6 leading-7 text-zinc-400">
+            A context plan is evidence, not mutation authority or proof that an editorial choice is correct. Clear local context when it is no longer needed.
+          </p>
+          <a className="mt-6 inline-flex font-medium text-purple-200 hover:text-white" href="https://github.com/leancoderkavy/premiere-pro-mcp/blob/main/docs/project-context-engine.md">
+            Read the project-context engine guide <span aria-hidden="true" className="ml-2">→</span>
+          </a>
+        </section>
+
         <section className="border-t border-zinc-800 py-12" aria-labelledby="resources-heading">
           <h2 id="resources-heading" className="text-3xl font-semibold">Canonical resources</h2>
           <ul className="mt-6 space-y-3 text-purple-300">

--- a/landing/app/sitemap.ts
+++ b/landing/app/sitemap.ts
@@ -2,7 +2,7 @@ import type { MetadataRoute } from "next"
 
 export const dynamic = "force-static"
 
-const lastModified = new Date("2026-08-04")
+const lastModified = new Date("2026-08-19")
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
@@ -16,6 +16,30 @@ export default function sitemap(): MetadataRoute.Sitemap {
       url: "https://premiere-pro-mcp.com/docs/",
       lastModified,
       changeFrequency: "weekly",
+      priority: 0.8,
+    },
+    {
+      url: "https://premiere-pro-mcp.com/blog/",
+      lastModified,
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
+    {
+      url: "https://premiere-pro-mcp.com/blog/what-is-a-premiere-pro-mcp-server/",
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: "https://premiere-pro-mcp.com/blog/ai-video-editing-with-premiere-pro/",
+      lastModified,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: "https://premiere-pro-mcp.com/blog/premiere-pro-workflow-automation/",
+      lastModified,
+      changeFrequency: "monthly",
       priority: 0.8,
     },
     {

--- a/landing/components/sections/footer.tsx
+++ b/landing/components/sections/footer.tsx
@@ -1,5 +1,6 @@
 import { Github, Package } from "lucide-react"
 import Image from "next/image"
+import Link from "next/link"
 
 export function Footer() {
   return (
@@ -27,6 +28,7 @@ export function Footer() {
               <a href="#how-it-works" className="hover:text-white">How it works</a>
               <a href="#install" className="hover:text-white">Install</a>
               <a href="#faq" className="hover:text-white">FAQ</a>
+              <Link href="/blog/" className="hover:text-white">Guides</Link>
               <a href="/docs/" className="hover:text-white">Documentation</a>
               <a href="/changelog/" className="hover:text-white">Changelog</a>
             </div>

--- a/landing/components/sections/hero.tsx
+++ b/landing/components/sections/hero.tsx
@@ -2,6 +2,7 @@ import { Github, Monitor, Package, ShieldCheck, Sparkles } from "lucide-react"
 import Image from "next/image"
 import { HeroDepthLoader } from "@/components/sections/hero-depth-loader"
 import { MobileNav } from "@/components/sections/mobile-nav"
+import { WorkflowProof } from "@/components/sections/workflow-proof"
 import { TrackedLink } from "@/components/ui/tracked-link"
 import { product } from "@/lib/product"
 
@@ -11,6 +12,7 @@ const navItems = [
   { label: "How it works", href: "#how-it-works" },
   { label: "Install", href: "#install" },
   { label: "FAQ", href: "#faq" },
+  { label: "Guides", href: "/blog/" },
   { label: "Docs", href: "/docs/" },
   { label: "Changelog", href: "/changelog/" },
 ]
@@ -72,49 +74,39 @@ export function HeroSection() {
         <div className="relative mx-auto max-w-6xl">
           <div className="mx-auto max-w-4xl text-center">
             <p className="hero-enter hero-enter-1 mb-5 font-mono text-xs font-semibold uppercase tracking-[0.18em] text-purple-300">
-              For editors and automation teams
+              Open source · local-first · editor approved
             </p>
             <h1 className="hero-enter hero-enter-1 text-balance text-4xl font-bold leading-[1.02] tracking-[-0.045em] text-white sm:text-6xl md:text-7xl">
-              Control Adobe Premiere Pro with <span className="accent-text">AI</span>
+              Make repeatable edits a <span className="accent-text">reviewed workflow.</span>
             </h1>
             <p className="hero-enter hero-enter-2 mx-auto mt-7 max-w-2xl text-balance text-lg leading-8 text-zinc-400 md:text-xl">
-              Inspect projects, plan edits, automate repeatable timeline work, and export from your AI client—while Premiere and your media stay on your computer.
+              Use the MCP-compatible client your team already trusts to capture local project context, prepare a non-mutating plan, and verify supported Premiere work before you rely on it.
             </p>
             <div className="hero-enter hero-enter-3 mt-9 flex flex-col items-center justify-center gap-3 sm:flex-row">
               <TrackedLink
                 href="#install"
                 trackingLocation="hero"
-                trackingDestination="install"
-                className="inline-flex h-12 items-center justify-center gap-2 rounded-lg bg-gradient-to-r from-[#8b7cff] to-[#ef76b9] px-6 text-sm font-semibold text-white shadow-[0_12px_40px_rgba(139,124,255,0.22)] transition-transform hover:-translate-y-0.5"
+                trackingDestination="safe_connection_check"
+                className="inline-flex h-12 items-center justify-center gap-2 rounded-lg bg-purple-300 px-6 text-sm font-semibold text-black transition-colors hover:bg-white"
               >
-                <Package className="h-4 w-4" /> Choose your assistant
+                <Package className="h-4 w-4" /> Run a safe connection check
               </TrackedLink>
               <TrackedLink
-                href="https://github.com/leancoderkavy/premiere-pro-mcp"
-                target="_blank"
-                rel="noopener noreferrer"
+                href="/docs/#project-context-heading"
                 trackingLocation="hero"
-                trackingDestination="github"
+                trackingDestination="project_context_docs"
                 className="inline-flex h-12 items-center justify-center gap-2 rounded-lg border border-zinc-700 bg-zinc-950/80 px-6 text-sm font-semibold text-zinc-100 transition-colors hover:border-zinc-500 hover:bg-zinc-900"
               >
-                <Github className="h-4 w-4" /> View on GitHub
+                <ShieldCheck className="h-4 w-4" /> See the workflow boundary
               </TrackedLink>
             </div>
             <p className="hero-enter hero-enter-3 mt-4 text-sm text-zinc-500">
-              Free and MIT licensed · runs locally · guided first check
+              Project context is opt-in and local · every applied plan requires current targets and confirmation
             </p>
           </div>
 
-          <div className="hero-enter hero-enter-4 relative mx-auto mt-12 max-w-6xl overflow-hidden rounded-xl border border-white/10 bg-[#050506] shadow-[0_28px_90px_rgba(0,0,0,0.55)] md:mt-16">
-            <Image
-              src="/marketing/premiere-pro-mcp-campaign-hero-v1.png"
-              alt="A structured AI request passes through a local protocol bridge into an organized video-editing timeline and verified export."
-              width={1672}
-              height={941}
-              sizes="(max-width: 768px) 100vw, 1152px"
-              className="h-auto w-full"
-              priority
-            />
+          <div className="hero-enter hero-enter-4">
+            <WorkflowProof />
           </div>
 
           <div className="hero-enter hero-enter-5 mt-6 flex snap-x overflow-x-auto rounded-xl border border-zinc-800 bg-zinc-950/75 sm:mt-8 sm:grid sm:grid-cols-2 sm:overflow-hidden lg:grid-cols-4">

--- a/landing/components/sections/mobile-nav.tsx
+++ b/landing/components/sections/mobile-nav.tsx
@@ -10,6 +10,7 @@ const mobileLinks = [
   { label: "How it works", href: "#how-it-works" },
   { label: "Install", href: "#install" },
   { label: "FAQ", href: "#faq" },
+  { label: "Guides", href: "/blog/" },
   { label: "Docs", href: "/docs/" },
   { label: "Changelog", href: "/changelog/" },
 ] as const

--- a/landing/components/sections/workflow-proof.tsx
+++ b/landing/components/sections/workflow-proof.tsx
@@ -1,0 +1,156 @@
+"use client"
+
+import { useState } from "react"
+import { CheckCircle2, ClipboardCheck, FileSearch, ListChecks, ScanSearch, ShieldCheck } from "lucide-react"
+
+type WorkflowStep = {
+  id: "capture" | "search" | "plan" | "preview"
+  number: string
+  title: string
+  tool: string
+  summary: string
+  boundary: string
+  details: string[]
+  icon: typeof ScanSearch
+}
+
+const steps: WorkflowStep[] = [
+  {
+    id: "capture",
+    number: "01",
+    title: "Capture context",
+    tool: "manage_project_context",
+    summary: "Create a bounded local snapshot of the active sequence and source identities.",
+    boundary: "Read-only · opt-in local index",
+    details: [
+      "No context is captured until an MCP client explicitly calls the tool.",
+      "Native project and media paths are hashed before persistence.",
+      "Capture establishes revisions for later stale-state checks.",
+    ],
+    icon: ScanSearch,
+  },
+  {
+    id: "search",
+    number: "02",
+    title: "Find evidence",
+    tool: "search_project_context",
+    summary: "Retrieve only the clips, transcript passages, observations, and placements relevant to the request.",
+    boundary: "Read-only · bounded evidence",
+    details: [
+      "Search returns stable Premiere identities and revision provenance.",
+      "The client can limit context to the kinds needed for one editing intent.",
+      "A stale or ambiguous state calls for a fresh capture, not a blind edit.",
+    ],
+    icon: FileSearch,
+  },
+  {
+    id: "plan",
+    number: "03",
+    title: "Build the plan",
+    tool: "create_context_edit_plan",
+    summary: "Produce an evidence-backed, non-mutating candidate scaffold before constructing timeline operations.",
+    boundary: "Non-mutating · editorial review required",
+    details: [
+      "Candidates include source/time evidence and stale-state guards.",
+      "The plan is not proof that an editorial decision is correct.",
+      "The editor and chosen AI client can refine the plan before any mutation.",
+    ],
+    icon: ListChecks,
+  },
+  {
+    id: "preview",
+    number: "04",
+    title: "Preview, approve, verify",
+    tool: "preview_edit_plan → apply_edit_plan",
+    summary: "Preview the compound edit, then apply only with the exact confirmation token and current targets.",
+    boundary: "Explicit confirmation · post-state verification",
+    details: [
+      "Every target is revalidated before an edit is attempted.",
+      "The preview confirmation token prevents applying a different plan by mistake.",
+      "Returned state or diagnostics are evidence; an attempted command is not enough.",
+    ],
+    icon: ClipboardCheck,
+  },
+]
+
+export function WorkflowProof() {
+  const [selectedId, setSelectedId] = useState<WorkflowStep["id"]>("capture")
+  const selected = steps.find((step) => step.id === selectedId) ?? steps[0]
+  const SelectedIcon = selected.icon
+
+  return (
+    <section
+      className="relative mx-auto mt-12 max-w-6xl border border-zinc-800 bg-[#08080a] p-5 shadow-[0_28px_90px_rgba(0,0,0,0.45)] sm:mt-16 sm:p-7 lg:p-8"
+      aria-labelledby="project-context-heading"
+    >
+      <div className="flex flex-col gap-5 border-b border-zinc-800 pb-6 lg:flex-row lg:items-end lg:justify-between">
+        <div>
+          <p className="font-mono text-xs font-semibold uppercase tracking-[0.16em] text-purple-300">Illustrated product workflow</p>
+          <h2 id="project-context-heading" className="mt-3 text-2xl font-semibold tracking-tight text-white sm:text-3xl">
+            Keep the context. Review the change.
+          </h2>
+        </div>
+        <p className="max-w-xl text-sm leading-6 text-zinc-400">
+          A local project-context workflow makes the request inspectable from first evidence to returned result. This maps real MCP tools; it is not a recording of a live Premiere session.
+        </p>
+      </div>
+
+      <div className="mt-6 grid gap-6 lg:grid-cols-[14rem_minmax(0,1fr)]">
+        <ol className="grid gap-2 sm:grid-cols-2 lg:grid-cols-1" aria-label="Project context workflow steps">
+          {steps.map((step) => {
+            const Icon = step.icon
+            const active = step.id === selected.id
+
+            return (
+              <li key={step.id}>
+                <button
+                  type="button"
+                  onClick={() => setSelectedId(step.id)}
+                  aria-pressed={active}
+                  aria-controls="workflow-step-detail"
+                  className={`flex min-h-20 w-full items-center gap-3 border px-3 py-3 text-left transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#08080a] ${
+                    active ? "border-purple-400/70 bg-purple-400/[0.09]" : "border-zinc-800 bg-black hover:border-zinc-600"
+                  }`}
+                >
+                  <span className={`font-mono text-xs ${active ? "text-purple-200" : "text-zinc-500"}`}>{step.number}</span>
+                  <Icon className={`h-4 w-4 shrink-0 ${active ? "text-purple-200" : "text-zinc-500"}`} aria-hidden="true" />
+                  <span>
+                    <span className="block text-sm font-semibold text-zinc-100">{step.title}</span>
+                    <span className="mt-1 block font-mono text-[0.65rem] text-zinc-500">{step.tool}</span>
+                  </span>
+                </button>
+              </li>
+            )
+          })}
+        </ol>
+
+        <article id="workflow-step-detail" aria-live="polite" className="border border-zinc-800 bg-black p-5 sm:p-7">
+          <div className="flex flex-col gap-5 border-b border-zinc-800 pb-5 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex items-start gap-3">
+              <span className="grid h-10 w-10 shrink-0 place-items-center border border-purple-400/50 bg-purple-400/[0.08] text-purple-200">
+                <SelectedIcon className="h-5 w-5" aria-hidden="true" />
+              </span>
+              <div>
+                <p className="font-mono text-xs uppercase tracking-[0.14em] text-purple-300">{selected.tool}</p>
+                <h3 className="mt-2 text-xl font-semibold text-white">{selected.title}</h3>
+              </div>
+            </div>
+            <p className="inline-flex w-fit items-center gap-2 border border-emerald-400/30 bg-emerald-400/[0.06] px-3 py-2 text-xs font-medium text-emerald-200">
+              <ShieldCheck className="h-4 w-4" aria-hidden="true" /> {selected.boundary}
+            </p>
+          </div>
+
+          <p className="mt-6 max-w-2xl text-base leading-7 text-zinc-300">{selected.summary}</p>
+          <ul className="mt-6 space-y-3 border-t border-zinc-900 pt-5 text-sm leading-6 text-zinc-400">
+            {selected.details.map((detail) => (
+              <li key={detail} className="flex gap-3">
+                <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-300" aria-hidden="true" />
+                <span>{detail}</span>
+              </li>
+            ))}
+          </ul>
+        </article>
+      </div>
+    </section>
+  )
+}

--- a/landing/lib/articles.ts
+++ b/landing/lib/articles.ts
@@ -1,0 +1,256 @@
+export type ArticleSection = {
+  heading: string
+  paragraphs: string[]
+  bullets?: string[]
+}
+
+export type ArticleFaq = {
+  question: string
+  answer: string
+}
+
+export type Article = {
+  slug: string
+  title: string
+  description: string
+  eyebrow: string
+  publishedAt: string
+  modifiedAt: string
+  readingTime: string
+  keywords: string[]
+  sections: ArticleSection[]
+  faqs: ArticleFaq[]
+  resources: Array<{ label: string; href: string }>
+}
+
+export const articles: Article[] = [
+  {
+    slug: "what-is-a-premiere-pro-mcp-server",
+    title: "What Is a Premiere Pro MCP Server? A Practical Guide to AI-Assisted Editing",
+    description:
+      "Learn what a Premiere Pro MCP server does, how it connects a compatible AI assistant to Adobe Premiere Pro, and how to start with a safe read-only check.",
+    eyebrow: "Premiere Pro MCP explained",
+    publishedAt: "2026-08-19",
+    modifiedAt: "2026-08-19",
+    readingTime: "7 min read",
+    keywords: ["Premiere Pro MCP server", "MCP video editing", "AI assistant for Adobe Premiere Pro"],
+    sections: [
+      {
+        heading: "The short version",
+        paragraphs: [
+          "A Premiere Pro MCP server is a local service that gives a compatible AI assistant a structured way to work with Adobe Premiere Pro. Instead of asking an assistant to guess what is on screen or operate the interface like a person, the server exposes named tools for supported tasks such as inspecting a sequence, organizing media, preparing an edit, applying a supported change, or sending an export to Adobe Media Encoder.",
+          "MCP stands for Model Context Protocol, an open standard for connecting AI applications with external tools, data, and workflows. In this case, the external system is a Premiere project running on the editor’s computer. The useful outcome is not “AI edits a video by itself.” It is a more inspectable way to ask for repeatable Premiere work while the editor retains the creative decision and a chance to verify what happened.",
+        ],
+      },
+      {
+        heading: "How the connection works",
+        paragraphs: [
+          "Premiere Pro MCP uses a local-first path: your AI client sends a structured request to a local MCP server, and a local Premiere connector carries supported commands into the open Premiere session. Premiere returns structured data, confirmation, or diagnostics to the client. The recommended setup keeps the server, connector, Premiere, and project media on the same computer.",
+          "This architecture matters because a tool listing is not proof that a particular Premiere build can complete a particular operation. A robust workflow starts by checking the connection and available capabilities, then previewing or applying the smallest supported step, then inspecting the returned result. That is more dependable than treating natural-language output as evidence that a timeline changed.",
+        ],
+        bullets: [
+          "AI client: Claude Desktop, Cursor, VS Code / Copilot, Windsurf, or another MCP-compatible client.",
+          "Local server: translates structured tool calls into supported Premiere workflows.",
+          "Premiere connector: the signed CEP bridge is the default compatibility route; UXP tools are capability-gated on compatible hosts.",
+          "Observed result: the client receives returned data, confirmation, or diagnostics instead of a silent best-effort claim.",
+        ],
+      },
+      {
+        heading: "What can an AI assistant help with in Premiere Pro?",
+        paragraphs: [
+          "The server currently registers 285 core structured tools across timeline work, effects and Lumetri color, audio, captions, markers, keyframes, project organization, media and proxy workflows, diagnostics, and export. The default capability profile exposes 283 of those tools. An authenticated compatible UXP host can add 49 capability-gated tools, bringing the connected surface to 332.",
+          "Those numbers describe discovery, not a blanket promise. A better question is whether the current host can perform the specific task you need. For example, an editor might ask for the active sequence and its clip structure before requesting a preview of a B-roll assembly. A post-production lead might ask for a project inventory before standardizing bins. A workflow developer might use the structured surface as a starting point rather than building and maintaining a bridge from scratch.",
+        ],
+      },
+      {
+        heading: "What a Premiere Pro MCP server is not",
+        paragraphs: [
+          "It is not a hosted video editor, a replacement for editorial judgment, or a guarantee that every operation will work in every Premiere version. It does not turn a simulated product demo into proof of a completed edit. The local-first recommendation also does not override the privacy settings of the AI client you choose.",
+          "That boundary is a feature, not a footnote. Repeatable automation is most useful when an editor can set the goal, review the plan, limit authority, and inspect the outcome. For unusual, destructive, or version-sensitive work, use a small test sequence and verify state before relying on a larger batch.",
+        ],
+      },
+      {
+        heading: "A safe first prompt",
+        paragraphs: [
+          "After installing the assistant bundle or local server and the separate Premiere connector, restart both applications, open a project, and run a read-only connection check. This establishes whether the client can reach the live Premiere bridge before an editing request enters the picture.",
+          "Use this exact first request: “Safely check my Premiere connection with verify_premiere_connection. Make no changes.” If it succeeds, ask the assistant to inspect the active project or sequence before you progress to a supported edit. If it returns a diagnostic, resolve that first instead of retrying an edit blindly.",
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: "Does Premiere Pro MCP upload my footage?",
+        answer:
+          "The recommended setup is local-first: the server, Premiere connector, Premiere app, and project media stay on the editor’s computer. Your chosen AI client has its own privacy behavior and settings, so review those separately.",
+      },
+      {
+        question: "Does it work with every AI assistant?",
+        answer:
+          "It works with MCP-compatible clients. Claude Desktop has a released bundle; other clients can use the local server through their MCP configuration. A native one-click installer is not currently shipped for every client.",
+      },
+      {
+        question: "Will every Premiere tool work on my machine?",
+        answer:
+          "No static list can prove a live host operation. Run the read-only connection check, inspect capabilities, start with a small supported task, and verify the returned state or diagnostics.",
+      },
+    ],
+    resources: [
+      { label: "Read the setup and technical guide", href: "/docs/" },
+      { label: "View the open-source repository", href: "https://github.com/leancoderkavy/premiere-pro-mcp" },
+      { label: "Read the Model Context Protocol introduction", href: "https://modelcontextprotocol.io/docs/getting-started/intro" },
+    ],
+  },
+  {
+    slug: "ai-video-editing-with-premiere-pro",
+    title: "AI Video Editing with Premiere Pro: Keep Creative Control, Automate the Repetitive Work",
+    description:
+      "A practical approach to AI video editing in Adobe Premiere Pro: inspect first, automate repeatable work with structured tools, and verify every result.",
+    eyebrow: "AI video editing workflow",
+    publishedAt: "2026-08-19",
+    modifiedAt: "2026-08-19",
+    readingTime: "8 min read",
+    keywords: ["AI video editing Premiere Pro", "Adobe Premiere Pro AI workflow", "AI assistant video editing"],
+    sections: [
+      {
+        heading: "AI editing is most useful when it removes friction, not authorship",
+        paragraphs: [
+          "Editors do not need another tool that makes an opaque promise to “edit a video.” They need help with the parts of post-production that are repetitive, easy to describe, and expensive to repeat: taking inventory of a project, creating a sequence from known clips, lining up B-roll, applying a repeatable treatment, organizing bins, preparing markers, or queuing a delivery preset.",
+          "Adobe Premiere already includes its own evolving AI features. An MCP workflow solves a different problem: it lets a compatible AI assistant work with an existing local Premiere project through named, structured tools. The assistant can help turn a goal into a sequence of supported steps, while the editor stays responsible for taste, story, pacing, and final approval.",
+        ],
+      },
+      {
+        heading: "Use a four-stage workflow: inspect, plan, apply, verify",
+        paragraphs: [
+          "The fastest-looking prompt is not always the safest one. Begin by asking the assistant to inspect the project and active sequence without changing anything. That establishes clip names, tracks, timing, and the current state that a later edit depends on.",
+          "Next, ask for a bounded plan or preview. Name the target sequence, tracks, clips, timing constraints, and desired output. Apply only the supported steps you understand, then inspect the returned state or diagnostics. This keeps the work legible when a Premiere host differs from another machine, when a tool needs a specific capability, or when an operation cannot be confirmed.",
+        ],
+        bullets: [
+          "Inspect: “Show the active sequence, tracks, and clips. Make no changes.”",
+          "Plan: “Create a proposed B-roll assembly on V2 using these named clips. Do not apply it yet.”",
+          "Apply: approve the bounded operation only after the target and intent are clear.",
+          "Verify: re-read the sequence, inspect the expected values, or review the explicit export result.",
+        ],
+      },
+      {
+        heading: "Good AI-assisted Premiere tasks start with a clear definition of done",
+        paragraphs: [
+          "Natural language is useful for intent, but video timelines are precise. A request such as “make this more engaging” asks the assistant to invent editorial taste. A request such as “place these four B-roll clips on V2 over the interview section, preserve A1, add a cross dissolve between the B-roll clips, and prepare a 1080p ProRes export” gives it constraints that can be inspected.",
+          "Use names, tracks, time ranges, desired effects, output presets, and no-change boundaries. When a task is sensitive, split it into stages. For example, first collect the clips and report the plan; then let the editor approve the assembly; then apply the color or export pass. Smaller stages are easier to review and easier to recover from.",
+        ],
+      },
+      {
+        heading: "Where an MCP workflow fits",
+        paragraphs: [
+          "Premiere Pro MCP is free, MIT-licensed, and designed for local-first use. It registers 285 core tools for project inspection, timeline editing, effects, color, audio, media management, diagnostics, and export. The default profile deliberately limits the surface to 283 tools; a compatible authenticated UXP host can add 49 capability-gated tools. These boundaries let the client report what is available rather than pretending that every supported feature is ready at every moment.",
+          "For an editor, the key benefit is repeatability without moving the project into a separate hosted editor. For a team, it is a consistent way to ask for and check common operations. For a workflow developer, it is a maintained bridge and structured discovery surface instead of a screen-reading macro.",
+        ],
+      },
+      {
+        heading: "Protect the project before the convenience",
+        paragraphs: [
+          "Use a duplicate project or a small test sequence when trying a new operation. Keep destructive and unsafe capabilities disabled unless you explicitly need them. Re-query the timeline after a mutation, and do not treat an attempted command as a verified change. The right response to a capability error or diagnostic is to understand it, not to repeat the request until something changes.",
+          "That does not make the workflow slow. It turns review into part of the loop: the assistant handles the mechanical steps, and the editor maintains authorship. The result is a more dependable use of AI in Premiere, especially for work that needs to be repeated across projects or collaborators.",
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: "Can AI make my creative decisions for me?",
+        answer:
+          "It can help execute clearly specified, supported tasks, but editorial taste, story, pacing, and final approval remain human decisions. The most reliable requests include concrete constraints and a verification step.",
+      },
+      {
+        question: "Can I start without changing my project?",
+        answer:
+          "Yes. Start with the read-only verify_premiere_connection prompt, then inspect the project and active sequence. Ask for a preview or plan before applying any supported edit.",
+      },
+      {
+        question: "Is Premiere Pro MCP Adobe’s AI Assistant?",
+        answer:
+          "No. Premiere Pro MCP is an independent, open-source MCP server that works through a local Premiere connection. Adobe’s own AI features and their availability are separate products and workflows.",
+      },
+    ],
+    resources: [
+      { label: "Install and run a safe first check", href: "/docs/" },
+      { label: "Learn about Adobe Premiere’s AI Assistant", href: "https://helpx.adobe.com/premiere/desktop/premiere-ai-assistant/overview.html" },
+      { label: "Read how a Premiere Pro MCP server works", href: "/blog/what-is-a-premiere-pro-mcp-server/" },
+    ],
+  },
+  {
+    slug: "premiere-pro-workflow-automation",
+    title: "Premiere Pro Workflow Automation: Repeat the Work, Not the Edit",
+    description:
+      "See which Adobe Premiere Pro tasks are good candidates for workflow automation, how to keep edits reviewable, and how to verify an AI-assisted result.",
+    eyebrow: "Premiere Pro automation",
+    publishedAt: "2026-08-19",
+    modifiedAt: "2026-08-19",
+    readingTime: "7 min read",
+    keywords: ["Premiere Pro workflow automation", "Premiere Pro automation", "automate video editing workflow"],
+    sections: [
+      {
+        heading: "Automate the repeated parts of post-production",
+        paragraphs: [
+          "Premiere Pro workflow automation works best when the job is repeatable, the inputs are known, and the outcome can be checked. That includes creating a project inventory, organizing bins to a defined structure, inspecting an active sequence, applying a documented treatment, preparing markers or captions, checking proxy state, and queuing an export with a chosen preset.",
+          "The point is not to erase the editor. It is to remove the friction between a clear request and a verifiable result. A good automation gives the team more time for the decisions a computer should not make: what matters in an interview, how a scene should breathe, which take carries the story, and when the cut is finished.",
+        ],
+      },
+      {
+        heading: "Choose tasks that have clear inputs, constraints, and output",
+        paragraphs: [
+          "A task is a strong automation candidate when you can describe the source, the target, the constraints, and the expected state afterward. “Create a review sequence from the selected clips in this bin, place them on V1 in the listed order, and preserve all audio tracks” is inspectable. “Fix the pacing” is not—at least not without an editor deciding what that means.",
+          "This distinction makes automation easier to trust. If a tool cannot find the named clips, does not have the required capability, or cannot verify the outcome, it should return a useful diagnostic. It should not silently substitute a different target or claim success because it attempted a command.",
+        ],
+        bullets: [
+          "Strong candidates: media inventory, bin organization, project and sequence setup, repetitive timeline placement, known effect settings, proxy checks, marker work, and delivery preparation.",
+          "Needs editorial review: shot selection, story structure, performance judgments, comedic timing, music taste, and brand-sensitive creative choices.",
+          "Needs extra care: destructive batches, incomplete source media, undocumented host behavior, and operations that affect shared project files.",
+        ],
+      },
+      {
+        heading: "A reliable automation loop",
+        paragraphs: [
+          "Start with a no-change connection and project check. Then provide a bounded request that names the project or sequence, the target tracks, inputs, and the expected output. Where a preview is available, ask for it before applying the change. Afterward, inspect the state or the terminal receipt rather than relying on a conversational confirmation.",
+          "That loop works whether you are a solo editor preparing social versions or a workflow lead standardizing a repeated delivery step. It also generates useful evidence for debugging: if a host returns a capability error, you know whether the issue is installation, version support, authority, or an incorrect target.",
+        ],
+      },
+      {
+        heading: "Why structured tools are better than UI guessing",
+        paragraphs: [
+          "Traditional macros and screen-driven automation infer state from a changing interface. Panels move, workspaces differ, dialogs steal focus, and a visible click does not always prove the project changed. A structured MCP tool surface can expose specific actions and return data or diagnostics about the request.",
+          "Premiere Pro MCP combines that structure with a local-first bridge. The server registers 285 core tools, with capabilities and authority reported separately from static tool support. That matters when different Premiere versions, permission settings, and connection states change what is safe to run. The correct path is to discover the available surface and verify the particular operation at call time.",
+        ],
+      },
+      {
+        heading: "Start with one workflow you already repeat",
+        paragraphs: [
+          "Pick a workflow that happens every week and has a simple success condition. It might be creating a consistent bin layout for incoming footage, placing approved selects onto a review sequence, preparing a proxy report, or queueing a standard export. Write the steps as you would hand them to a careful assistant, including what must not change.",
+          "Install the local server and Premiere connector, run the read-only connection check, and try the workflow on a duplicate project or small test sequence. Once the returned state matches expectations, keep the prompt as a team-ready recipe. Building confidence one bounded workflow at a time is more valuable than asking for an all-purpose autonomous edit.",
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: "What Premiere Pro tasks should I automate first?",
+        answer:
+          "Start with a frequent, low-risk task that has a concrete outcome: project inventory, bin organization, known timeline placement, proxy checking, marker preparation, or a standard export setup.",
+      },
+      {
+        question: "How do I know an automated edit worked?",
+        answer:
+          "Ask the assistant to inspect the resulting sequence or project state, and review returned confirmation or diagnostics. Do not rely on a tool call having been attempted as evidence that it succeeded.",
+      },
+      {
+        question: "Can I run the server remotely?",
+        answer:
+          "A remote HTTP transport exists, but it requires authentication and a functioning connection to the local Premiere bridge. The local setup is the recommended route for most editors.",
+      },
+    ],
+    resources: [
+      { label: "See the supported capability categories", href: "/docs/" },
+      { label: "Read the full README and setup guidance", href: "https://github.com/leancoderkavy/premiere-pro-mcp#readme" },
+      { label: "Explore AI-assisted Premiere workflows", href: "/blog/ai-video-editing-with-premiere-pro/" },
+    ],
+  },
+]
+
+export const articleBySlug = new Map(articles.map((article) => [article.slug, article]))

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -4,6 +4,10 @@ Premiere Pro MCP is an open-source, local-first Model Context Protocol server th
 
 Canonical website: https://premiere-pro-mcp.com/
 Documentation: https://premiere-pro-mcp.com/docs/
+Guides: https://premiere-pro-mcp.com/blog/
+Guide: What is a Premiere Pro MCP server?: https://premiere-pro-mcp.com/blog/what-is-a-premiere-pro-mcp-server/
+Guide: AI video editing with Premiere Pro: https://premiere-pro-mcp.com/blog/ai-video-editing-with-premiere-pro/
+Guide: Premiere Pro workflow automation: https://premiere-pro-mcp.com/blog/premiere-pro-workflow-automation/
 Source: https://github.com/leancoderkavy/premiere-pro-mcp
 npm: https://www.npmjs.com/package/premiere-pro-mcp
 License: MIT

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -8,6 +8,10 @@ Premiere Pro MCP registers 285 core structured tools for timeline editing, effec
 
 - Website: https://premiere-pro-mcp.com/
 - Documentation: https://premiere-pro-mcp.com/docs/
+- Guides: https://premiere-pro-mcp.com/blog/
+- What is a Premiere Pro MCP server?: https://premiere-pro-mcp.com/blog/what-is-a-premiere-pro-mcp-server/
+- AI video editing with Premiere Pro: https://premiere-pro-mcp.com/blog/ai-video-editing-with-premiere-pro/
+- Premiere Pro workflow automation: https://premiere-pro-mcp.com/blog/premiere-pro-workflow-automation/
 - Source and documentation: https://github.com/leancoderkavy/premiere-pro-mcp
 - npm package: https://www.npmjs.com/package/premiere-pro-mcp
 - Releases: https://github.com/leancoderkavy/premiere-pro-mcp/releases


### PR DESCRIPTION
## Summary
- add three static, intent-specific Premiere Pro MCP guides plus the `/blog/` hub
- add sitemap, footer, LLM context, and launch-kit coverage for the new guides
- replace the generic hero image with an accessible, interactive project-context workflow that maps real MCP tools and their review boundaries
- add the project-context workflow to docs and record visual QA evidence

## Validation
- `npm run lint` (landing)
- `npm run build` (landing; 14 static routes)
- `git diff --check origin/main...HEAD`
- local desktop/mobile, keyboard, CTA-anchor, and console-error checks

## Evidence boundary
This PR is locally validated landing/static content. It does not claim deployment, public indexing, or a live Premiere-host editing test.