### PR TITLE
fix: support MOGRT strings and diagnose empty QE catalogs

### DIFF
--- a/src/bridge/script-builder.ts
+++ b/src/bridge/script-builder.ts
@@ -116,6 +116,50 @@ function __findClip(nodeId) {
   return null;
 }
 
+// CEP's legacy QE path can enumerate a host's effect catalog before adding an
+// effect to a timeline clip. Recent Premiere builds can expose QE yet return an
+// empty catalog, so distinguish that host limitation from a misspelled effect
+// name. Calling addVideoEffect/addAudioEffect without a catalog entry is not a
+// safe fallback; an available UXP bridge has its own documented effect workflow.
+function __getQeEffectCatalog(kind) {
+  var label = kind === "audio" ? "audio" : "video";
+  if (typeof app === "undefined" || typeof app.enableQE !== "function") {
+    return { ok: false, error: "QE is unavailable in this Premiere build, so " + label + " effects cannot be enumerated or applied." };
+  }
+
+  try {
+    app.enableQE();
+  } catch (eEnable) {
+    return { ok: false, error: "Premiere could not enable QE for " + label + " effect discovery: " + eEnable.toString() };
+  }
+
+  if (typeof qe === "undefined" || !qe.project) {
+    return { ok: false, error: "QE did not expose a project after enableQE(), so " + label + " effects cannot be enumerated or applied." };
+  }
+
+  var getter = kind === "audio" ? qe.project.getAudioEffectList : qe.project.getVideoEffectList;
+  if (typeof getter !== "function") {
+    return { ok: false, error: "This Premiere QE build does not expose the " + label + " effect catalog API." };
+  }
+
+  var effects = null;
+  try {
+    effects = getter.call(qe.project);
+  } catch (eList) {
+    return { ok: false, error: "Premiere could not read its QE " + label + " effect catalog: " + eList.toString() };
+  }
+
+  var count = effects && typeof effects.numItems !== "undefined" ? Number(effects.numItems) : NaN;
+  if (isNaN(count) || count < 1) {
+    return {
+      ok: false,
+      error: "Premiere returned an empty legacy QE " + label + " effect catalog; no effect was applied. If the authenticated Premiere UXP bridge is connected, use manage_clip_effects_uxp with action 'catalog' and then 'add' instead. Existing clip components can still be inspected or edited."
+    };
+  }
+
+  return { ok: true, effects: effects, count: count };
+}
+
 function __getAllClips(seq) {
   if (!seq) seq = app.project.activeSequence;
   if (!seq) return [];

--- a/src/tools/effects.ts
+++ b/src/tools/effects.ts
@@ -40,7 +40,9 @@ export function getEffectsTools(bridgeOptions: BridgeOptions) {
           if (!qeClip) return __error("QE clip not found");
           
           // Search for the effect
-          var effects = qe.project.getVideoEffectList();
+          var effectCatalog = __getQeEffectCatalog("video");
+          if (!effectCatalog.ok) return __error(effectCatalog.error);
+          var effects = effectCatalog.effects;
           var found = false;
           for (var i = 0; i < effects.numItems; i++) {
             if (effects[i].name === effectName) {
@@ -89,7 +91,9 @@ export function getEffectsTools(bridgeOptions: BridgeOptions) {
           var qeClip = qeTrack.getItemAt(result.clipIndex);
           if (!qeClip) return __error("QE clip not found");
           
-          var effects = qe.project.getAudioEffectList();
+          var effectCatalog = __getQeEffectCatalog("audio");
+          if (!effectCatalog.ok) return __error(effectCatalog.error);
+          var effects = effectCatalog.effects;
           var found = false;
           for (var i = 0; i < effects.numItems; i++) {
             if (effects[i].name === effectName) {
@@ -186,7 +190,9 @@ export function getEffectsTools(bridgeOptions: BridgeOptions) {
       handler: async () => {
         const script = buildToolScript(`
           app.enableQE();
-          var effects = qe.project.getVideoEffectList();
+          var effectCatalog = __getQeEffectCatalog("video");
+          if (!effectCatalog.ok) return __error(effectCatalog.error);
+          var effects = effectCatalog.effects;
           var list = [];
           for (var i = 0; i < effects.numItems; i++) {
             list.push({ name: effects[i].name, index: i });
@@ -203,7 +209,9 @@ export function getEffectsTools(bridgeOptions: BridgeOptions) {
       handler: async () => {
         const script = buildToolScript(`
           app.enableQE();
-          var effects = qe.project.getAudioEffectList();
+          var effectCatalog = __getQeEffectCatalog("audio");
+          if (!effectCatalog.ok) return __error(effectCatalog.error);
+          var effects = effectCatalog.effects;
           var list = [];
           for (var i = 0; i < effects.numItems; i++) {
             list.push({ name: effects[i].name, index: i });
@@ -301,7 +309,9 @@ export function getEffectsTools(bridgeOptions: BridgeOptions) {
           if (!hasLumetri) {
             var qeTrack = qeSeq.getVideoTrackAt(result.trackIndex);
             var qeClip = qeTrack.getItemAt(result.clipIndex);
-            var effects = qe.project.getVideoEffectList();
+            var effectCatalog = __getQeEffectCatalog("video");
+            if (!effectCatalog.ok) return __error(effectCatalog.error);
+            var effects = effectCatalog.effects;
             for (var i = 0; i < effects.numItems; i++) {
               if (effects[i].name === "Lumetri Color") {
                 qeClip.addVideoEffect(effects[i]);
@@ -374,7 +384,9 @@ export function getEffectsTools(bridgeOptions: BridgeOptions) {
             var qeSeq = qe.project.getActiveSequence();
             var qeTrack = qeSeq.getVideoTrackAt(result.trackIndex);
             var qeClip = qeTrack.getItemAt(result.clipIndex);
-            var effects = qe.project.getVideoEffectList();
+            var effectCatalog = __getQeEffectCatalog("video");
+            if (!effectCatalog.ok) return __error(effectCatalog.error);
+            var effects = effectCatalog.effects;
             for (var i = 0; i < effects.numItems; i++) {
               if (effects[i].name === "Lumetri Color") {
                 qeClip.addVideoEffect(effects[i]);
@@ -446,7 +458,9 @@ export function getEffectsTools(bridgeOptions: BridgeOptions) {
           if (!qeClip) return __error("QE clip not found");
           
           // Find and apply Warp Stabilizer
-          var effects = qe.project.getVideoEffectList();
+          var effectCatalog = __getQeEffectCatalog("video");
+          if (!effectCatalog.ok) return __error(effectCatalog.error);
+          var effects = effectCatalog.effects;
           var found = false;
           for (var i = 0; i < effects.numItems; i++) {
             if (effects[i].name === "Warp Stabilizer") {

--- a/src/tools/keyframes.ts
+++ b/src/tools/keyframes.ts
@@ -80,13 +80,17 @@ export function getKeyframeTools(bridgeOptions: BridgeOptions) {
             description: "Display name of the property (e.g., 'Scale', 'Position', 'Opacity')",
           },
           value: {
-            type: "number",
-            description: "Value to set",
+            type: ["number", "string"],
+            maxLength: 8192,
+            description: "Number or string value to set. Use the exact JSON string reported for a MOGRT text or graphic parameter.",
           },
         },
         required: ["node_id", "effect_name", "property_name", "value"],
       },
-      handler: async (args: { node_id: string; effect_name: string; property_name: string; value: number }) => {
+      handler: async (args: { node_id: string; effect_name: string; property_name: string; value: number | string }) => {
+        const requestedValue = typeof args.value === "string"
+          ? `"${escapeForExtendScript(args.value)}"`
+          : String(args.value);
         const script = buildToolScript(`
           var result = __findClip("${escapeForExtendScript(args.node_id)}");
           if (!result) return __error("Clip not found");
@@ -110,12 +114,30 @@ export function getKeyframeTools(bridgeOptions: BridgeOptions) {
           }
           if (!prop) return __error("Property not found: ${escapeForExtendScript(args.property_name)}");
           
-          prop.setValue(${args.value}, true);
+          var requestedValue = ${requestedValue};
+          try {
+            prop.setValue(requestedValue, true);
+          } catch (e) {
+            return __error("Premiere could not set the requested effect property: " + e.toString());
+          }
+
+          var readbackValue;
+          var readbackAvailable = true;
+          try {
+            readbackValue = prop.getValue();
+          } catch (eReadback) {
+            readbackAvailable = false;
+          }
           return __result({
             set: true,
             effect: "${escapeForExtendScript(args.effect_name)}",
             property: "${escapeForExtendScript(args.property_name)}",
-            value: ${args.value}
+            value: readbackAvailable ? readbackValue : requestedValue,
+            requestedValue: requestedValue,
+            readbackVerified: readbackAvailable && readbackValue === requestedValue,
+            verification: readbackAvailable
+              ? "Premiere parameter readback only; verify playback or exported frames before delivery."
+              : "Premiere accepted the parameter write, but this property did not expose a readback value. Verify playback or exported frames before delivery."
           });
         `);
         return sendCommand(script, bridgeOptions);

--- a/tests/tools/regressions.test.ts
+++ b/tests/tools/regressions.test.ts
@@ -300,6 +300,49 @@ describe("issue #189 — Premiere 26.3 capability boundaries and macOS presets",
   });
 });
 
+// https://github.com/leancoderkavy/premiere-pro-mcp/issues/194
+describe("issue #194 — string-backed MOGRT effect properties", () => {
+  const keyframes = getKeyframeTools(bridgeOptions);
+
+  it("accepts and safely serializes the JSON string exposed by MOGRT text properties", async () => {
+    expect(keyframes.set_effect_property.parameters.properties.value).toMatchObject({
+      type: ["number", "string"],
+    });
+
+    const script = await scriptFor(keyframes.set_effect_property, {
+      node_id: "clip-1",
+      effect_name: "AE.ADBE Capsule",
+      property_name: "Source Text",
+      value: '{"textEditValue":"Hello \\"editor\\""}',
+    });
+
+    expect(script).toContain('var requestedValue = "{\\"textEditValue\\":\\"Hello \\\\\\\"editor\\\\\\\"\\"}";');
+    expect(script).toContain("prop.setValue(requestedValue, true)");
+    expect(script).toContain("readbackVerified: readbackAvailable && readbackValue === requestedValue");
+  });
+});
+
+// https://github.com/leancoderkavy/premiere-pro-mcp/issues/196
+describe("issue #196 — empty Premiere 26.x QE effect catalogs", () => {
+  const effects = getEffectsTools(bridgeOptions);
+
+  it("routes an empty legacy QE catalog to the documented UXP effect workflow, not an effect-name miss", async () => {
+    const script = await scriptFor(effects.apply_effect, {
+      node_id: "clip-1",
+      effect_name: "Transform",
+    });
+
+    expect(script).toContain('var effectCatalog = __getQeEffectCatalog("video")');
+    expect(script).toContain("if (!effectCatalog.ok) return __error(effectCatalog.error)");
+
+    const helpers = getHelpersSource();
+    expect(helpers).toContain("function __getQeEffectCatalog(kind)");
+    expect(helpers).toContain("Premiere returned an empty legacy QE");
+    expect(helpers).toContain("no effect was applied");
+    expect(helpers).toContain("manage_clip_effects_uxp");
+  });
+});
+
 // https://github.com/leancoderkavy/premiere-pro-mcp/issues/129
 describe("issue #129 — CEP component removal is capability-gated", () => {
   const effects = getEffectsTools(bridgeOptions);

--- a/tests/tools/tool-modules.test.ts
+++ b/tests/tools/tool-modules.test.ts
@@ -138,9 +138,12 @@ describe("Tool Module Structure", () => {
           if (props) {
             for (const [propName, prop] of Object.entries(props) as [string, any][]) {
               expect(prop.type, `${name}.${propName} type`).toBeDefined();
+              const types = Array.isArray(prop.type) ? prop.type : [prop.type];
               expect(
-                ["string", "number", "integer", "boolean", "array", "object"].includes(prop.type),
-                `${name}.${propName} has valid type "${prop.type}"`
+                types.length > 0 && types.every((type) =>
+                  ["string", "number", "integer", "boolean", "array", "object"].includes(type)
+                ),
+                `${name}.${propName} has valid type "${types.join(",")}"`
               ).toBe(true);
             }
           }


### PR DESCRIPTION
## Summary
- allow set_effect_property to receive escaped string values as well as numbers, with parameter readback status for MOGRT/graphic payloads
- centralize legacy QE effect-catalog discovery so an empty Premiere 26.x catalog returns a specific no-mutation capability response instead of Effect not found
- direct affected users to the existing documented UXP catalog/add workflow when its authenticated bridge is connected
- cover JSON-Schema type unions and both issue regressions

## Verification
- 
pm run lint
- 
pm run build
- 
pm run docs:supported-actions:check
- 
pm test -- tests/tools/regressions.test.ts tests/tools/tool-modules.test.ts (295 tests)
- 
pm test (1,576 tests)
- git diff --check

## Host boundary
This has not been exercised in a licensed Premiere 26.x host. The UXP fallback guidance is based on Premiere's documented VideoFilterFactory and component-chain action APIs; a host check should confirm the reporter's MOGRT and localized effects workflow.