### PR TITLE
chore: release v1.12.2

### DIFF
--- a/.agents/product-marketing.md
+++ b/.agents/product-marketing.md
@@ -137,7 +137,7 @@
 
 ## Proof Points
 
-**Release-backed facts:** v1.12.1 registers 287 core tools; the default profile exposes 285; an authenticated compatible UXP host can add 50 capability-gated tools for a 335-tool connected surface. The release also declares 33 modules, 4 MCP resources, and 10 workflow prompts. These are catalog and packaging facts from `release-metadata.json`, not a promise that a particular host operation will work.
+**Release-backed facts:** v1.12.2 registers 287 core tools; the default profile exposes 285; an authenticated compatible UXP host can add 50 capability-gated tools for a 335-tool connected surface. The release also declares 33 modules, 4 MCP resources, and 10 workflow prompts. These are catalog and packaging facts from `release-metadata.json`, not a promise that a particular host operation will work.
 
 **Compatibility boundary:** The release targets Premiere Pro 2020–2026; UXP workflows require a compatible Premiere Pro 25.6.0+ host and advertised capabilities. CEP remains the default compatibility route. A compatibility range, package validation, CI pass, HTTP health check, or local build is not real-host proof.
 
@@ -176,6 +176,7 @@
 
 - v6 (2026-08-22) — Added privacy-bounded acquisition attribution and the paid-acquisition measurement gate after production-readiness hardening.
 - v5 (2026-08-22) — Repositioned around reviewable workflow automation; refreshed v1.12.1 release facts, ICP, Adobe AI Assistant overlap, commercial hypotheses, and explicit proof boundaries.
+- v6 (2026-08-22) — Released v1.12.2 with string-backed MOGRT property inputs and clearer legacy-QE effect-catalog diagnostics; real Premiere host validation remains separate.
 - v4 (2026-08-20) — Added the project-context review workflow and client-choice differentiation after Adobe AI Assistant comparison.
 - v3 (2026-08-19) — Updated proof counts for v1.11.4 and added the organic article strategy and activation path.
 - v2 (2026-08-15) — Expanded audience, differentiation, objections, brand voice, proof, and activation goals; aligned the current 280-core and 307-connected tool surfaces.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "premiere-pro",
       "source": "./claude-plugins/premiere-pro",
       "description": "Inspect, edit, verify, and export local Premiere Pro projects through MCP.",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "category": "creative",
       "tags": ["premiere-pro", "video-editing", "mcp"]
     }

--- a/.github/ISSUE_TEMPLATE/compatibility_report.yml
+++ b/.github/ISSUE_TEMPLATE/compatibility_report.yml
@@ -14,7 +14,7 @@ body:
     id: versions
     attributes:
       label: Premiere Pro and MCP versions
-      placeholder: Premiere 26.3.0, Premiere Pro MCP 1.12.1
+      placeholder: Premiere 26.3.0, Premiere Pro MCP 1.12.2
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/tool_failure.yml
+++ b/.github/ISSUE_TEMPLATE/tool_failure.yml
@@ -17,7 +17,7 @@ body:
     id: package-version
     attributes:
       label: Premiere Pro MCP version
-      placeholder: 1.12.1
+      placeholder: 1.12.2
     validations:
       required: true
   - type: input

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.12.2] - 2026-08-22
+
+### Fixed
+
+- `set_effect_property` now accepts safely serialized string values as well as
+  numbers, unlocking MOGRT and graphic parameters that Premiere exposes as
+  JSON strings. Responses report parameter readback separately from render
+  verification.
+- An empty legacy QE effect catalog now returns a clear no-mutation capability
+  response rather than incorrectly reporting a requested effect as missing.
+  When connected, the documented UXP effect catalog and transaction workflow is
+  the supported alternative.
+
 ## [1.12.1] - 2026-08-22
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -31,16 +31,17 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 
 The AI handles the entire workflow through 287 core tools spanning the supported ExtendScript, QE DOM, revisioned project-context retrieval, safe edit-planning, and connection-verification surfaces. A compatible, authenticated UXP panel adds 50 documented, capability-gated tools without replacing the production CEP bridge.
 
-### Latest release: 1.12.1
+### Latest release: 1.12.2
 
-- **MCP safety research:** ten documented recommendations now cover subscription streams,
-  contextual completions, workspace boundaries, resource metadata and canonical URIs.
-- **Trust boundaries:** the recommendations define prompt/resource-injection defenses, layered
-  end-to-end health checks, C2PA inspection limits, and UXP external-launch safeguards.
-- **Verification clarity:** semantic keyframe verification is scoped separately from implementation
-  and licensed Premiere Pro host confirmation.
+- **MOGRT text and graphics:** `set_effect_property` now accepts string-backed
+  parameters with safe serialization and readback status.
+- **Effect discovery clarity:** an empty legacy QE effect catalog now returns a
+  no-mutation capability response and directs connected hosts to the documented
+  UXP catalog/add workflow.
+- **Verification clarity:** property readback remains distinct from playback or
+  exported-frame verification in a licensed Premiere Pro host.
 
-See the [v1.12.1 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.12.1)
+See the [v1.12.2 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.12.2)
 for complete details. Live installation in Premiere Pro still requires host verification.
 
 ---
@@ -49,9 +50,9 @@ for complete details. Live installation in Premiere Pro still requires host veri
 
 ### Easiest supported path: Claude Desktop
 
-1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.12.1/premiere-pro-mcp-1.12.1.mcpb).
+1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.12.2/premiere-pro-mcp-1.12.2.mcpb).
 2. In Claude Desktop, open **Settings > Extensions > Advanced settings > Install Extension**, select the downloaded bundle, and restart Claude Desktop.
-3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.12.1/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
+3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.12.2/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
 4. Restart Premiere, open a project, then open **Window > Extensions > MCP for Adobe Premiere Pro**.
 5. In Claude, enter: `Safely check my Premiere connection with verify_premiere_connection. Make no changes.`
 
@@ -275,11 +276,11 @@ From a clone of this repository:
 ```bash
 codex plugin marketplace add .
 codex plugin add premiere-pro@premiere-pro-mcp
-npx -y premiere-pro-mcp@1.12.1 --install-cep
+npx -y premiere-pro-mcp@1.12.2 --install-cep
 ```
 
 Restart Premiere Pro and start a new Codex session after installation. The plugin
-launches `premiere-pro-mcp@1.12.1` through `npx`; the separate CEP installation is
+launches `premiere-pro-mcp@1.12.2` through `npx`; the separate CEP installation is
 required because the MCP server communicates with the running Premiere host through
 the local bridge.
 
@@ -299,7 +300,7 @@ For Claude Code, add this repository as a marketplace and install the plugin:
 Then install the Premiere bridge and start a new Claude Code session:
 
 ```bash
-npx -y premiere-pro-mcp@1.12.1 --install-cep
+npx -y premiere-pro-mcp@1.12.2 --install-cep
 ```
 
 The Claude Code package lives in

--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.12.1" ExtensionBundleName="MCP for Adobe Premiere Pro">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.12.2" ExtensionBundleName="MCP for Adobe Premiere Pro">
   <ExtensionList>
-    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.12.1"/>
-    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.12.1"/>
+    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.12.2"/>
+    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.12.2"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/cep-plugin/index.html
+++ b/cep-plugin/index.html
@@ -81,7 +81,7 @@
     <section class="update-section" aria-live="polite">
       <div class="update-copy">
         <span class="section-label">Connector updates</span>
-        <strong id="updateTitle">Version 1.12.1</strong>
+        <strong id="updateTitle">Version 1.12.2</strong>
         <span id="updateDetail">Checking for updates…</span>
       </div>
       <button id="btnUpdate" class="button button-update" onclick="handleUpdateClick()" type="button" disabled>

--- a/cep-plugin/updater.cjs
+++ b/cep-plugin/updater.cjs
@@ -7,7 +7,7 @@
 })(this, function () {
   "use strict";
 
-  var CURRENT_VERSION = "1.12.1";
+  var CURRENT_VERSION = "1.12.2";
   var LATEST_RELEASE_API =
     "https://api.github.com/repos/leancoderkavy/premiere-pro-mcp/releases/latest";
   var RELEASES_URL =

--- a/claude-desktop/manifest.json
+++ b/claude-desktop/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "premiere-pro-mcp",
   "display_name": "MCP for Adobe Premiere Pro",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "Control a local Adobe Premiere Pro project through MCP.",
   "long_description": "Inspect projects, assemble and modify timelines, manage media, effects, audio and captions, and export deliverables through a local bridge to Adobe Premiere Pro.",
   "author": {

--- a/claude-plugins/premiere-pro/.claude-plugin/plugin.json
+++ b/claude-plugins/premiere-pro/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "premiere-pro",
   "displayName": "Premiere Pro MCP",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "Inspect, edit, verify, and export local Adobe Premiere Pro projects through MCP.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/claude-plugins/premiere-pro/.mcp.json
+++ b/claude-plugins/premiere-pro/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "premiere-pro": {
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.12.1"]
+      "args": ["-y", "premiere-pro-mcp@1.12.2"]
     }
   }
 }

--- a/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.12.1 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.12.2 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -5,6 +5,20 @@ import { product } from "@/lib/product"
 
 const releases = [
   {
+    version: "1.12.2",
+    date: "2026-08-22",
+    label: "MOGRT values and QE catalog diagnostics",
+    groups: [
+      {
+        title: "Fixed",
+        items: [
+          "Allowed string-backed MOGRT and graphic effect properties, with parameter readback status that remains distinct from render verification.",
+          "Made empty legacy QE effect catalogs fail clearly without a mutation and point connected hosts to the documented UXP catalog and transaction workflow.",
+        ],
+      },
+    ],
+  },
+  {
     version: "1.12.1",
     date: "2026-08-22",
     label: "Analytics CSP compatibility",

--- a/landing/lib/product.ts
+++ b/landing/lib/product.ts
@@ -1,6 +1,6 @@
 export const product = {
   name: "MCP for Adobe Premiere Pro",
-  version: "1.12.1",
+  version: "1.12.2",
   releaseDate: "2026-08-22",
   coreToolCount: 287,
   defaultProfileToolCount: 285,
@@ -10,10 +10,10 @@ export const product = {
   uxpMinimumVersion: "25.6",
   downloads: {
     claudeBundle:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.12.1/premiere-pro-mcp-1.12.1.mcpb",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.12.2/premiere-pro-mcp-1.12.2.mcpb",
     signedCepConnector:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.12.1/MCPBridgeCEP.zxp",
-    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.12.1",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.12.2/MCPBridgeCEP.zxp",
+    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.12.2",
   },
   links: {
     repository: "https://github.com/leancoderkavy/premiere-pro-mcp",

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -11,7 +11,7 @@ Guide: Premiere Pro workflow automation: https://premiere-pro-mcp.com/blog/premi
 Source: https://github.com/leancoderkavy/premiere-pro-mcp
 npm: https://www.npmjs.com/package/premiere-pro-mcp
 License: MIT
-Current release: 1.12.1
+Current release: 1.12.2
 
 ## What it does
 

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -28,7 +28,7 @@ The recommended setup runs the MCP server and CEP bridge locally. Project media 
 
 ## Verified facts
 
-- Current project release: 1.12.1.
+- Current project release: 1.12.2.
 - Tool surface: 287 core structured MCP tools are registered; the default profile exposes 285. With an authenticated compatible UXP panel, 50 additional capability-gated tools bring the connected surface to 335. The server also exposes 4 resources and 10 workflow prompts.
 - Supported desktop platforms: Windows and macOS.
 - Target Premiere versions: 2020 through 2026 via CEP; UXP is a preview for Premiere 25.6 and newer.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "premiere-pro-mcp",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "MCP server for Adobe Premiere Pro with 287 core AI video editing tools and a capability-aware UXP bridge for supported Premiere workflows.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/premiere-pro/.codex-plugin/plugin.json
+++ b/plugins/premiere-pro/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "Plan, execute, verify, and export video edits in Adobe Premiere Pro through the Premiere Pro MCP server.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/plugins/premiere-pro/.mcp.json
+++ b/plugins/premiere-pro/.mcp.json
@@ -4,7 +4,7 @@
       "title": "Premiere Pro MCP",
       "description": "Inspect and edit a local Adobe Premiere Pro project through the Premiere Pro MCP bridge.",
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.12.1"]
+      "args": ["-y", "premiere-pro-mcp@1.12.2"]
     }
   }
 }

--- a/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.12.1 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.12.2 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.1",
+  "version": "1.12.2",
   "coreTools": 287,
   "defaultProfileTools": 285,
   "uxpAdditionalTools": 50,

--- a/uxp-plugin/manifest.json
+++ b/uxp-plugin/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.ppmcp.premiere.uxp",
   "name": "MCP for Adobe Premiere Pro",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "main": "index.html",
   "host": { "app": "premierepro", "minVersion": "25.6.0" },
   "entrypoints": [


### PR DESCRIPTION
## Release v1.12.2

Patch release for the merged MOGRT effect-property value support and clear no-mutation diagnostics when the legacy QE effect catalog is unavailable. Includes the merged production-readiness changes from #200.

## Validation
- `npm run lint`
- `npm run build`
- `npm run docs:supported-actions:check`
- `npm run check:release-metadata`
- `node scripts/validate-distribution.mjs --all`
- `npm test` (57 files, 1,593 tests)
- `npm run test:coverage` (93.65% statements)
- root and landing production dependency audits
- root and landing production builds
- Claude Desktop bundle build and signed CEP package verification

## Release sequence
After merge: publish npm from `main`, create `v1.12.2` GitHub release, then deploy the merged SHA to Fly.