### PR TITLE
feat(marketing): execute Premiere acquisition funnel

### DIFF
--- a/docs/marketing/community-launch-kit.md
+++ b/docs/marketing/community-launch-kit.md
@@ -1,0 +1,73 @@
+# Premiere Pro MCP community launch kit
+
+**Status:** prepared drafts only. Nothing in this file has been posted, sent, or scheduled.
+
+## Use this only when it helps the current conversation
+
+- Check each community's self-promotion rules before posting.
+- Answer the workflow question first. Link a guide only when it genuinely answers the follow-up.
+- Never represent illustrated site assets as a live Premiere session.
+- Do not claim every tool or host version will work. Direct readers to the read-only connection check and capability inspection.
+- Do not say the local server changes the privacy terms of the AI client the reader chooses.
+- Do not contact people from this document without an approved contact list and owner authorization.
+
+## Owned social draft
+
+AI editing is most useful when it removes repeated Premiere work without hiding the edit.
+
+Premiere Pro MCP is a free, MIT-licensed local bridge between a compatible AI client and supported Premiere workflows. Start with a read-only connection check, inspect the project, preview a bounded request, and verify the returned result before relying on it.
+
+Practical setup and workflow guides: `https://premiere-pro-mcp.com/blog/?utm_source=linkedin&utm_medium=organic_social&utm_campaign=premiere_workflow_guides`
+
+## Technical-community draft
+
+I maintain an open-source MCP server for supported Adobe Premiere Pro workflows. The goal is not autonomous editing. It is to make repeated work inspectable: check the connection, inspect a project, create a non-mutating plan where available, preview it, and verify the returned result.
+
+The project is local-first and independent from Adobe's AI Assistant. This guide compares the workflows without claiming either is universally better:
+
+`https://premiere-pro-mcp.com/blog/adobe-premiere-ai-assistant-vs-mcp/?utm_source=community&utm_medium=organic_referral&utm_campaign=premiere_workflow_comparison`
+
+Useful feedback: installation friction, capability boundaries, and the first repeatable Premiere task a team would test.
+
+## Editorial-community reply pattern
+
+1. Name the specific Premiere task the person is trying to repeat.
+2. Share one concrete, non-promotional way to make it safer: define the target sequence, what must not change, and how the result will be checked.
+3. If the person asks for a tool or implementation, disclose the project relationship and link the one relevant guide.
+4. Invite correction or workflow details. Do not push a download.
+
+## Design-partner interview invitation draft
+
+**Subject:** Could we map one repeatable Premiere workflow?
+
+Hi [name],
+
+I maintain Premiere Pro MCP, an open-source local bridge for reviewable Premiere workflows through compatible AI clients. I am looking to learn how post teams handle one repeated task such as project intake, cutdown preparation, or delivery checks.
+
+This is a 30-minute research conversation, not a product-sale call. We will map the current steps, what must stay under editor control, and what evidence would make an automation trustworthy. We will not ask for project media, client footage, credentials, or confidential project names.
+
+If it is useful, I can send the workflow questions in advance.
+
+Thanks,
+Premiere Pro MCP contributors
+
+## Interview guide
+
+- Which Premiere task repeats often enough to document?
+- What triggers it, who owns it, and where does handoff fail?
+- What input must an assistant see, and what must it never change?
+- What output would prove the workflow succeeded?
+- Which host versions and AI clients are involved?
+- What would make setup too risky or too time-consuming?
+- May we retain this feedback anonymously? Do not record customer claims or quotes without separate written approval.
+
+## Measurement
+
+Use campaign links with the existing allowlisted UTM format:
+
+- `utm_source`: channel or named partner
+- `utm_medium`: `organic_social`, `referral`, or `email`
+- `utm_campaign`: `premiere_workflow_guides` or another stable lowercase campaign ID
+- `utm_content`: a stable creative ID when variants are tested
+
+Primary success signal: a completed read-only connection check and an observable first workflow result. Likes, impressions, stars, and downloads are diagnostic only.

--- a/docs/marketing/mcp-registry-readiness.md
+++ b/docs/marketing/mcp-registry-readiness.md
@@ -1,0 +1,29 @@
+# MCP Registry readiness
+
+**Status:** prepared for review; not submitted to any registry.
+
+The official MCP Registry is a separate public listing. A repository change, an npm package, or a GitHub release does not create a listing. Submission requires a user-authorized registry login and publication action.
+
+Before a future submission:
+
+1. Release a new npm package version containing any required registry metadata.
+2. Generate and inspect the registry manifest from the exact released package.
+3. Confirm the listing describes the published local stdio/server route accurately; do not present the local Premiere bridge as a hosted service.
+4. Validate the manifest and package version before authenticating.
+5. Obtain action-time approval, authenticate, and publish once.
+6. Query the registry for the exact listing name and retain the returned URL as public evidence.
+
+Use only these evidence-bounded facts in a future directory entry:
+
+- Free, MIT-licensed, local-first MCP server for supported Premiere Pro workflows.
+- A compatible AI client calls structured tools through a local Premiere connection.
+- Begin with `verify_premiere_connection`; support remains capability- and host-dependent.
+- The chosen AI client's privacy behavior is separate from the server's local-first recommendation.
+
+Do not submit until the package version, transport, authentication expectations, privacy disclosures, and source URL are all verified for that directory.
+
+Official references:
+
+- <https://modelcontextprotocol.io/registry/quickstart>
+- <https://registry.modelcontextprotocol.io/docs>
+- <https://modelcontextprotocol.io/registry/faq>

--- a/landing/app/blog/[slug]/page.tsx
+++ b/landing/app/blog/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next"
 import Link from "next/link"
 import { notFound } from "next/navigation"
+import { TrackedLink } from "@/components/ui/tracked-link"
 import { articleBySlug, articles } from "@/lib/articles"
 
 type ArticlePageProps = {
@@ -8,6 +9,18 @@ type ArticlePageProps = {
 }
 
 export const dynamic = "force-static"
+const socialImage = "/marketing/premiere-pro-mcp-social-square-v1.png"
+
+const articleDateFormatter = new Intl.DateTimeFormat("en-US", {
+  day: "numeric",
+  month: "long",
+  timeZone: "UTC",
+  year: "numeric",
+})
+
+function formatArticleDate(date: string) {
+  return articleDateFormatter.format(new Date(`${date}T00:00:00Z`))
+}
 
 export function generateStaticParams() {
   return articles.map(({ slug }) => ({ slug }))
@@ -34,6 +47,13 @@ export async function generateMetadata({ params }: ArticlePageProps): Promise<Me
       publishedTime: article.publishedAt,
       modifiedTime: article.modifiedAt,
       authors: ["MCP for Adobe Premiere Pro contributors"],
+      images: [{ url: socialImage, width: 1254, height: 1254, alt: "Premiere Pro MCP — reviewable workflow automation" }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: article.title,
+      description: article.description,
+      images: [socialImage],
     },
   }
 }
@@ -68,6 +88,7 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
         publisher: { "@id": "https://premiere-pro-mcp.com/#organization" },
         mainEntityOfPage: articleUrl,
         keywords: article.keywords.join(", "),
+        image: `https://premiere-pro-mcp.com${socialImage}`,
       },
       {
         "@type": "FAQPage",
@@ -110,7 +131,7 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
             <h1 className="mt-5 text-balance text-4xl font-bold tracking-tight text-white sm:text-6xl">{article.title}</h1>
             <p className="mt-6 text-lg leading-8 text-zinc-400">{article.description}</p>
             <div className="mt-7 flex items-center gap-3 text-sm text-zinc-500">
-              <time dateTime={article.publishedAt}>Published August 19, 2026</time>
+              <time dateTime={article.publishedAt}>Published {formatArticleDate(article.publishedAt)}</time>
               <span aria-hidden="true">·</span>
               <span>{article.readingTime}</span>
             </div>
@@ -165,9 +186,14 @@ export default async function ArticlePage({ params }: ArticlePageProps) {
             <p className="mt-3 max-w-2xl leading-7 text-zinc-300">
               Connect your assistant, verify the local bridge without changing a project, then inspect the active sequence before requesting a supported edit.
             </p>
-            <Link href="/docs/" className="mt-6 inline-flex bg-purple-300 px-5 py-3 font-medium text-black transition-colors hover:bg-white">
-              Read the setup guide <span aria-hidden="true" className="ml-2">→</span>
-            </Link>
+            <TrackedLink
+              href="/#install"
+              trackingLocation={`guide:${article.slug}`}
+              trackingDestination="safe_connection_check"
+              className="mt-6 inline-flex bg-purple-300 px-5 py-3 font-medium text-black transition-colors hover:bg-white"
+            >
+              Run a safe connection check <span aria-hidden="true" className="ml-2">→</span>
+            </TrackedLink>
           </section>
 
           <aside className="border-t border-zinc-800 py-10" aria-labelledby="related-heading">

--- a/landing/app/blog/page.tsx
+++ b/landing/app/blog/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next"
 import Link from "next/link"
+import { TrackedLink } from "@/components/ui/tracked-link"
 import { articles } from "@/lib/articles"
 
 export const metadata: Metadata = {
@@ -36,6 +37,17 @@ const structuredData = {
   },
 }
 
+const articleDateFormatter = new Intl.DateTimeFormat("en-US", {
+  day: "numeric",
+  month: "long",
+  timeZone: "UTC",
+  year: "numeric",
+})
+
+function formatArticleDate(date: string) {
+  return articleDateFormatter.format(new Date(`${date}T00:00:00Z`))
+}
+
 export default function BlogPage() {
   return (
     <>
@@ -60,7 +72,7 @@ export default function BlogPage() {
             </p>
           </header>
 
-          <section className="grid gap-6 py-12 md:grid-cols-3" aria-label="MCP for Adobe Premiere Pro guides">
+          <section className="grid gap-6 py-12 md:grid-cols-2" aria-label="MCP for Adobe Premiere Pro guides">
             {articles.map((article, index) => (
               <article key={article.slug} className="flex min-h-full flex-col border border-zinc-800 bg-zinc-950 p-6 transition-colors hover:border-purple-400/60 sm:p-7">
                 <p className="font-mono text-xs font-medium uppercase tracking-[0.14em] text-purple-300">0{index + 1} · {article.eyebrow}</p>
@@ -69,7 +81,7 @@ export default function BlogPage() {
                 </h2>
                 <p className="mt-4 flex-1 leading-7 text-zinc-400">{article.description}</p>
                 <div className="mt-7 flex items-center justify-between border-t border-zinc-800 pt-5 text-sm">
-                  <time dateTime={article.publishedAt} className="text-zinc-500">August 19, 2026</time>
+                  <time dateTime={article.publishedAt} className="text-zinc-500">{formatArticleDate(article.publishedAt)}</time>
                   <Link href={`/blog/${article.slug}/`} className="font-medium text-purple-200 hover:text-white">
                     Read guide <span aria-hidden="true">→</span>
                   </Link>
@@ -84,9 +96,14 @@ export default function BlogPage() {
             <p className="mt-4 max-w-2xl leading-7 text-zinc-400">
               Install the local server and connector, verify the live bridge without changing a project, then inspect your first sequence.
             </p>
-            <Link href="/docs/" className="mt-6 inline-flex border border-purple-300 bg-purple-300 px-5 py-3 font-medium text-black transition-colors hover:bg-white">
-              Read the setup guide <span aria-hidden="true" className="ml-2">→</span>
-            </Link>
+            <TrackedLink
+              href="/#install"
+              trackingLocation="blog_hub"
+              trackingDestination="safe_connection_check"
+              className="mt-6 inline-flex border border-purple-300 bg-purple-300 px-5 py-3 font-medium text-black transition-colors hover:bg-white"
+            >
+              Run a safe connection check <span aria-hidden="true" className="ml-2">→</span>
+            </TrackedLink>
           </section>
         </div>
       </main>

--- a/landing/app/layout.tsx
+++ b/landing/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Script from "next/script";
 import "./globals.css";
+import { MarketingPageView } from "@/components/analytics/marketing-page-view";
 import { product } from "@/lib/product";
 
 const geistSans = Geist({
@@ -15,9 +16,9 @@ const geistMono = Geist_Mono({
 });
 
 const siteUrl = "https://premiere-pro-mcp.com";
-const title = "MCP for Adobe Premiere Pro – AI Video Editing Tools";
+const title = "Premiere Pro Workflow Automation | Local MCP Server";
 const description =
-  `Connect AI assistants to Adobe Premiere Pro with ${product.coreToolCount} local-first MCP tools for timeline editing, effects, color, media management, automation, and export.`;
+  "Use a compatible AI client to inspect local Premiere projects, preview bounded work, and verify supported workflow results before you rely on them.";
 const googleAnalyticsId =
   process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID ?? "G-XSH74T16E4";
 
@@ -63,7 +64,7 @@ export const metadata: Metadata = {
         url: "/marketing/premiere-pro-mcp-social-square-v1.png",
         width: 1254,
         height: 1254,
-        alt: "MCP for Adobe Premiere Pro — local AI-assisted video editing tools",
+        alt: "MCP for Adobe Premiere Pro — local-first, reviewable workflow automation",
       },
     ],
   },
@@ -104,6 +105,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <a className="skip-link" href="#main-content">Skip to main content</a>
+        <MarketingPageView />
         {children}
         {googleAnalyticsId ? (
           <>

--- a/landing/app/sitemap.ts
+++ b/landing/app/sitemap.ts
@@ -1,56 +1,48 @@
 import type { MetadataRoute } from "next"
+import { articles } from "@/lib/articles"
 
 export const dynamic = "force-static"
 
-const lastModified = new Date("2026-08-19")
+const siteUrl = "https://premiere-pro-mcp.com"
+const latestArticleDate = new Date(
+  `${articles.reduce((latest, article) => article.modifiedAt > latest ? article.modifiedAt : latest, articles[0].modifiedAt)}T00:00:00Z`,
+)
 
 export default function sitemap(): MetadataRoute.Sitemap {
   return [
     {
-      url: "https://premiere-pro-mcp.com/",
-      lastModified,
+      url: `${siteUrl}/`,
+      lastModified: latestArticleDate,
       changeFrequency: "weekly",
       priority: 1,
     },
     {
-      url: "https://premiere-pro-mcp.com/docs/",
-      lastModified,
+      url: `${siteUrl}/docs/`,
+      lastModified: latestArticleDate,
       changeFrequency: "weekly",
       priority: 0.8,
     },
     {
-      url: "https://premiere-pro-mcp.com/blog/",
-      lastModified,
+      url: `${siteUrl}/blog/`,
+      lastModified: latestArticleDate,
       changeFrequency: "weekly",
       priority: 0.9,
     },
-    {
-      url: "https://premiere-pro-mcp.com/blog/what-is-a-premiere-pro-mcp-server/",
-      lastModified,
-      changeFrequency: "monthly",
+    ...articles.map((article) => ({
+      url: `${siteUrl}/blog/${article.slug}/`,
+      lastModified: new Date(`${article.modifiedAt}T00:00:00Z`),
+      changeFrequency: "monthly" as const,
       priority: 0.8,
-    },
+    })),
     {
-      url: "https://premiere-pro-mcp.com/blog/ai-video-editing-with-premiere-pro/",
-      lastModified,
-      changeFrequency: "monthly",
-      priority: 0.8,
-    },
-    {
-      url: "https://premiere-pro-mcp.com/blog/premiere-pro-workflow-automation/",
-      lastModified,
-      changeFrequency: "monthly",
-      priority: 0.8,
-    },
-    {
-      url: "https://premiere-pro-mcp.com/changelog/",
-      lastModified,
+      url: `${siteUrl}/changelog/`,
+      lastModified: latestArticleDate,
       changeFrequency: "monthly",
       priority: 0.7,
     },
     {
-      url: "https://premiere-pro-mcp.com/privacy/",
-      lastModified,
+      url: `${siteUrl}/privacy/`,
+      lastModified: latestArticleDate,
       changeFrequency: "yearly",
       priority: 0.5,
     },

--- a/landing/components/analytics/marketing-page-view.tsx
+++ b/landing/components/analytics/marketing-page-view.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import { usePathname } from "next/navigation"
+import { trackOnboardingEvent } from "@/lib/onboarding-events"
+
+/**
+ * Records bounded, anonymous page views for acquisition measurement. It sends
+ * no prompt, project, media, identity, or file-path data and respects DNT/GPC.
+ */
+export function MarketingPageView() {
+  const pathname = usePathname()
+  const lastTrackedPath = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (lastTrackedPath.current === pathname) return
+    lastTrackedPath.current = pathname
+    trackOnboardingEvent("marketing_viewed")
+  }, [pathname])
+
+  return null
+}

--- a/landing/components/ui/tracked-link.tsx
+++ b/landing/components/ui/tracked-link.tsx
@@ -18,7 +18,7 @@ export function TrackedLink({
     <a
       {...props}
       onClick={(event) => {
-        trackOnboardingEvent("marketing_cta_clicked", {
+        trackOnboardingEvent("primary_cta_clicked", {
           location: trackingLocation,
           destination: trackingDestination,
         })

--- a/landing/lib/articles.ts
+++ b/landing/lib/articles.ts
@@ -251,6 +251,167 @@ export const articles: Article[] = [
       { label: "Explore AI-assisted Premiere workflows", href: "/blog/ai-video-editing-with-premiere-pro/" },
     ],
   },
+  {
+    slug: "adobe-premiere-ai-assistant-vs-mcp",
+    title: "Adobe Premiere Pro AI Assistant vs. MCP: How to Choose an AI Editing Workflow",
+    description:
+      "Compare Adobe’s in-app AI Assistant with a local MCP workflow: client choice, bounded project context, and reviewable Premiere automation.",
+    eyebrow: "Choose the right workflow",
+    publishedAt: "2026-08-22",
+    modifiedAt: "2026-08-22",
+    readingTime: "8 min read",
+    keywords: [
+      "Adobe Premiere Pro AI Assistant vs MCP",
+      "Premiere Pro AI Assistant alternative",
+      "Premiere Pro MCP workflow",
+      "AI assistant for Adobe Premiere Pro",
+    ],
+    sections: [
+      {
+        heading: "These are different ways to bring AI into Premiere",
+        paragraphs: [
+          "Adobe Premiere Pro AI Assistant and Premiere Pro MCP address related needs, but they are not the same product or control path. Adobe’s assistant is a first-party in-Premiere experience for documented workflows. Premiere Pro MCP is an independent, MIT-licensed server that lets a compatible AI client call structured tools through a local Premiere connection.",
+          "The useful comparison is not which product is universally better. Start with the task, the AI client your team prefers, the amount of project context involved, and how much review you need before a change is applied.",
+        ],
+      },
+      {
+        heading: "Choose Adobe’s assistant when the in-app experience is the priority",
+        paragraphs: [
+          "Adobe’s AI Assistant is a sensible first place to look when you want a first-party conversational experience in Premiere and the documented feature fits the task. Its availability and feature scope can change, so check Adobe’s current documentation and test the exact workflow in the Premiere version your team uses.",
+          "A public-beta feature list is useful for discovery, but it is not a substitute for testing in the project and host version that matter to your delivery. Use a duplicate project or a small test sequence for any new automation, regardless of which assistant you choose.",
+        ],
+      },
+      {
+        heading: "Choose Premiere Pro MCP when client choice and reviewable automation matter",
+        paragraphs: [
+          "Premiere Pro MCP fits when an assistant is part of a broader editorial or development workflow. Claude Desktop, Cursor, VS Code or Copilot, Windsurf, and other compatible MCP clients can call named Premiere operations, inspect capability information, and receive explicit diagnostics through a recommended local-first setup.",
+          "Its project-context flow is deliberately bounded: a client can explicitly capture a local context snapshot, retrieve relevant evidence, create a non-mutating edit-plan candidate, then preview and confirm the plan before an eligible compound edit applies. That is useful when a team wants the request and returned result to be inspectable, not merely conversational.",
+        ],
+        bullets: [
+          "Use the AI client that fits your team’s editorial or development workflow.",
+          "Run a read-only connection check before requesting a change.",
+          "Capture context only when the client explicitly requests it.",
+          "Treat returned state or diagnostics as evidence, not an attempted command as proof.",
+        ],
+      },
+      {
+        heading: "Keep privacy and creative control separate from marketing claims",
+        paragraphs: [
+          "The recommended MCP setup keeps Premiere, its connector, the server, and project media on the same computer. That does not change the privacy settings or data handling of the AI client a team chooses. Review that client separately, and do not treat a local server as a universal privacy guarantee.",
+          "Neither approach removes editorial judgment. AI can assist with inspection, organization, documented timeline operations, metadata work, and delivery preparation. Decisions about story, performance, pacing, and taste remain the editor’s job.",
+        ],
+      },
+      {
+        heading: "A practical way to evaluate either workflow",
+        paragraphs: [
+          "Pick one common task with a concrete success condition. Identify what must not change, use a duplicate project or test sequence, and start with the smallest inspectable step. For Premiere Pro MCP, begin with verify_premiere_connection, inspect the active sequence, then use a preview where it is available. For Adobe’s assistant, test the documented feature in the current host before relying on it in a larger project.",
+          "The winning workflow is the one that reduces repeated effort while leaving the editor confident about what changed, why it changed, and how to recover if the expected result is not there.",
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: "Is Premiere Pro MCP affiliated with Adobe or Adobe’s AI Assistant?",
+        answer:
+          "No. Premiere Pro MCP is an independent, MIT-licensed open-source project. Adobe Premiere Pro and Adobe’s AI Assistant are separate Adobe products and workflows.",
+      },
+      {
+        question: "Which one is better for Premiere Pro automation?",
+        answer:
+          "It depends on the workflow. Adobe’s assistant suits teams that prefer the supported first-party in-app experience. Premiere Pro MCP suits teams that need a compatible AI client, a local structured control path, and an explicit inspect-plan-preview-verify workflow.",
+      },
+      {
+        question: "Can project context replace an editor’s review?",
+        answer:
+          "No. Context retrieval and edit plans are evidence tools, not editorial truth. An editor should review the target, preview, returned state, and any diagnostics before relying on a change.",
+      },
+    ],
+    resources: [
+      { label: "Read Adobe’s current AI Assistant overview", href: "https://helpx.adobe.com/premiere/desktop/premiere-ai-assistant/overview.html" },
+      { label: "Run a safe Premiere connection check", href: "/#install" },
+      { label: "Learn what an MCP server does in Premiere", href: "/blog/what-is-a-premiere-pro-mcp-server/" },
+    ],
+  },
+  {
+    slug: "claude-desktop-premiere-pro-mcp-setup",
+    title: "Claude Desktop + Premiere Pro: Start with a Safe MCP Workflow",
+    description:
+      "Connect Claude Desktop to Adobe Premiere Pro with the local bundle and CEP connector, then verify the bridge before requesting any supported edit.",
+    eyebrow: "Safe Premiere setup",
+    publishedAt: "2026-08-22",
+    modifiedAt: "2026-08-22",
+    readingTime: "6 min read",
+    keywords: [
+      "Claude Desktop Premiere Pro",
+      "Claude Premiere Pro MCP setup",
+      "Premiere Pro MCP Claude Desktop",
+      "Premiere Pro safe connection check",
+    ],
+    sections: [
+      {
+        heading: "The first goal is a verified connection, not an edit",
+        paragraphs: [
+          "When you connect an AI client to Adobe Premiere Pro, the first useful question is whether the client can reach the open Premiere session without changing a project. That check separates installation or compatibility problems from editing problems and gives you a low-risk place to start.",
+          "Premiere Pro MCP provides a self-contained Claude Desktop bundle and a separate Premiere CEP connector. Both need to be installed on the same computer as Premiere. The connector is what carries supported commands between the local server and the open host session.",
+        ],
+      },
+      {
+        heading: "Set up the local path",
+        paragraphs: [
+          "Download the Claude Desktop bundle, install the Premiere connector with a trusted ZXP installer, then fully quit and reopen both Claude Desktop and Premiere. Open a Premiere project and make sure an active sequence is selected before you ask Claude to do anything with it.",
+          "The signed CEP connector is the default compatibility route for Premiere Pro 2020–2026 on Windows and macOS. The newer UXP bridge is capability-gated for compatible Premiere 25.6+ workflows, so it does not replace the CEP setup path for a first install.",
+        ],
+      },
+      {
+        heading: "Use this exact safe first request",
+        paragraphs: [
+          "In Claude Desktop, ask: Safely check my Premiere connection with verify_premiere_connection. Make no changes. The request is read-only. It does not ask Premiere to change a sequence, and it does not ask you to upload footage.",
+          "If the check returns a connection state, continue by inspecting the active project or sequence. If it returns a diagnostic, resolve that condition before attempting an edit. Repeating a mutating request is not a substitute for understanding whether the connector, host, active project, or capability state is ready.",
+        ],
+      },
+      {
+        heading: "Choose a first workflow with a clear definition of done",
+        paragraphs: [
+          "After the safe check passes, start with a small task that has named inputs and an observable result. Inspecting the active sequence, collecting a project inventory, or asking for a proposed plan is a better first exercise than a large timeline rewrite.",
+          "For a supported change, name the sequence, tracks, source clips, expected output, and no-change boundaries. Ask for a preview where available. Then review the returned state or diagnostics before you use the result in a larger project.",
+        ],
+        bullets: [
+          "Good first step: inspect an active sequence without changes.",
+          "Good next step: request a bounded preview or plan.",
+          "Use extra care: destructive batches, shared projects, and undocumented host behavior.",
+        ],
+      },
+      {
+        heading: "Troubleshoot without exposing project data",
+        paragraphs: [
+          "If the connection check fails, fully reopen both applications, confirm that a project is open with an active sequence, and look for Window → Extensions → MCP Bridge in Premiere. Share the returned connection state or diagnostic with support rather than project media, prompts, project names, or file paths.",
+          "Your AI client’s own privacy settings still apply. The local-first recommendation describes the Premiere MCP server and connector path; it does not override how a chosen client handles conversations or data.",
+        ],
+      },
+    ],
+    faqs: [
+      {
+        question: "Do I need Node.js to connect Claude Desktop?",
+        answer:
+          "The released Claude Desktop bundle includes the local server, so the recommended Claude path does not require a separate Node.js install just to connect. Other clients may use the npm or manual setup route.",
+      },
+      {
+        question: "Does a successful connection check prove every Premiere tool works?",
+        answer:
+          "No. It confirms the connection path. Inspect current capabilities, keep the task small, and verify the returned state or diagnostics for the specific operation you need.",
+      },
+      {
+        question: "Can I use a client other than Claude Desktop?",
+        answer:
+          "Yes, if it supports local MCP servers. Cursor, VS Code or Copilot, Windsurf, and other compatible clients use their own guided or advanced setup paths.",
+      },
+    ],
+    resources: [
+      { label: "Open the Premiere setup guide", href: "/#install" },
+      { label: "Read full technical setup documentation", href: "/docs/" },
+      { label: "Understand reviewable Premiere workflows", href: "/blog/premiere-pro-workflow-automation/" },
+    ],
+  },
 ]
 
 export const articleBySlug = new Map(articles.map((article) => [article.slug, article]))

--- a/landing/lib/onboarding-events.ts
+++ b/landing/lib/onboarding-events.ts
@@ -1,13 +1,16 @@
 export type OnboardingEvent =
+  | "marketing_viewed"
+  | "primary_cta_clicked"
   | "onboarding_assistant_selected"
   | "onboarding_download_started"
   | "onboarding_safe_prompt_copied"
   | "onboarding_advanced_opened"
   | "onboarding_recovery_opened"
-  | "marketing_cta_clicked"
   | "marketing_demo_played"
 
 type OnboardingEventParameters = Record<string, string>
+
+const firstTouchStorageKey = "premiere-pro-mcp:first-touch"
 
 const campaignParameterNames = [
   "utm_source",
@@ -28,6 +31,53 @@ function campaignParameters(): OnboardingEventParameters {
   return values
 }
 
+function sessionCampaignParameters(key: string): OnboardingEventParameters {
+  if (typeof window === "undefined") return {}
+  try {
+    const stored = window.sessionStorage.getItem(key)
+    if (!stored) return {}
+    const parsed = JSON.parse(stored) as unknown
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {}
+
+    return Object.fromEntries(
+      campaignParameterNames.flatMap((name) => {
+        const value = (parsed as Record<string, unknown>)[name]
+        return typeof value === "string" && value.length <= 80 && /^[a-z0-9._~-]+$/i.test(value)
+          ? [[name, value]]
+          : []
+      }),
+    )
+  } catch {
+    return {}
+  }
+}
+
+function attributionParameters(): OnboardingEventParameters {
+  const latestTouch = campaignParameters()
+  let firstTouch = sessionCampaignParameters(firstTouchStorageKey)
+
+  if (!Object.keys(firstTouch).length && Object.keys(latestTouch).length) {
+    firstTouch = latestTouch
+    try {
+      window.sessionStorage.setItem(firstTouchStorageKey, JSON.stringify(firstTouch))
+    } catch {
+      // Private browsing and restrictive browser settings can disable storage.
+      // Analytics remains optional, so continue without durable attribution.
+    }
+  }
+
+  return {
+    ...firstTouch,
+    ...Object.fromEntries(Object.entries(latestTouch).map(([name, value]) => [`latest_${name}`, value])),
+  }
+}
+
+function analyticsPermitted() {
+  if (typeof window === "undefined") return false
+  const nav = navigator as Navigator & { globalPrivacyControl?: boolean }
+  return !["1", "yes"].includes(nav.doNotTrack ?? "") && !nav.globalPrivacyControl
+}
+
 declare global {
   interface Window {
     dataLayer?: unknown[]
@@ -43,8 +93,15 @@ export function trackOnboardingEvent(
   eventName: OnboardingEvent,
   parameters: OnboardingEventParameters = {},
 ) {
-  if (typeof window === "undefined") return
-  const safeParameters = { ...campaignParameters(), ...parameters }
+  if (!analyticsPermitted()) return
+  const safeParameters = {
+    product: "premiere-pro-mcp",
+    event: eventName,
+    occurred_at: new Date().toISOString(),
+    path: window.location.pathname,
+    ...attributionParameters(),
+    ...parameters,
+  }
 
   window.dispatchEvent(
     new CustomEvent("premiere-pro-mcp:onboarding", {

--- a/landing/public/icon.svg
+++ b/landing/public/icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title">
+  <title>Premiere Pro MCP</title>
+  <defs>
+    <linearGradient id="accent" x1="8" y1="8" x2="56" y2="56" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#a78bfa"/>
+      <stop offset="1" stop-color="#f472b6"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="#09090b"/>
+  <path d="M17 15h18.2c7.6 0 12.8 4.4 12.8 11.5 0 7.2-5.3 11.7-12.8 11.7H25V49H17V15Zm8 7v9.3h9.2c3.7 0 5.9-1.7 5.9-4.7S37.9 22 34.2 22H25Z" fill="url(#accent)"/>
+</svg>

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -107,7 +107,31 @@ function serveLanding(req: http.IncomingMessage, res: http.ServerResponse, scrip
     path.isAbsolute(relativePath)
   ) return false;
 
-  if (!fs.existsSync(filePath)) return false;
+  if (!fs.existsSync(filePath)) {
+    // Next static exports store dynamic-route Flight payloads in nested folders
+    // (for example, __next.blog/$d$slug/__PAGE__.txt), while the client asks
+    // for a flattened filename (__next.blog.$d$slug.__PAGE__.txt). Map only
+    // that generated shape after every original URL segment has passed the
+    // containment check above. Without this, guide-to-guide navigation falls
+    // back to a full-document load and emits avoidable 404s.
+    const requestedFlightFile = safeSegments.at(-1);
+    const flightParts = requestedFlightFile?.split(".") ?? [];
+    const isNestedFlightPayload =
+      flightParts.length >= 4 &&
+      flightParts[0] === "__next" &&
+      flightParts.at(-1) === "txt";
+    if (!isNestedFlightPayload) return false;
+
+    const remappedFlightPath = path.join(
+      LANDING_DIR,
+      ...safeSegments.slice(0, -1),
+      `${flightParts[0]}.${flightParts[1]}`,
+      ...flightParts.slice(2, -2),
+      `${flightParts.at(-2)}.txt`,
+    );
+    if (!fs.existsSync(remappedFlightPath)) return false;
+    filePath = remappedFlightPath;
+  }
 
   let fileStats: fs.Stats;
   try {

--- a/tests/entrypoints-unit.test.ts
+++ b/tests/entrypoints-unit.test.ts
@@ -443,6 +443,20 @@ describe("HTTP entry point", () => {
     }));
   });
 
+  it("serves nested static-export Flight payloads requested with Next's flattened path", async () => {
+    mocks.fsExists.mockImplementation((candidate) => (
+      String(candidate).endsWith("landing-dist") ||
+      /[\\/]blog[\\/]guide[\\/]__next\.blog[\\/]\$d\$slug[\\/]__PAGE__\.txt$/.test(String(candidate))
+    ));
+    const handler = await loadHttp();
+    const res = response();
+    await handler({ method: "GET", url: "/blog/guide/__next.blog.$d$slug.__PAGE__.txt?_rsc=test", headers: {} }, res);
+    expect(mocks.fsCreateReadStream).toHaveBeenCalledWith(
+      expect.stringMatching(/[\\/]blog[\\/]guide[\\/]__next\.blog[\\/]\$d\$slug[\\/]__PAGE__\.txt$/),
+    );
+    expect(res.statusCode).toBe(200);
+  });
+
   it("does not crash when a landing asset read fails after validation", async () => {
     mocks.fsExists.mockReturnValue(true);
     const error = vi.spyOn(console, "error").mockImplementation(() => {});


### PR DESCRIPTION
## Summary
- adds two high-intent Premiere guides: a factual Adobe AI Assistant comparison and a safe Claude Desktop setup path
- makes the acquisition path measurable with privacy-bounded page/CTA events and session-only first-touch attribution
- improves SEO through dynamic sitemap entries, article social metadata, consistent safe-check CTAs, and a real SVG icon
- fixes static-export Flight payload routing so guide navigation does not emit 404s in the production HTTP server
- adds unposted community/design-partner and MCP Registry readiness drafts

## Verification
- `npm run check`
- `npm test` — 57 files, 1,594 tests passed
- `npm run lint` and `npm run build` in `landing/`
- strict marketing-surface audit — 14/14 passed
- production-like browser QA: guide navigation with no console errors; CTA route; 360/390/430 no horizontal overflow

## Boundaries
- No paid campaigns, directory publication, prospect outreach, or social posts were activated.
- Analytics destination receipt, real Premiere host workflows, and production deployment remain separate verification gates.