### PR TITLE
fix(telemetry): record only verified activation

### DIFF
--- a/.agents/analytics-tracking-plan.md
+++ b/.agents/analytics-tracking-plan.md
@@ -1,6 +1,6 @@
 # Premiere Pro MCP Tracking Plan
 
-**Last updated:** 2026-08-15
+**Last updated:** 2026-08-23
 
 ## Decisions this data should inform
 
@@ -35,6 +35,7 @@
 | `mcp_connection_attempt` | bounded transport, status, duration | Connection attempt |
 | `mcp_request` | bounded method, outcome, status, duration | MCP request |
 | `mcp_tool_call` | tool name, outcome, status, duration, bounded error category | Supported action result |
+| `premiere_mcp_activation_completed` | selected bridge and fixed `verified_connection` stage | The read-only check confirms the selected bridge, an open project, and an active sequence |
 
 ## GA4 conversions to configure
 
@@ -45,7 +46,9 @@
 
 ## Activation reporting boundary
 
-The meaningful activation funnel is connection attempt → request → successful tool call. A website download cannot prove installation, a connection attempt cannot prove a live Premiere host, and an attempted tool call cannot prove a successful project change.
+The repository-owned activation signal is emitted only when `verify_premiere_connection` returns `ready`: the MCP client reached the server, the selected bridge answered, and Premiere reported an open project and active sequence. A website download, connection attempt, incomplete diagnostic, or generic successful tool call is not activation.
+
+There is no privacy-safe way to identify an editor's or client-side installation's first supported value from this event: it carries no editor, project, or client-installation identifier. `mcp_tool_call` remains operational telemetry, not a first-value conversion or proof of a host-observable workflow result.
 
 ## Validation checklist
 

--- a/README.md
+++ b/README.md
@@ -801,10 +801,18 @@ Then connect with:
 | `POSTHOG_DISTINCT_ID` | Optional stable anonymous server identifier | Fly machine ID or random boot ID |
 
 When PostHog is enabled, the server records `mcp_connection_attempt`,
-`mcp_request`, `mcp_request_rejected`, and `mcp_tool_call`. Events contain operational fields such as
-method, tool name, outcome, status code, and duration. Authentication tokens,
-IP addresses, MCP arguments, project paths, media names, and tool results are
-never sent. Person profiles are disabled for these events.
+`mcp_request`, `mcp_request_rejected`, and `mcp_tool_call`. It also records
+`premiere_mcp_activation_completed` only after the read-only
+`verify_premiere_connection` check confirms the selected bridge, an open
+project, and an active sequence. Events contain bounded operational fields such
+as method, tool name, outcome, status code, duration, and selected bridge.
+Authentication tokens, IP addresses, MCP arguments, project paths, media names,
+and tool results are never sent. Person profiles are disabled for these events.
+
+This signal is an aggregate emission, not proof that an analytics provider
+received it, a count of unique people or editors, or evidence that an editing
+workflow succeeded. It does not carry a person or editor identifier, so it
+cannot safely infer "first value."
 
 ---
 

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -13,29 +13,20 @@ export interface Telemetry {
 }
 
 /**
- * Activation events have a deliberately smaller contract than operational tool
- * telemetry. Keep this list bounded: these events must remain useful without
- * ever receiving prompts, paths, project/media names, arguments, results,
- * tokens, IP addresses, or person profiles.
+ * Activation telemetry is deliberately narrower than operational tool
+ * telemetry. Emit it only after the read-only connection check has confirmed
+ * the selected bridge, an open project, and an active sequence. This avoids
+ * treating attempts or incomplete diagnostics as activation, and never sends
+ * prompts, paths, project/media names, arguments, results, tokens, IP
+ * addresses, or person profiles.
  */
-export type ActivationEventName =
-  | "premiere_mcp_activation_check_started"
-  | "premiere_mcp_activation_check_finished";
-
-export type ActivationOutcome = "ready" | "needs_attention";
-
 export function captureActivationEvent(
   telemetry: Telemetry,
-  event: ActivationEventName,
-  properties: {
-    backend: "cep" | "uxp";
-    outcome?: ActivationOutcome;
-  },
+  properties: { backend: "cep" | "uxp" },
 ): void {
-  telemetry.capture(event, {
-    activation_stage: "first_run",
+  telemetry.capture("premiere_mcp_activation_completed", {
+    activation_stage: "verified_connection",
     backend: properties.backend,
-    ...(properties.outcome ? { outcome: properties.outcome } : {}),
   });
 }
 

--- a/src/tools/health.ts
+++ b/src/tools/health.ts
@@ -125,7 +125,6 @@ export function getHealthTools(
       handler: async (args: { backend?: "cep" | "uxp" }) => {
         const backend = args.backend ?? "cep";
         const telemetry = options.telemetry ?? disabledTelemetry;
-        captureActivationEvent(telemetry, "premiere_mcp_activation_check_started", { backend });
 
         let report: FirstRunReport;
         if (backend === "uxp") {
@@ -169,10 +168,12 @@ export function getHealthTools(
           }
         }
 
-        captureActivationEvent(telemetry, "premiere_mcp_activation_check_finished", {
-          backend,
-          outcome: report.overall,
-        });
+        // This is the only repository-owned activation signal. A tool call
+        // that finds an unavailable bridge, project, or sequence remains a
+        // useful diagnostic, but is not activation.
+        if (report.overall === "ready") {
+          captureActivationEvent(telemetry, { backend });
+        }
         // A completed diagnostic remains a successful tool call even if it
         // identifies a problem. The structured report tells the user what to fix.
         return { success: true, data: report };

--- a/tests/telemetry.test.ts
+++ b/tests/telemetry.test.ts
@@ -80,13 +80,11 @@ describe("telemetry", () => {
   it("emits only the bounded activation properties", async () => {
     const { captureActivationEvent } = await import("../src/telemetry.js");
     const telemetry = { enabled: true, capture: vi.fn(), shutdown: vi.fn(async () => {}) };
-    captureActivationEvent(telemetry, "premiere_mcp_activation_check_started", { backend: "uxp" });
-    captureActivationEvent(telemetry, "premiere_mcp_activation_check_finished", { backend: "cep", outcome: "ready" });
-    expect(telemetry.capture).toHaveBeenNthCalledWith(1, "premiere_mcp_activation_check_started", {
-      activation_stage: "first_run", backend: "uxp",
+    captureActivationEvent(telemetry, { backend: "uxp" });
+    expect(telemetry.capture).toHaveBeenCalledOnce();
+    expect(telemetry.capture).toHaveBeenCalledWith("premiere_mcp_activation_completed", {
+      activation_stage: "verified_connection", backend: "uxp",
     });
-    expect(telemetry.capture).toHaveBeenNthCalledWith(2, "premiere_mcp_activation_check_finished", {
-      activation_stage: "first_run", backend: "cep", outcome: "ready",
-    });
+    expect(JSON.stringify(telemetry.capture.mock.calls)).not.toMatch(/prompt|path|token|project|media|argument|result|profile/i);
   });
 });

--- a/tests/tools/tool-modules.test.ts
+++ b/tests/tools/tool-modules.test.ts
@@ -228,7 +228,7 @@ describe("Tool Handler Behavior", () => {
   });
 
   describe("health.verify_premiere_connection", () => {
-    it("uses a read-only boolean check and emits bounded activation events", async () => {
+    it("uses a read-only boolean check and emits activation only after readiness is confirmed", async () => {
       const events: Array<{ event: string; properties?: TelemetryProperties }> = [];
       const telemetry: Telemetry = {
         enabled: true,
@@ -254,15 +254,30 @@ describe("Tool Handler Behavior", () => {
       expect(script).not.toContain("project.path");
       expect(events).toEqual([
         expect.objectContaining({
-          event: "premiere_mcp_activation_check_started",
-          properties: { activation_stage: "first_run", backend: "cep" },
-        }),
-        expect.objectContaining({
-          event: "premiere_mcp_activation_check_finished",
-          properties: { activation_stage: "first_run", backend: "cep", outcome: "ready" },
+          event: "premiere_mcp_activation_completed",
+          properties: { activation_stage: "verified_connection", backend: "cep" },
         }),
       ]);
       expect(JSON.stringify(events)).not.toMatch(/prompt|path|token|project|media|argument|result|profile/i);
+    });
+
+    it("does not record activation when the read-only check is incomplete", async () => {
+      const events: Array<{ event: string; properties?: TelemetryProperties }> = [];
+      const telemetry: Telemetry = {
+        enabled: true,
+        capture: (event, properties) => events.push({ event, properties }),
+        shutdown: async () => {},
+      };
+      mockedSendCommand.mockResolvedValue({
+        success: true,
+        data: { projectOpen: true, sequenceOpen: false },
+      });
+
+      const tools = getHealthTools(bridgeOptions, undefined, undefined, { telemetry });
+      const result = await (tools.verify_premiere_connection.handler as any)({});
+
+      expect(result).toMatchObject({ success: true, data: { overall: "needs_attention" } });
+      expect(events).toEqual([]);
     });
 
     it("does not fall back from an unavailable UXP check to CEP", async () => {


### PR DESCRIPTION
## Summary
- replace attempt-style activation events with one premiere_mcp_activation_completed event emitted only when the read-only check returns ready
- keep the payload bounded to selected bridge and a fixed activation stage; no prompt, project, media, path, argument, result, token, or person/profile data
- document that first supported value cannot be inferred safely without client/editor identity, so existing tool-call telemetry remains operational only

## Verification
- npm test -- tests/telemetry.test.ts tests/tools/tool-modules.test.ts
- npm test (59 files, 1613 tests)
- npm run lint
- npm run build
- npm run validate:marketplace-branding
- npm run docs:supported-actions:check

## Limits
- No deployment, PostHog configuration, analytics-receipt claim, durable identifier, first-value event, paid spend, or external outreach.