### PR TITLE
feat: add Project Intake host evidence contract

### DIFF
--- a/docs/industry/project-intake-workflow.md
+++ b/docs/industry/project-intake-workflow.md
@@ -470,10 +470,12 @@ version, MCP client, fixture revision/checksum, case status, and evidence
 references. A case is `passed`, `failed`, `unsupported`, or `not_run`; a
 passing schema validator or an MCP response labeled `verified` is insufficient
 without human review of the exact host and post-state evidence. The repository
-already provides `npm run validate:host-report -- path/to/redacted-report.json`
-for its documented redacted report format; Project Intake SHOULD either use its
-compatible evidence shape or extend that validator in a separately reviewed
-change. See [host-validation report rules](../editorial-workflow-host-validation.md).
+now provides a separate, versioned
+`npm run validate:project-intake-host-report -- path/to/redacted-report.json`
+contract for this preview-only workflow. It accepts only the defined Project
+Intake cases, requires the documented non-mutation postconditions, and rejects
+project data from the shared evidence index. See the
+[Project Intake host-validation runbook](../project-intake-host-validation.md).
 
 ## Acceptance gates
 

--- a/docs/project-intake-host-report.schema.json
+++ b/docs/project-intake-host-report.schema.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:premiere-pro-mcp:project-intake-host-report:v1",
+  "title": "Premiere Project Intake licensed-host evidence report",
+  "description": "A privacy-safe, reviewer-facing evidence index for the preview-only Project Intake workflow. The repository validator adds case-specific and redaction checks beyond this portable schema.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "sourceCommit", "host", "client", "fixture", "privacy", "cases"],
+  "properties": {
+    "schemaVersion": { "const": "project-intake-host-report/v1" },
+    "sourceCommit": { "type": "string", "pattern": "^[0-9a-fA-F]{40}$" },
+    "host": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["os", "premiereVersion", "premiereBuild", "connector"],
+      "properties": {
+        "os": { "enum": ["Windows", "macOS"] },
+        "premiereVersion": { "type": "string", "minLength": 1, "maxLength": 64 },
+        "premiereBuild": { "type": "string", "minLength": 1, "maxLength": 64 },
+        "connector": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["type", "buildHash"],
+          "properties": {
+            "type": { "const": "cep" },
+            "buildHash": { "type": "string", "pattern": "^[0-9a-fA-F]{7,64}$" }
+          }
+        }
+      }
+    },
+    "client": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["name", "version"],
+      "properties": {
+        "name": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "version": { "type": "string", "minLength": 1, "maxLength": 128 }
+      }
+    },
+    "fixture": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["revision", "sha256"],
+      "properties": {
+        "revision": { "type": "string", "pattern": "^[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}$" },
+        "sha256": { "type": "string", "pattern": "^[0-9a-fA-F]{64}$" }
+      }
+    },
+    "privacy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["containsOnlyGeneratedFixtureData", "localPathsRemoved", "mediaNamesRemoved", "promptsRemoved", "transcriptsRemoved", "credentialsRemoved"],
+      "properties": {
+        "containsOnlyGeneratedFixtureData": { "const": true },
+        "localPathsRemoved": { "const": true },
+        "mediaNamesRemoved": { "const": true },
+        "promptsRemoved": { "const": true },
+        "transcriptsRemoved": { "const": true },
+        "credentialsRemoved": { "const": true }
+      }
+    },
+    "cases": {
+      "type": "array",
+      "minItems": 3,
+      "maxItems": 3,
+      "items": { "$ref": "#/$defs/case" }
+    }
+  },
+  "$defs": {
+    "evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "reference", "sha256"],
+      "properties": {
+        "kind": { "type": "string", "minLength": 1, "maxLength": 64 },
+        "reference": { "type": "string", "pattern": "^evidence://[a-zA-Z0-9][a-zA-Z0-9._-]{0,127}$" },
+        "sha256": { "type": "string", "pattern": "^[0-9a-fA-F]{64}$" }
+      }
+    },
+    "case": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "status", "evidence"],
+      "properties": {
+        "id": { "enum": ["PIP-CONNECT-001", "PIP-PREVIEW-001", "PIP-NO-MUTATION-001"] },
+        "status": { "enum": ["passed", "failed", "unsupported", "not_run"] },
+        "executedAt": { "type": "string", "format": "date-time" },
+        "assertions": { "type": "object" },
+        "evidence": { "type": "array", "items": { "$ref": "#/$defs/evidence" } }
+      }
+    }
+  }
+}

--- a/docs/project-intake-host-report.template.json
+++ b/docs/project-intake-host-report.template.json
@@ -1,0 +1,34 @@
+{
+  "schemaVersion": "project-intake-host-report/v1",
+  "sourceCommit": "0000000000000000000000000000000000000000",
+  "host": {
+    "os": "Windows",
+    "premiereVersion": "26.0.0",
+    "premiereBuild": "template-only",
+    "connector": {
+      "type": "cep",
+      "buildHash": "0000000"
+    }
+  },
+  "client": {
+    "name": "template-client",
+    "version": "template-only"
+  },
+  "fixture": {
+    "revision": "generated-fixture-v1",
+    "sha256": "0000000000000000000000000000000000000000000000000000000000000000"
+  },
+  "privacy": {
+    "containsOnlyGeneratedFixtureData": true,
+    "localPathsRemoved": true,
+    "mediaNamesRemoved": true,
+    "promptsRemoved": true,
+    "transcriptsRemoved": true,
+    "credentialsRemoved": true
+  },
+  "cases": [
+    { "id": "PIP-CONNECT-001", "status": "not_run", "evidence": [] },
+    { "id": "PIP-PREVIEW-001", "status": "not_run", "evidence": [] },
+    { "id": "PIP-NO-MUTATION-001", "status": "not_run", "evidence": [] }
+  ]
+}

--- a/docs/project-intake-host-validation.md
+++ b/docs/project-intake-host-validation.md
@@ -1,0 +1,76 @@
+# Project Intake licensed-host validation
+
+This runbook is the evidence gate for the v1.13.0, **preview-only**
+`preview_project_intake` workflow. It is not run by unit, contract, lint, or
+package checks. It does not authorize an apply workflow, because v1.13.0 does
+not provide one.
+
+The 2026-08-22 Premiere 2026 attempt is recorded as blocked before CEP and MCP
+execution in [the host-validation record](industry/host-validation-2026-08-22.md).
+Do not transform that blocked attempt into a passing report or backfill a
+report from automated tests.
+
+## What this report can establish
+
+For one exact source commit, CEP panel build, Premiere build, operating system,
+client, and generated fixture, a completed report can index evidence that:
+
+| Case | Required observed assertion | Required redacted evidence |
+| --- | --- | --- |
+| `PIP-CONNECT-001` | `verify_premiere_connection` returned `overall: "ready"`. | Structured connection-response digest. |
+| `PIP-PREVIEW-001` | `preview_project_intake` returned `applied: false`, `capture.pathDisclosure: "redacted"`, and `organizationPlan.applied: false`. | Structured preview-response digest. |
+| `PIP-NO-MUTATION-001` | The Project panel did not change and the project was not saved by the preview call. | Before and after Project-panel capture digests plus the structured preview-response digest. |
+
+The report is an evidence index, not the evidence itself. Its references are
+opaque `evidence://` identifiers and SHA-256 digests; keep the separately
+redacted artifacts in the approved evidence store. A validator pass means only
+that a human reviewer has a complete, privacy-bounded package to inspect. It
+never makes a host, client, build, or workflow universally supported.
+
+## Safe procedure
+
+1. Start from the exact candidate source commit and record its full SHA. Do not
+   reuse a report from another build.
+2. Use a generated disposable fixture with non-sensitive labels. Never open or
+   save a customer project, and never use customer media, prompts, transcripts,
+   or credentials as evidence.
+3. Capture redacted before state, then call `verify_premiere_connection` and
+   `preview_project_intake` with `include_paths: false`. The preview must remain
+   bounded and non-mutating. Do not call an organization apply tool as part of
+   this runbook.
+4. Capture redacted after state before closing the fixture. If the host is
+   unavailable, the bridge fails, the preview errors, or the before/after state
+   differs, record the relevant case as `failed`, `unsupported`, or `not_run`.
+   Do not retry a potentially uncertain host action as if it were idempotent.
+5. Copy [the versioned template](project-intake-host-report.template.json) out
+   of source control. Replace only its non-sensitive provenance values and
+   opaque evidence references. The template itself is deliberately `not_run`.
+6. Validate the shared report before review:
+
+   ```bash
+   npm run validate:project-intake-host-report -- path/to/redacted-report.json
+   ```
+
+7. A human reviewer compares the evidence artifacts to the report, the exact
+   source commit, and the linked [schema](project-intake-host-report.schema.json).
+   Only that reviewer can decide whether the listed combination has enough
+   evidence for a narrowly worded host-validation record.
+
+## Privacy and failure-closed rules
+
+- The report accepts no notes, project names, media names, native paths,
+  prompts, transcripts, tokens, passwords, or arbitrary evidence locations.
+- All six privacy confirmations must be `true`; any local-path or
+  credential-like content makes validation fail.
+- A passed preview case requires a separate passed no-mutation case. A preview
+  response alone cannot establish that Premiere state remained unchanged.
+- Non-passing cases contain no evidence references in this minimal shared
+  index. Retain any sensitive diagnostic artifacts only in the approved
+  restricted store, not in a repository report.
+- This is CEP-specific because v1.13.0 Project Intake is validated through the
+  CEP bridge. It neither proves UXP behavior nor permits CEP/QE mutation
+  fallback.
+
+See the broader [editorial host-validation runbook](editorial-workflow-host-validation.md)
+for mutation evidence rules. This Project Intake runbook is intentionally
+narrower: it tests only the current read-only preview contract.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "validate:host-report": "node scripts/validate-licensed-host-report.mjs",
+    "validate:project-intake-host-report": "node scripts/validate-project-intake-host-report.mjs",
     "validate:marketplace-branding": "node scripts/validate-adobe-marketplace-branding.mjs",
     "benchmark:uxp-hybrid:verify": "node scripts/verify-uxp-hybrid-benchmark.mjs",
     "docs:supported-actions": "npm run build && node scripts/generate-supported-actions.mjs",

--- a/scripts/validate-project-intake-host-report.mjs
+++ b/scripts/validate-project-intake-host-report.mjs
@@ -1,0 +1,211 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const SCHEMA_VERSION = "project-intake-host-report/v1";
+const NOT_RUN_SHA256 = "0".repeat(64);
+const NOT_RUN_COMMIT = "0".repeat(40);
+const ALLOWED_STATUSES = new Set(["passed", "failed", "unsupported", "not_run"]);
+const CASE_REQUIREMENTS = {
+  "PIP-CONNECT-001": {
+    tool: "verify_premiere_connection",
+    evidence: ["structured_connection_response"],
+    assertions: { overall: "ready" },
+  },
+  "PIP-PREVIEW-001": {
+    tool: "preview_project_intake",
+    evidence: ["structured_preview_response"],
+    assertions: {
+      applied: false,
+      pathDisclosure: "redacted",
+      organizationPlanApplied: false,
+    },
+  },
+  "PIP-NO-MUTATION-001": {
+    tool: "preview_project_intake",
+    evidence: ["before_project_panel", "after_project_panel", "structured_preview_response"],
+    assertions: {
+      projectMutated: false,
+      projectSaved: false,
+    },
+  },
+};
+const SENSITIVE_CONTENT = /(?:(?:^|[^A-Za-z0-9])[A-Za-z]:[\\/]|\\\\|file:\/\/|\/(?:Users|home|private)\/|authorization|bearer\s+[A-Za-z0-9._-]+|api[_-]?key|password|secret|access[_-]?token|refresh[_-]?token|project(?:Name|Path)|media(?:Name|Path)|transcript|prompt)/i;
+
+function isObject(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasOnlyKeys(value, allowedKeys, label, errors) {
+  if (!isObject(value)) {
+    errors.push(`${label} must be an object`);
+    return false;
+  }
+  for (const key of Object.keys(value)) {
+    if (!allowedKeys.has(key)) errors.push(`${label} contains unsupported field: ${key}`);
+  }
+  return true;
+}
+
+function isNonEmptyString(value, maxLength = 128) {
+  return typeof value === "string" && value.trim().length > 0 && value.length <= maxLength;
+}
+
+function isSha256(value) {
+  return /^[0-9a-f]{64}$/i.test(value ?? "");
+}
+
+function isCommit(value) {
+  return /^[0-9a-f]{40}$/i.test(value ?? "");
+}
+
+function isRfc3339(value) {
+  return typeof value === "string" && !Number.isNaN(Date.parse(value)) && /(?:Z|[+-]\d\d:\d\d)$/.test(value);
+}
+
+function serializedValues(value) {
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) return value.map(serializedValues).join("\n");
+  if (isObject(value)) return Object.values(value).map(serializedValues).join("\n");
+  return "";
+}
+
+function validateEvidence(evidence, label, errors) {
+  if (!Array.isArray(evidence)) {
+    errors.push(`${label}.evidence must be an array`);
+    return [];
+  }
+
+  const kinds = [];
+  for (const [index, item] of evidence.entries()) {
+    const evidenceLabel = `${label}.evidence[${index}]`;
+    hasOnlyKeys(item, new Set(["kind", "reference", "sha256"]), evidenceLabel, errors);
+    if (!isNonEmptyString(item?.kind, 64)) errors.push(`${evidenceLabel}.kind is required`);
+    else kinds.push(item.kind);
+    if (typeof item?.reference !== "string" || !/^evidence:\/\/[a-z0-9][a-z0-9._-]{0,127}$/i.test(item.reference)) {
+      errors.push(`${evidenceLabel}.reference must be an opaque evidence:// reference`);
+    }
+    if (!isSha256(item?.sha256)) errors.push(`${evidenceLabel}.sha256 must be a SHA-256 hash`);
+  }
+  if (new Set(kinds).size !== kinds.length) errors.push(`${label}.evidence must not repeat a kind`);
+  return kinds;
+}
+
+function validatePassedCase(entry, requirement, errors) {
+  const label = `case ${entry.id}`;
+  if (!isRfc3339(entry.executedAt)) errors.push(`${label}.executedAt must be an RFC 3339 timestamp`);
+  hasOnlyKeys(entry.assertions, new Set(["tool", ...Object.keys(requirement.assertions)]), `${label}.assertions`, errors);
+  if (entry.assertions?.tool !== requirement.tool) errors.push(`${label}.assertions.tool must be ${requirement.tool}`);
+  for (const [key, expected] of Object.entries(requirement.assertions)) {
+    if (entry.assertions?.[key] !== expected) errors.push(`${label}.assertions.${key} must be ${JSON.stringify(expected)}`);
+  }
+
+  const evidenceKinds = validateEvidence(entry.evidence, label, errors);
+  for (const requiredKind of requirement.evidence) {
+    if (!evidenceKinds.includes(requiredKind)) errors.push(`${label} requires ${requiredKind} evidence`);
+  }
+  for (const kind of evidenceKinds) {
+    if (!requirement.evidence.includes(kind)) errors.push(`${label} has unsupported evidence kind: ${kind}`);
+  }
+}
+
+function validateReport(report) {
+  const errors = [];
+  hasOnlyKeys(report, new Set(["schemaVersion", "sourceCommit", "host", "client", "fixture", "privacy", "cases"]), "report", errors);
+  if (report?.schemaVersion !== SCHEMA_VERSION) errors.push(`schemaVersion must be ${SCHEMA_VERSION}`);
+  if (!isCommit(report?.sourceCommit)) errors.push("sourceCommit must be a 40-character commit SHA");
+
+  hasOnlyKeys(report?.host, new Set(["os", "premiereVersion", "premiereBuild", "connector"]), "host", errors);
+  if (!new Set(["Windows", "macOS"]).has(report?.host?.os)) errors.push("host.os must be Windows or macOS");
+  if (!isNonEmptyString(report?.host?.premiereVersion, 64)) errors.push("host.premiereVersion is required");
+  if (!isNonEmptyString(report?.host?.premiereBuild, 64)) errors.push("host.premiereBuild is required");
+  hasOnlyKeys(report?.host?.connector, new Set(["type", "buildHash"]), "host.connector", errors);
+  if (report?.host?.connector?.type !== "cep") errors.push("host.connector.type must be cep for v1.13.0 Project Intake validation");
+  if (!/^[0-9a-f]{7,64}$/i.test(report?.host?.connector?.buildHash ?? "")) errors.push("host.connector.buildHash must be a build hash");
+
+  hasOnlyKeys(report?.client, new Set(["name", "version"]), "client", errors);
+  if (!isNonEmptyString(report?.client?.name)) errors.push("client.name is required");
+  if (!isNonEmptyString(report?.client?.version)) errors.push("client.version is required");
+
+  hasOnlyKeys(report?.fixture, new Set(["revision", "sha256"]), "fixture", errors);
+  if (!/^[a-z0-9][a-z0-9._-]{0,63}$/i.test(report?.fixture?.revision ?? "")) errors.push("fixture.revision must be a non-sensitive identifier");
+  if (!isSha256(report?.fixture?.sha256)) errors.push("fixture.sha256 must be a SHA-256 hash");
+
+  const requiredPrivacyFlags = ["containsOnlyGeneratedFixtureData", "localPathsRemoved", "mediaNamesRemoved", "promptsRemoved", "transcriptsRemoved", "credentialsRemoved"];
+  hasOnlyKeys(report?.privacy, new Set(requiredPrivacyFlags), "privacy", errors);
+  for (const flag of requiredPrivacyFlags) {
+    if (report?.privacy?.[flag] !== true) errors.push(`privacy.${flag} must be true`);
+  }
+
+  if (!Array.isArray(report?.cases) || report.cases.length !== Object.keys(CASE_REQUIREMENTS).length) {
+    errors.push(`cases must contain exactly ${Object.keys(CASE_REQUIREMENTS).length} Project Intake cases`);
+  }
+
+  const seenCaseIds = new Set();
+  for (const entry of report?.cases ?? []) {
+    const label = `case ${entry?.id ?? "<unknown>"}`;
+    hasOnlyKeys(entry, new Set(["id", "status", "executedAt", "assertions", "evidence"]), label, errors);
+    if (!Object.hasOwn(CASE_REQUIREMENTS, entry?.id)) errors.push(`${label} is not a supported Project Intake case`);
+    if (seenCaseIds.has(entry?.id)) errors.push(`${label} is duplicated`);
+    seenCaseIds.add(entry?.id);
+    if (!ALLOWED_STATUSES.has(entry?.status)) errors.push(`${label} has an invalid status`);
+
+    if (entry?.status === "passed" && CASE_REQUIREMENTS[entry.id]) {
+      validatePassedCase(entry, CASE_REQUIREMENTS[entry.id], errors);
+    } else {
+      if (entry?.executedAt !== undefined) errors.push(`${label}.executedAt is only recorded for passed cases`);
+      if (entry?.assertions !== undefined) errors.push(`${label}.assertions are only accepted for passed cases`);
+      const evidenceKinds = validateEvidence(entry?.evidence, label, errors);
+      if (evidenceKinds.length > 0) errors.push(`${label} must not include evidence unless it passed; retain failure evidence outside this minimal shared report`);
+    }
+  }
+  for (const id of Object.keys(CASE_REQUIREMENTS)) {
+    if (!seenCaseIds.has(id)) errors.push(`cases must include ${id}`);
+  }
+
+  const previewCase = report?.cases?.find((entry) => entry?.id === "PIP-PREVIEW-001");
+  const noMutationCase = report?.cases?.find((entry) => entry?.id === "PIP-NO-MUTATION-001");
+  if (previewCase?.status === "passed" && noMutationCase?.status !== "passed") {
+    errors.push("PIP-PREVIEW-001 cannot pass unless PIP-NO-MUTATION-001 also passes");
+  }
+  if (report?.cases?.some((entry) => entry?.status === "passed")) {
+    if (report.sourceCommit === NOT_RUN_COMMIT) errors.push("passed cases require a real sourceCommit, not the template sentinel");
+    if (report.fixture?.sha256 === NOT_RUN_SHA256) errors.push("passed cases require a real fixture checksum, not the template sentinel");
+  }
+
+  if (SENSITIVE_CONTENT.test(serializedValues(report))) {
+    errors.push("report appears to contain project data, a local path, or credential-like content; redact it before sharing");
+  }
+
+  return errors;
+}
+
+const reportPath = process.argv[2];
+if (!reportPath) {
+  throw new Error("Usage: node scripts/validate-project-intake-host-report.mjs <redacted-report.json>");
+}
+
+const resolvedPath = path.resolve(reportPath);
+let report;
+try {
+  report = JSON.parse(fs.readFileSync(resolvedPath, "utf8"));
+} catch (error) {
+  throw new Error(`Unable to parse Project Intake host report: ${error instanceof Error ? error.message : String(error)}`);
+}
+
+const errors = validateReport(report);
+if (errors.length > 0) {
+  throw new Error(`Project Intake host report is invalid:\n- ${errors.join("\n- ")}`);
+}
+
+console.log(JSON.stringify({
+  report: path.basename(resolvedPath),
+  schemaVersion: SCHEMA_VERSION,
+  sourceCommit: report.sourceCommit,
+  host: report.host,
+  totals: Object.fromEntries([...ALLOWED_STATUSES].map((status) => [
+    status,
+    report.cases.filter((entry) => entry.status === status).length,
+  ])),
+  humanReviewRequired: true,
+  licensedHostVerifiedByValidator: false,
+}, null, 2));

--- a/tests/project-intake-host-report.test.ts
+++ b/tests/project-intake-host-report.test.ts
@@ -1,0 +1,118 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+
+const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), "premiere-project-intake-host-report-"));
+const validator = path.resolve("scripts/validate-project-intake-host-report.mjs");
+
+function evidence(kind: string, reference: string) {
+  return { kind, reference: `evidence://${reference}`, sha256: "d".repeat(64) };
+}
+
+function completeSyntheticReport() {
+  return {
+    schemaVersion: "project-intake-host-report/v1",
+    sourceCommit: "a".repeat(40),
+    host: {
+      os: "Windows",
+      premiereVersion: "26.0.0",
+      premiereBuild: "26.0.0-build-1",
+      connector: { type: "cep", buildHash: "b".repeat(40) },
+    },
+    client: { name: "test-client", version: "1.0.0" },
+    fixture: { revision: "generated-fixture-v1", sha256: "c".repeat(64) },
+    privacy: {
+      containsOnlyGeneratedFixtureData: true,
+      localPathsRemoved: true,
+      mediaNamesRemoved: true,
+      promptsRemoved: true,
+      transcriptsRemoved: true,
+      credentialsRemoved: true,
+    },
+    cases: [
+      {
+        id: "PIP-CONNECT-001",
+        status: "passed",
+        executedAt: "2026-08-23T00:00:00Z",
+        assertions: { tool: "verify_premiere_connection", overall: "ready" },
+        evidence: [evidence("structured_connection_response", "connection")],
+      },
+      {
+        id: "PIP-PREVIEW-001",
+        status: "passed",
+        executedAt: "2026-08-23T00:01:00Z",
+        assertions: {
+          tool: "preview_project_intake",
+          applied: false,
+          pathDisclosure: "redacted",
+          organizationPlanApplied: false,
+        },
+        evidence: [evidence("structured_preview_response", "preview")],
+      },
+      {
+        id: "PIP-NO-MUTATION-001",
+        status: "passed",
+        executedAt: "2026-08-23T00:02:00Z",
+        assertions: { tool: "preview_project_intake", projectMutated: false, projectSaved: false },
+        evidence: [
+          evidence("before_project_panel", "before-panel"),
+          evidence("after_project_panel", "after-panel"),
+          evidence("structured_preview_response", "preview-no-mutation"),
+        ],
+      },
+    ],
+  };
+}
+
+function validate(report: unknown) {
+  const reportPath = path.join(tempDirectory, `${Math.random().toString(16).slice(2)}.json`);
+  fs.writeFileSync(reportPath, JSON.stringify(report));
+  return spawnSync(process.execPath, [validator, reportPath], { encoding: "utf8" });
+}
+
+afterAll(() => fs.rmSync(tempDirectory, { recursive: true, force: true }));
+
+describe("Project Intake licensed-host report validator", () => {
+  it("accepts the not-run template without treating it as host verification", () => {
+    const template = JSON.parse(fs.readFileSync("docs/project-intake-host-report.template.json", "utf8"));
+    const result = validate(template);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('"not_run": 3');
+    expect(result.stdout).toContain('"licensedHostVerifiedByValidator": false');
+  });
+
+  it("validates a structurally complete synthetic fixture without treating it as host evidence", () => {
+    const result = validate(completeSyntheticReport());
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain('"passed": 3');
+    expect(result.stdout).toContain('"humanReviewRequired": true');
+    expect(result.stdout).toContain('"licensedHostVerifiedByValidator": false');
+  });
+
+  it("fails closed when a preview report reveals paths or fails its redacted postcondition", () => {
+    const report = completeSyntheticReport();
+    report.cases[1].assertions.pathDisclosure = "requested";
+    report.client.name = "C:/restricted";
+    const result = validate(report);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("pathDisclosure must be \"redacted\"");
+    expect(result.stderr).toContain("project data, a local path, or credential-like content");
+  });
+
+  it("requires no-mutation evidence whenever the Project Intake preview passes", () => {
+    const report = completeSyntheticReport();
+    report.cases[2].status = "not_run";
+    delete report.cases[2].executedAt;
+    delete report.cases[2].assertions;
+    report.cases[2].evidence = [];
+    const result = validate(report);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("PIP-PREVIEW-001 cannot pass unless PIP-NO-MUTATION-001 also passes");
+  });
+});


### PR DESCRIPTION
## Summary
- add a versioned, privacy-safe host-evidence schema and not-run template for the v1.13.0 preview-only Project Intake workflow
- add a fail-closed validator that requires the read-only and no-mutation postconditions for any passed case
- document the CEP-only licensed-host procedure and link the Project Intake contract to it

## Validation
- npm run check (60 files, 1,616 tests)
- npm test -- --run tests/project-intake-host-report.test.ts tests/project-intake.test.ts tests/tools/project-intake.test.ts
- npm run validate:project-intake-host-report -- docs/project-intake-host-report.template.json

## Evidence boundary
This PR contains no Premiere run or host result. The current 2026-08-22 Premiere 2026 attempt remains blocked before CEP/MCP execution. A validator pass means only that a report is structurally complete and privacy-bounded for human review; it does not make a licensed-host claim.