### PR TITLE
feat: add bounded live Premiere context resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Give compatible AI assistants structured control over supported Adobe Premiere Pro workflows.**
 
-313 core tools across 36 modules, 4 resources, and 11 guided workflows. A connected UXP host adds 50 capability-gated tools.
+313 core tools across 36 modules, 9 resources, and 11 guided workflows. A connected UXP host adds 50 capability-gated tools.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Node.js](https://img.shields.io/badge/Node.js-20.19%2B-green.svg)](https://nodejs.org)
@@ -731,15 +731,24 @@ Track targeting, batch operations, markers, audio levels, motion/transform, meta
 
 ## MCP Resources
 
-The server exposes four LLM context resources and eleven workflow prompts:
+The server exposes nine LLM context resources and eleven workflow prompts:
 
 | Resource URI | Description |
 | :----------- | :---------- |
 | `config://premiere-instructions` | Best practices: workflow order, timeline rules, effect tips, error handling |
 | `config://extendscript-reference` | Complete ExtendScript API reference for writing custom scripts |
 | `config://premiere-workflows` | Machine-readable catalog for rough cuts, dialogue cleanup, captions, and delivery |
+| `config://premiere-project-context` | Revisioned local project-context indexing and retrieval workflow |
+| `premiere://project/info` | Fresh, path-redacted current-project and active-sequence summary |
+| `premiere://project/sequences` | Bounded sequence inventory with stable Premiere IDs |
+| `premiere://project/media` | Bounded, path-redacted project-media inventory |
+| `premiere://project/bins` | Bounded, path-redacted project-bin inventory |
+| `premiere://timeline/active` | Bounded active-timeline tracks, clips, and markers snapshot |
 
-These are automatically available to MCP clients that support resources, giving the AI deep context about how to drive Premiere Pro effectively.
+The five `premiere://` snapshots are read-only CEP bridge requests. They include a
+revision token for stale-state detection and never return native media or project-tree
+paths. A successful snapshot proves bridge readback only—not licensed-host feature
+coverage, playback, rendering, or editorial correctness.
 
 ---
 

--- a/src/resources/live-context-resources.ts
+++ b/src/resources/live-context-resources.ts
@@ -1,0 +1,317 @@
+import { createHash } from "node:crypto";
+import {
+  sendCommand,
+  type BridgeOptions,
+  type CommandResult,
+} from "../bridge/file-bridge.js";
+import { buildToolScript } from "../bridge/script-builder.js";
+
+/**
+ * Compact, read-only snapshots exposed as MCP resources.  They deliberately
+ * do not return native file paths or project tree paths: callers can discover
+ * stable Premiere IDs and names, then ask an operator before a path-sensitive
+ * action.  Each read is a fresh CEP bridge request and gets a revision hash
+ * calculated from the returned, redacted payload.
+ */
+export interface LiveContextResource {
+  name: string;
+  uri: string;
+  description: string;
+  read: (uri: URL) => Promise<{
+    contents: Array<{ uri: string; mimeType: "application/json"; text: string }>;
+  }>;
+}
+
+const MAX_SEQUENCES = 50;
+const MAX_PROJECT_ITEMS = 100;
+const MAX_TIMELINE_CLIPS = 128;
+const MAX_MARKERS = 128;
+
+function snapshotRevision(payload: unknown): string {
+  return createHash("sha256")
+    .update(JSON.stringify(payload))
+    .digest("hex")
+    .slice(0, 20);
+}
+
+function resourceResult(uri: URL, resource: string, result: CommandResult) {
+  const payload = result.success
+    ? {
+        ok: true,
+        resource,
+        resourceSchemaVersion: 1,
+        backend: "cep",
+        data: result.data ?? null,
+      }
+    : {
+        ok: false,
+        resource,
+        resourceSchemaVersion: 1,
+        backend: "cep",
+        error: result.error ?? "Premiere did not return a resource snapshot",
+      };
+
+  const snapshot = {
+    ...payload,
+    snapshotRevision: snapshotRevision(payload),
+  };
+
+  return {
+    contents: [
+      {
+        uri: uri.href,
+        mimeType: "application/json" as const,
+        text: JSON.stringify(snapshot, null, 2),
+      },
+    ],
+  };
+}
+
+function createReader(scriptBody: string, bridgeOptions: BridgeOptions) {
+  const script = buildToolScript(scriptBody);
+  return async (uri: URL, resource: string) =>
+    resourceResult(uri, resource, await sendCommand(script, bridgeOptions));
+}
+
+export function getLiveContextResources(
+  bridgeOptions: BridgeOptions,
+): LiveContextResource[] {
+  const projectInfo = createReader(
+    `
+      var project = app.project;
+      if (!project) return __error("No project is open");
+      var active = project.activeSequence;
+      return __result({
+        project: {
+          name: String(project.name || ""),
+          isDirty: project.dirty === true,
+          sequenceCount: project.sequences.numSequences,
+          rootItemCount: project.rootItem && project.rootItem.children ? project.rootItem.children.numItems : 0
+        },
+        activeSequence: active ? {
+          id: String(active.sequenceID),
+          name: String(active.name || ""),
+          videoTrackCount: active.videoTracks.numTracks,
+          audioTrackCount: active.audioTracks.numTracks,
+          durationSeconds: __ticksToSeconds(active.end.ticks)
+        } : null,
+        privacy: { nativePaths: "not returned", projectTreePaths: "not returned" }
+      });
+    `,
+    bridgeOptions,
+  );
+
+  const sequences = createReader(
+    `
+      var project = app.project;
+      if (!project) return __error("No project is open");
+      var allCount = project.sequences.numSequences;
+      var rows = [];
+      for (var i = 0; i < allCount && i < ${MAX_SEQUENCES}; i++) {
+        var sequence = project.sequences[i];
+        rows.push({
+          id: String(sequence.sequenceID),
+          name: String(sequence.name || ""),
+          width: sequence.frameSizeHorizontal,
+          height: sequence.frameSizeVertical,
+          durationSeconds: __ticksToSeconds(sequence.end.ticks),
+          videoTrackCount: sequence.videoTracks.numTracks,
+          audioTrackCount: sequence.audioTracks.numTracks,
+          isActive: project.activeSequence && String(project.activeSequence.sequenceID) === String(sequence.sequenceID)
+        });
+      }
+      return __result({
+        sequences: rows,
+        returnedCount: rows.length,
+        totalCount: allCount,
+        truncated: allCount > rows.length,
+        maximumSequences: ${MAX_SEQUENCES},
+        privacy: { nativePaths: "not returned" }
+      });
+    `,
+    bridgeOptions,
+  );
+
+  const media = createReader(
+    `
+      var project = app.project;
+      if (!project) return __error("No project is open");
+      var rows = [];
+      var scannedItems = 0;
+      var truncated = false;
+      function scan(parent, depth) {
+        if (!parent || !parent.children || truncated) return;
+        for (var i = 0; i < parent.children.numItems; i++) {
+          if (rows.length >= ${MAX_PROJECT_ITEMS}) { truncated = true; return; }
+          var item = parent.children[i];
+          scannedItems++;
+          if (item.type === 1) {
+            var hasMediaPath = false;
+            var offline = null;
+            var hasVideo = null;
+            var hasAudio = null;
+            try { hasMediaPath = !!item.getMediaPath(); } catch (pathError) {}
+            try { offline = !!item.isOffline(); } catch (offlineError) {}
+            try { hasVideo = !!item.hasVideo(); } catch (videoError) {}
+            try { hasAudio = !!item.hasAudio(); } catch (audioError) {}
+            rows.push({
+              id: String(item.nodeId),
+              name: String(item.name || ""),
+              type: "clip",
+              depth: depth,
+              hasMediaPath: hasMediaPath,
+              offline: offline,
+              hasVideo: hasVideo,
+              hasAudio: hasAudio
+            });
+          }
+          if (item.type === 2) scan(item, depth + 1);
+        }
+      }
+      scan(project.rootItem, 0);
+      return __result({
+        media: rows,
+        returnedCount: rows.length,
+        scannedItems: scannedItems,
+        truncated: truncated,
+        maximumMediaItems: ${MAX_PROJECT_ITEMS},
+        privacy: { nativePaths: "not returned", projectTreePaths: "not returned" }
+      });
+    `,
+    bridgeOptions,
+  );
+
+  const bins = createReader(
+    `
+      var project = app.project;
+      if (!project) return __error("No project is open");
+      var rows = [];
+      var scannedItems = 0;
+      var truncated = false;
+      function scan(parent, depth) {
+        if (!parent || !parent.children || truncated) return;
+        for (var i = 0; i < parent.children.numItems; i++) {
+          if (rows.length >= ${MAX_PROJECT_ITEMS}) { truncated = true; return; }
+          var item = parent.children[i];
+          scannedItems++;
+          if (item.type === 2) {
+            rows.push({
+              id: String(item.nodeId),
+              name: String(item.name || ""),
+              depth: depth,
+              directItemCount: item.children ? item.children.numItems : 0
+            });
+            scan(item, depth + 1);
+          }
+        }
+      }
+      scan(project.rootItem, 0);
+      return __result({
+        bins: rows,
+        returnedCount: rows.length,
+        scannedItems: scannedItems,
+        truncated: truncated,
+        maximumBins: ${MAX_PROJECT_ITEMS},
+        privacy: { nativePaths: "not returned", projectTreePaths: "not returned" }
+      });
+    `,
+    bridgeOptions,
+  );
+
+  const activeTimeline = createReader(
+    `
+      var project = app.project;
+      if (!project) return __error("No project is open");
+      var sequence = project.activeSequence;
+      if (!sequence) return __result({ activeSequence: null, tracks: [], clips: [], markers: [] });
+      var tracks = [];
+      var clips = [];
+      var clipsTruncated = false;
+      function collectTracks(trackCollection, type) {
+        for (var t = 0; t < trackCollection.numTracks; t++) {
+          var track = trackCollection[t];
+          var muted = null;
+          var locked = null;
+          try { muted = !!track.isMuted(); } catch (muteError) {}
+          try { locked = !!track.isLocked(); } catch (lockError) {}
+          tracks.push({ type: type, index: t, name: String(track.name || ""), clipCount: track.clips.numItems, muted: muted, locked: locked });
+          for (var c = 0; c < track.clips.numItems; c++) {
+            if (clips.length >= ${MAX_TIMELINE_CLIPS}) { clipsTruncated = true; break; }
+            var clip = track.clips[c];
+            clips.push({
+              id: String(clip.nodeId),
+              name: String(clip.name || ""),
+              trackType: type,
+              trackIndex: t,
+              startSeconds: __ticksToSeconds(clip.start.ticks),
+              endSeconds: __ticksToSeconds(clip.end.ticks),
+              durationSeconds: __ticksToSeconds(clip.duration.ticks)
+            });
+          }
+        }
+      }
+      collectTracks(sequence.videoTracks, "video");
+      collectTracks(sequence.audioTracks, "audio");
+      var markers = [];
+      var markersTruncated = false;
+      try {
+        var marker = sequence.markers.getFirstMarker();
+        while (marker) {
+          if (markers.length >= ${MAX_MARKERS}) { markersTruncated = true; break; }
+          markers.push({
+            name: String(marker.name || ""),
+            startSeconds: __ticksToSeconds(marker.start.ticks),
+            endSeconds: __ticksToSeconds(marker.end.ticks),
+            type: marker.type || null
+          });
+          marker = sequence.markers.getNextMarker(marker);
+        }
+      } catch (markerError) {}
+      return __result({
+        activeSequence: { id: String(sequence.sequenceID), name: String(sequence.name || ""), durationSeconds: __ticksToSeconds(sequence.end.ticks) },
+        tracks: tracks,
+        clips: clips,
+        markers: markers,
+        clipsTruncated: clipsTruncated,
+        markersTruncated: markersTruncated,
+        maximumClips: ${MAX_TIMELINE_CLIPS},
+        maximumMarkers: ${MAX_MARKERS},
+        privacy: { nativePaths: "not returned" }
+      });
+    `,
+    bridgeOptions,
+  );
+
+  return [
+    {
+      name: "premiere-live-project-info",
+      uri: "premiere://project/info",
+      description: "Bounded, read-only current-project summary with no native paths.",
+      read: (uri) => projectInfo(uri, "premiere://project/info"),
+    },
+    {
+      name: "premiere-live-project-sequences",
+      uri: "premiere://project/sequences",
+      description: "Bounded, read-only sequence inventory with stable Premiere IDs.",
+      read: (uri) => sequences(uri, "premiere://project/sequences"),
+    },
+    {
+      name: "premiere-live-project-media",
+      uri: "premiere://project/media",
+      description: "Bounded, path-redacted media inventory for planning and inspection.",
+      read: (uri) => media(uri, "premiere://project/media"),
+    },
+    {
+      name: "premiere-live-project-bins",
+      uri: "premiere://project/bins",
+      description: "Bounded, path-redacted bin inventory for project organization planning.",
+      read: (uri) => bins(uri, "premiere://project/bins"),
+    },
+    {
+      name: "premiere-live-active-timeline",
+      uri: "premiere://timeline/active",
+      description: "Bounded, read-only active-timeline tracks, clips, and markers snapshot.",
+      read: (uri) => activeTimeline(uri, "premiere://timeline/active"),
+    },
+  ];
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -45,6 +45,7 @@ import {
   resolveCapabilities,
 } from "./security/index.js";
 import { EXTENDSCRIPT_REFERENCE } from "./resources/extendscript-reference.js";
+import { getLiveContextResources } from "./resources/live-context-resources.js";
 import { PROJECT_CONTEXT_RESOURCE } from "./context/project-context-resource.js";
 import { WORKFLOW_PROMPTS, WORKFLOW_RESOURCE } from "./workflows/catalog.js";
 import {
@@ -478,6 +479,18 @@ export function createServer(
     }),
   );
 
+  for (const resource of getLiveContextResources(bridgeOptions)) {
+    server.resource(
+      resource.name,
+      resource.uri,
+      {
+        description: resource.description,
+        mimeType: "application/json",
+      },
+      resource.read,
+    );
+  }
+
   server.resource(
     "premiere-workflows",
     "config://premiere-workflows",
@@ -547,7 +560,7 @@ export function createServer(
 
   const toolCount = Object.keys(toolModules).length;
   debugLog(
-    `Registered ${toolCount} tools + 4 resources + ${WORKFLOW_PROMPTS.length} prompts`,
+    `Registered ${toolCount} tools + 9 resources + ${WORKFLOW_PROMPTS.length} prompts`,
   );
 
   return server;

--- a/tests/live-context-resources.test.ts
+++ b/tests/live-context-resources.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { sendCommand } = vi.hoisted(() => ({ sendCommand: vi.fn() }));
+
+vi.mock("../src/bridge/file-bridge.js", () => ({
+  sendCommand,
+}));
+
+import { getLiveContextResources } from "../src/resources/live-context-resources.js";
+
+describe("live context resources", () => {
+  beforeEach(() => {
+    sendCommand.mockReset();
+  });
+
+  it("defines five bounded, read-only resource endpoints", () => {
+    const resources = getLiveContextResources({ timeoutMs: 10 });
+
+    expect(resources.map((resource) => resource.uri)).toEqual([
+      "premiere://project/info",
+      "premiere://project/sequences",
+      "premiere://project/media",
+      "premiere://project/bins",
+      "premiere://timeline/active",
+    ]);
+    expect(resources.every((resource) => resource.description.includes("read-only") || resource.description.includes("path-redacted"))).toBe(true);
+  });
+
+  it("returns a revisioned, path-safe JSON snapshot", async () => {
+    sendCommand.mockResolvedValueOnce({
+      success: true,
+      data: { project: { name: "Edit" }, privacy: { nativePaths: "not returned" } },
+    });
+    const resource = getLiveContextResources({ timeoutMs: 10 })[0];
+    const output = await resource.read(new URL(resource.uri));
+    const snapshot = JSON.parse(output.contents[0].text);
+
+    expect(snapshot).toMatchObject({
+      ok: true,
+      resource: "premiere://project/info",
+      resourceSchemaVersion: 1,
+      backend: "cep",
+      data: { project: { name: "Edit" } },
+    });
+    expect(snapshot.snapshotRevision).toMatch(/^[a-f0-9]{20}$/);
+    expect(output.contents[0].uri).toBe("premiere://project/info");
+  });
+
+  it("returns a structured resource failure without fabricating host data", async () => {
+    sendCommand.mockResolvedValueOnce({ success: false, error: "CEP bridge offline" });
+    const resource = getLiveContextResources({ timeoutMs: 10 })[2];
+    const output = await resource.read(new URL(resource.uri));
+    const snapshot = JSON.parse(output.contents[0].text);
+
+    expect(snapshot).toMatchObject({
+      ok: false,
+      resource: "premiere://project/media",
+      error: "CEP bridge offline",
+    });
+    expect(snapshot).not.toHaveProperty("data");
+  });
+});

--- a/tests/mcp-modernization.test.ts
+++ b/tests/mcp-modernization.test.ts
@@ -100,6 +100,13 @@ describe("modern MCP surface", () => {
       const resources = await client.listResources();
       expect(resources.resources.map((resource) => resource.uri)).toContain("config://premiere-workflows");
       expect(resources.resources.map((resource) => resource.uri)).toContain("config://premiere-project-context");
+      expect(resources.resources.map((resource) => resource.uri)).toEqual(expect.arrayContaining([
+        "premiere://project/info",
+        "premiere://project/sequences",
+        "premiere://project/media",
+        "premiere://project/bins",
+        "premiere://timeline/active",
+      ]));
 
       const tools = await client.listTools();
       expect(tools.tools.find((tool) => tool.name === "get_project_info")?.annotations?.readOnlyHint).toBe(true);

--- a/tests/server.test.ts
+++ b/tests/server.test.ts
@@ -3,6 +3,8 @@ import { createServer, SERVER_VERSION } from "../src/server.js";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { z } from "zod";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 
 // Mock all tool modules to return simple tool definitions
 vi.mock("../src/bridge/file-bridge.js", () => ({
@@ -89,6 +91,34 @@ describe("createServer", () => {
     expect(() =>
       createServer({ tempDir: "/custom/tmp", timeoutMs: 5000 })
     ).not.toThrow();
+  });
+
+  it("registers and serves the bounded live context resources", async () => {
+    const server = createServer({});
+    const client = new Client({ name: "live-resource-test", version: "1.0.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+    try {
+      const resources = await client.listResources();
+      expect(resources.resources.map((resource) => resource.uri)).toEqual(expect.arrayContaining([
+        "premiere://project/info",
+        "premiere://project/sequences",
+        "premiere://project/media",
+        "premiere://project/bins",
+        "premiere://timeline/active",
+      ]));
+
+      const read = await client.readResource({ uri: "premiere://project/info" });
+      expect(JSON.parse(read.contents[0].text as string)).toMatchObject({
+        ok: true,
+        resource: "premiere://project/info",
+        resourceSchemaVersion: 1,
+      });
+    } finally {
+      await client.close();
+      await server.close();
+    }
   });
 });
 


### PR DESCRIPTION
## Outcome
Adds five read-only MCP resources that close the remaining meaningful comparison gap: live project context that agents can attach without invoking unbounded discovery tools.

## Added resources
- premiere://project/info
- premiere://project/sequences
- premiere://project/media
- premiere://project/bins
- premiere://timeline/active

## Safety
Every snapshot is bounded, has a deterministic revision hash, returns no native media or project-tree paths, and reports bridge failure without fabricating host data. It does not make mutations or claim playback, render, or licensed-host verification.

## Validation
- npm run check: 74 files, 1,727 tests
- npm run test:coverage: 90.32 percent branches
- git diff --check

Rebased on main after PR #211.