### PR TITLE
Fail closed on mismatched CEP install artifacts

### DIFF
--- a/docs/industry/host-validation-2026-08-22.md
+++ b/docs/industry/host-validation-2026-08-22.md
@@ -38,3 +38,23 @@ command and no `preview_project_intake` call ran.
 
 This record is failure evidence for the host gate, not evidence that Project
 Intake works in Premiere 2026.
+
+## 2026-08-23 follow-up
+
+- Audited the public `v1.13.0` GitHub release connector before installation.
+  Its SHA-256 was
+  `583949dd0decd5ed91478ce3c39a75c67512b5b06ac6d1db712eb03ee9701bf7`,
+  and its embedded CEP manifest reported `1.13.0`.
+- Installed that exact signed connector and confirmed the local installer
+  diagnosis passed.
+- Adobe Premiere Pro 2026 opened the disposable project and rendered the empty
+  editing workspace, but became unresponsive when the Window menu was invoked.
+  No CEP panel command or MCP tool call completed.
+- Adobe Premiere Pro (Beta) opened the same fixture through its required
+  conversion flow into a separate disposable copy. The converted project then
+  stalled on a black editing canvas before the CEP panel could be opened.
+
+The repeated host failure now covers the stable and Beta applications with the
+audited signed connector. It still does not demonstrate a
+`preview_project_intake` execution, and it does not justify a real-host support
+claim for this workflow.

--- a/scripts/install-cep.ps1
+++ b/scripts/install-cep.ps1
@@ -7,6 +7,8 @@ $ErrorActionPreference = "Stop"
 $projectDir = Split-Path -Parent $PSScriptRoot
 $pluginSource = Join-Path $projectDir "cep-plugin"
 $signedPackage = Join-Path $projectDir "artifacts\MCPBridgeCEP.zxp"
+$packageMetadata = Get-Content -LiteralPath (Join-Path $projectDir "package.json") -Raw | ConvertFrom-Json
+$expectedVersion = [string]$packageMetadata.version
 $cepRoot = Join-Path $env:APPDATA "Adobe\CEP\extensions"
 $pluginDestination = Join-Path $cepRoot "MCPBridgeCEP"
 $resolvedCepRoot = [System.IO.Path]::GetFullPath($cepRoot).TrimEnd([System.IO.Path]::DirectorySeparatorChar)
@@ -27,13 +29,45 @@ if (-not (Test-Path -LiteralPath (Join-Path $pluginSource "CSXS\manifest.xml")))
   throw "CEP plugin manifest not found at $pluginSource"
 }
 
+$signedPackageMatchesRelease = $false
+if (Test-Path -LiteralPath $signedPackage) {
+  try {
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+    $archive = [System.IO.Compression.ZipFile]::OpenRead($signedPackage)
+    try {
+      $manifestEntry = $archive.Entries | Where-Object { $_.FullName -eq "CSXS/manifest.xml" } | Select-Object -First 1
+      if (-not $manifestEntry) {
+        throw "Signed package does not contain CSXS/manifest.xml"
+      }
+      $reader = [System.IO.StreamReader]::new($manifestEntry.Open())
+      try {
+        $signedManifest = $reader.ReadToEnd()
+      }
+      finally {
+        $reader.Dispose()
+      }
+    }
+    finally {
+      $archive.Dispose()
+    }
+
+    $signedPackageMatchesRelease = $signedManifest -match ('ExtensionBundleVersion="' + [regex]::Escape($expectedVersion) + '"')
+    if (-not $signedPackageMatchesRelease) {
+      Write-Warning "Ignoring artifacts\MCPBridgeCEP.zxp because its embedded connector version does not match package version $expectedVersion."
+    }
+  }
+  catch {
+    Write-Warning "Ignoring artifacts\MCPBridgeCEP.zxp because its embedded manifest could not be verified: $($_.Exception.Message)"
+  }
+}
+
 if (-not $Diagnose) {
   New-Item -ItemType Directory -Force -Path $cepRoot | Out-Null
 
   if (Test-Path -LiteralPath $pluginDestination) {
     Remove-Item -LiteralPath $resolvedDestination -Recurse -Force
   }
-  if (Test-Path -LiteralPath $signedPackage) {
+  if ($signedPackageMatchesRelease) {
     $temporaryZip = Join-Path ([System.IO.Path]::GetTempPath()) ("MCPBridgeCEP-" + [guid]::NewGuid().ToString("N") + ".zip")
     try {
       Copy-Item -LiteralPath $signedPackage -Destination $temporaryZip

--- a/tests/cep-install.test.ts
+++ b/tests/cep-install.test.ts
@@ -30,6 +30,9 @@ describe("CEP installation metadata", () => {
     expect(readme).not.toContain("set these DWORD values");
     expect(installer).toContain('-PropertyType String -Value "1"');
     expect(installer).toContain("artifacts\\MCPBridgeCEP.zxp");
+    expect(installer).toContain('ExtensionBundleVersion="');
+    expect(installer).toContain("signedPackageMatchesRelease");
+    expect(installer).toContain("embedded connector version does not match package version");
     expect(installer).toContain("Signature verification failed");
   });
 


### PR DESCRIPTION
## Summary
- inspect the embedded CEP manifest before installing a bundled ZXP
- fall back to the current source connector when the artifact version differs from package.json
- record stable and Beta host-validation failures against the audited v1.13.0 connector

## Verification
- npm run check (74 files, 1727 tests)
- scripts/install-cep.ps1 -Diagnose

## Evidence boundary
Real Premiere execution remains blocked: stable 26.3.2 freezes when opening the Window menu after the disposable project loads, and Premiere Beta stalls on the converted disposable project's editing canvas. No preview_project_intake call completed.