### PR TITLE
Fix real-host social sequence workflows

### DIFF
--- a/docs/supported-actions.md
+++ b/docs/supported-actions.md
@@ -58,7 +58,7 @@ operation” when the tool has no enum-based mode.
 | `apply_lut` | Default profile | Single operation | Apply a LUT file to a clip via Lumetri Color |
 | `apply_spot_workflow_plan` | Default profile | Single operation | Apply one exact previewed motion-demo, product-spot, or brand-spot plan. Requires edit authority, requires filesystem authority for a MOGRT, and only targets empty explicitly named tracks. Host readback is not playback or render verification. |
 | `attach_custom_property` | Default profile | Single operation | Attach a custom property (key/value pair) to the active sequence |
-| `auto_reframe_sequence` | Default profile | Single operation | Auto-reframe a sequence for a different aspect ratio |
+| `auto_reframe_sequence` | Default profile | `motion_preset`: `slower`, `default`, `faster` | Auto-reframe a sequence for a different aspect ratio |
 | `batch_add_transitions` | Default profile | Single operation | Add the same transition to all cut points on a track |
 | `batch_apply_effect` | Default profile | `target`: `selected`, `track`, `all`; `track_type`: `video`, `audio` | Apply an effect to multiple clips at once. Can target selected clips, all clips on a track, or all clips in the sequence. |
 | `batch_enable_disable` | Default profile | `target`: `selected`, `track`, `all`; `track_type`: `video`, `audio` | Enable or disable multiple clips at once (selected, track, or all). |

--- a/src/tools/playhead.ts
+++ b/src/tools/playhead.ts
@@ -115,10 +115,17 @@ export function getPlayheadTools(bridgeOptions: BridgeOptions) {
           var seq = app.project.activeSequence;
           if (!seq) return __error("No active sequence");
           
-          seq.setInPoint(__secondsToTicks(${args.in_seconds}).toString());
-          seq.setOutPoint(__secondsToTicks(${args.out_seconds}).toString());
-          
-          return __result({ inSeconds: ${args.in_seconds}, outSeconds: ${args.out_seconds} });
+          seq.setInPoint(${args.in_seconds});
+          seq.setOutPoint(${args.out_seconds});
+          var observedIn = Number(seq.getInPoint());
+          var observedOut = Number(seq.getOutPoint());
+          var tolerance = 0.001;
+          if (!isFinite(observedIn) || !isFinite(observedOut) ||
+              Math.abs(observedIn - ${args.in_seconds}) > tolerance ||
+              Math.abs(observedOut - ${args.out_seconds}) > tolerance) {
+            return __error("Premiere did not apply the requested sequence in/out points; observed " + observedIn + " to " + observedOut + " seconds");
+          }
+          return __result({ inSeconds: observedIn, outSeconds: observedOut, verified: true });
         `);
         return sendCommand(script, bridgeOptions);
       },
@@ -133,8 +140,8 @@ export function getPlayheadTools(bridgeOptions: BridgeOptions) {
           if (!seq) return __error("No active sequence");
           
           return __result({
-            inSeconds: __ticksToSeconds(seq.getInPoint()),
-            outSeconds: __ticksToSeconds(seq.getOutPoint())
+            inSeconds: Number(seq.getInPoint()),
+            outSeconds: Number(seq.getOutPoint())
           });
         `);
         return sendCommand(script, bridgeOptions);

--- a/src/tools/sequence.ts
+++ b/src/tools/sequence.ts
@@ -253,18 +253,59 @@ export function getSequenceTools(bridgeOptions: BridgeOptions) {
             type: "number",
             description: "Target frame height in pixels",
           },
+          motion_preset: {
+            type: "string",
+            enum: ["slower", "default", "faster"],
+            description: "Premiere Auto Reframe motion preset (default: default)",
+          },
+          new_name: {
+            type: "string",
+            description: "Name for the newly created auto-reframed sequence",
+          },
+          use_nested_sequences: {
+            type: "boolean",
+            description: "Whether Auto Reframe should honor nested sequences (default: false)",
+          },
         },
         required: ["target_width", "target_height"],
       },
-      handler: async (args: { sequence_id?: string; target_width: number; target_height: number }) => {
+      handler: async (args: {
+        sequence_id?: string;
+        target_width: number;
+        target_height: number;
+        motion_preset?: "slower" | "default" | "faster";
+        new_name?: string;
+        use_nested_sequences?: boolean;
+      }) => {
+        if (!Number.isInteger(args.target_width) || !Number.isInteger(args.target_height)
+          || args.target_width < 1 || args.target_height < 1) {
+          return { success: false, error: "target_width and target_height must be positive integers" };
+        }
+        let a = args.target_width;
+        let b = args.target_height;
+        while (b !== 0) [a, b] = [b, a % b];
+        const numerator = args.target_width / a;
+        const denominator = args.target_height / a;
+        const motionPreset = args.motion_preset ?? "default";
+        const requestedName = args.new_name?.trim();
         const seqLookup = args.sequence_id
           ? `var seq = __findSequence("${escapeForExtendScript(args.sequence_id)}"); if (!seq) return __error("Sequence not found");`
           : `var seq = app.project.activeSequence; if (!seq) return __error("No active sequence");`;
 
         const script = buildToolScript(`
           ${seqLookup}
-          seq.autoReframeSequence(${args.target_width}, ${args.target_height}, false);
-          return __result({ reframed: true, name: seq.name, targetSize: "${args.target_width}x${args.target_height}" });
+          var newName = "${escapeForExtendScript(requestedName || "")}" || (seq.name + " - Auto Reframe ${numerator}x${denominator}");
+          var reframed = seq.autoReframeSequence(${numerator}, ${denominator}, "${motionPreset}", newName, ${args.use_nested_sequences === true});
+          if (!reframed) return __error("Premiere did not create an auto-reframed sequence");
+          return __result({
+            reframed: true,
+            sourceName: seq.name,
+            name: reframed.name,
+            id: reframed.sequenceID,
+            requestedAspectRatio: "${numerator}:${denominator}",
+            observedWidth: reframed.frameSizeHorizontal,
+            observedHeight: reframed.frameSizeVertical
+          });
         `);
         return sendCommand(script, bridgeOptions);
       },

--- a/src/tools/utility.ts
+++ b/src/tools/utility.ts
@@ -87,8 +87,28 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
           if (!item) return __error("Item not found");
 
           var oldName = item.name;
+          var sequence = null;
+          try {
+            if (item.isSequence && item.isSequence()) {
+              for (var i = 0; i < app.project.sequences.numSequences; i++) {
+                var candidate = app.project.sequences[i];
+                if (candidate.projectItem && candidate.projectItem.nodeId === item.nodeId) {
+                  sequence = candidate;
+                  break;
+                }
+              }
+              if (!sequence) return __error("The sequence project item could not be matched to a live sequence; no rename was attempted");
+            }
+          } catch (e) {
+            return __error("Could not inspect the project item before rename: " + e.toString());
+          }
           item.name = "${escapeForExtendScript(args.new_name)}";
-          return __result({ oldName: oldName, newName: item.name });
+          if (sequence) sequence.name = "${escapeForExtendScript(args.new_name)}";
+          if (item.name !== "${escapeForExtendScript(args.new_name)}" ||
+              (sequence && sequence.name !== "${escapeForExtendScript(args.new_name)}")) {
+            return __error("Premiere did not apply the requested name to every sequence representation");
+          }
+          return __result({ oldName: oldName, newName: item.name, sequenceVerified: sequence ? true : undefined });
         `);
         return sendCommand(script, bridgeOptions);
       },

--- a/tests/tools/regressions.test.ts
+++ b/tests/tools/regressions.test.ts
@@ -21,6 +21,8 @@ import { getAdvancedTools } from "../../src/tools/advanced.js";
 import { getTextTools } from "../../src/tools/text.js";
 import { getKeyframeTools } from "../../src/tools/keyframes.js";
 import { getCaptionTools } from "../../src/tools/captions.js";
+import { getSequenceTools } from "../../src/tools/sequence.js";
+import { getPlayheadTools } from "../../src/tools/playhead.js";
 
 const mockedSendCommand = vi.mocked(sendCommand);
 const bridgeOptions: BridgeOptions = { tempDir: "/tmp/test-bridge", timeoutMs: 5000 };
@@ -44,6 +46,44 @@ async function codeFor(tool: { handler: (args: never) => Promise<unknown> }, arg
 }
 
 beforeEach(() => vi.clearAllMocks());
+
+describe("real-host social sequence regressions", () => {
+  const sequence = getSequenceTools(bridgeOptions);
+  const playhead = getPlayheadTools(bridgeOptions);
+  const utility = getUtilityTools(bridgeOptions);
+
+  it("calls Auto Reframe with its required five arguments and reports the derivative", async () => {
+    const script = await scriptFor(sequence.auto_reframe_sequence, {
+      sequence_id: "source-1",
+      target_width: 1080,
+      target_height: 1920,
+      motion_preset: "faster",
+      new_name: "TikTok Test",
+    });
+    expect(script).toContain('seq.autoReframeSequence(9, 16, "faster", newName, false)');
+    expect(script).toContain("if (!reframed) return __error");
+    expect(script).toContain("id: reframed.sequenceID");
+  });
+
+  it("sets and reads sequence in/out points in seconds with verification", async () => {
+    const setScript = await scriptFor(playhead.set_sequence_in_out_points, { in_seconds: 0, out_seconds: 60 });
+    expect(setScript).toContain("seq.setInPoint(0)");
+    expect(setScript).toContain("seq.setOutPoint(60)");
+    expect(setScript).not.toContain("__secondsToTicks(60)");
+    expect(setScript).toContain("Math.abs(observedOut - 60)");
+
+    const getScript = await scriptFor(playhead.get_sequence_in_out_points, {});
+    expect(getScript).toContain("outSeconds: Number(seq.getOutPoint())");
+    expect(getScript).not.toContain("__ticksToSeconds(seq.getOutPoint())");
+  });
+
+  it("matches a sequence through projectItem.nodeId and verifies both names", async () => {
+    const script = await scriptFor(utility.rename_project_item, { item_id: "item-1", new_name: "Instagram Test" });
+    expect(script).toContain("candidate.projectItem.nodeId === item.nodeId");
+    expect(script).toContain('sequence.name = "Instagram Test"');
+    expect(script).toContain("sequence && sequence.name !==");
+  });
+});
 
 // https://github.com/leancoderkavy/premiere-pro-mcp/issues/6
 describe("issue #6 — markers must use seconds, not ticks", () => {


### PR DESCRIPTION
## Summary
- call Premiere Auto Reframe with its required five-argument contract and report the created derivative
- set and read sequence in/out points in seconds with immediate verification
- rename sequence project items and live sequence objects together with readback verification
- add real-host regression coverage and refresh generated supported-actions docs

## Automated verification
- `npm run check`
- 74 test files passed
- 1,733 tests passed
- 0 npm audit vulnerabilities

## Licensed Premiere Pro 2026 verification
Tested against the real `Sonoma Escape.prproj` project through the MCP stdio-to-CEP bridge:
- Auto Reframe created `Sonoma Escape - PR FIX VALIDATION 9x16` at 1080x1920
- sequence in/out wrote and read back exactly 0-60 seconds
- sequence rename updated both project item and live sequence object and read back successfully

No export or publishing was performed.