### PR TITLE
fix(release): verify npm package integrity

### DIFF
--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -29,4 +29,4 @@ jobs:
         if: matrix.os == 'windows-latest' && matrix.node == 22
         run: npm run test:coverage
       - name: Verify packaged files
-        run: npm pack --dry-run
+        run: npm run pack:check

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -55,7 +55,7 @@ jobs:
       - run: npm run build
       - if: ${{ inputs.skip_tests != 'true' }}
         run: npm test
-      - run: npm pack --dry-run
+      - run: npm run pack:check
       - name: Fail if version is already published
         shell: bash
         run: |
@@ -65,4 +65,4 @@ jobs:
             exit 1
           fi
       - name: Publish to npm
-        run: npm publish --access public --tag "${{ inputs.tag }}"
+        run: npm publish --provenance --access public --tag "${{ inputs.tag }}"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "uninstall-cep": "node dist/index.js --uninstall-cep",
     "lint": "eslint uxp-plugin --ext .cjs --max-warnings 0",
     "publish:npm": "node scripts/publish-npm.mjs",
-    "publish:npm:dry-run": "node scripts/publish-npm.mjs --dry-run"
+    "publish:npm:dry-run": "node scripts/publish-npm.mjs --dry-run",
+    "pack:check": "node scripts/verify-npm-package.mjs"
   },
   "repository": {
     "type": "git",

--- a/scripts/verify-npm-package.mjs
+++ b/scripts/verify-npm-package.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { gunzipSync } from "node:zlib";
+import { dirname, join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+const root = process.cwd();
+const npmCli = join(
+  dirname(process.execPath),
+  "node_modules",
+  "npm",
+  "bin",
+  "npm-cli.js",
+);
+const requiredFiles = [
+  "package/package.json",
+  "package/dist/index.js",
+  "package/dist/index.d.ts",
+  "package/cep-plugin/CSXS/manifest.xml",
+  "package/uxp-plugin/manifest.json",
+  "package/docs/supported-actions.md",
+  "package/scripts/install-cep.ps1",
+  "package/scripts/install-cep.sh",
+];
+
+function tarEntries(tarball) {
+  const archive = gunzipSync(readFileSync(tarball));
+  const entries = new Set();
+  let offset = 0;
+
+  while (offset + 512 <= archive.length) {
+    const header = archive.subarray(offset, offset + 512);
+    if (header.every((byte) => byte === 0)) break;
+
+    const name = header.subarray(0, 100).toString("utf8").replace(/\0.*$/, "");
+    const prefix = header.subarray(345, 500).toString("utf8").replace(/\0.*$/, "");
+    const sizeText = header.subarray(124, 136).toString("utf8").replace(/\0.*$/, "").trim();
+    const size = Number.parseInt(sizeText || "0", 8);
+    if (!name || !Number.isSafeInteger(size) || size < 0) {
+      throw new Error(`Invalid tar entry at byte ${offset} in ${tarball}`);
+    }
+
+    entries.add(prefix ? `${prefix}/${name}` : name);
+    offset += 512 + Math.ceil(size / 512) * 512;
+  }
+
+  return entries;
+}
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, {
+    cwd: root,
+    encoding: "utf8",
+    stdio: "pipe",
+    ...options,
+  });
+}
+
+function runNpm(args, options = {}) {
+  if (!existsSync(npmCli)) {
+    throw new Error("The bundled npm CLI is unavailable for package verification");
+  }
+  return run(process.execPath, [npmCli, ...args], options);
+}
+
+let tarball;
+let installDir;
+
+try {
+  const packed = JSON.parse(runNpm(["pack", "--json", "--ignore-scripts"]));
+  if (!Array.isArray(packed) || packed.length !== 1 || typeof packed[0]?.filename !== "string") {
+    throw new Error("npm pack did not return exactly one package filename");
+  }
+
+  tarball = resolve(root, packed[0].filename);
+  const entries = tarEntries(tarball);
+  const missing = requiredFiles.filter((path) => !entries.has(path));
+  if (missing.length > 0) {
+    throw new Error(`npm package is missing required files: ${missing.join(", ")}`);
+  }
+
+  installDir = mkdtempSync(join(tmpdir(), "premiere-pro-mcp-pack-"));
+  runNpm(["install", "--ignore-scripts", "--no-audit", "--no-fund", tarball], {
+    cwd: installDir,
+  });
+
+  const installedCli = join(installDir, "node_modules", "premiere-pro-mcp", "dist", "index.js");
+  if (!existsSync(installedCli)) {
+    throw new Error("isolated package installation did not contain the CLI entrypoint");
+  }
+  const help = run(process.execPath, [installedCli, "--help"], { cwd: installDir });
+  if (!help.includes("Usage:")) {
+    throw new Error("installed CLI --help did not return the expected usage text");
+  }
+
+  console.log(`Verified npm package contents and isolated CLI install: ${packed[0].filename}`);
+} finally {
+  if (installDir) rmSync(installDir, { recursive: true, force: true });
+  if (tarball) rmSync(tarball, { force: true });
+}

--- a/scripts/verify-npm-package.mjs
+++ b/scripts/verify-npm-package.mjs
@@ -7,13 +7,11 @@ import { dirname, join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 
 const root = process.cwd();
-const npmCli = join(
-  dirname(process.execPath),
-  "node_modules",
-  "npm",
-  "bin",
-  "npm-cli.js",
-);
+const npmCli = [
+  process.env.npm_execpath,
+  join(dirname(process.execPath), "node_modules", "npm", "bin", "npm-cli.js"),
+  join(dirname(dirname(process.execPath)), "lib", "node_modules", "npm", "bin", "npm-cli.js"),
+].find((candidate) => candidate && existsSync(candidate));
 const requiredFiles = [
   "package/package.json",
   "package/dist/index.js",
@@ -59,7 +57,7 @@ function run(command, args, options = {}) {
 }
 
 function runNpm(args, options = {}) {
-  if (!existsSync(npmCli)) {
+  if (!npmCli) {
     throw new Error("The bundled npm CLI is unavailable for package verification");
   }
   return run(process.execPath, [npmCli, ...args], options);

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ const args = process.argv.slice(2);
 
 if (args.includes("--help") || args.includes("-h")) {
   console.log(`
-premiere-pro-mcp — MCP server for Adobe Premiere Pro (298 default-profile tools)
+premiere-pro-mcp — MCP server for Adobe Premiere Pro (311 default-profile tools)
 
 Usage:
   premiere-pro-mcp              Start the MCP server (stdio transport)

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -86,4 +86,10 @@ describe("canonical release metadata", () => {
     );
     expect(release.coreTools - release.defaultProfileTools).toBe(2);
   });
+
+  it("keeps the CLI help count aligned with the default profile", () => {
+    expect(read("src/index.ts")).toContain(
+      `(${release.defaultProfileTools} default-profile tools)`,
+    );
+  });
 });

--- a/tests/release-package.test.ts
+++ b/tests/release-package.test.ts
@@ -16,6 +16,8 @@ describe("npm release package verification", () => {
     expect(verifier).toContain('"package/uxp-plugin/manifest.json"');
     expect(verifier).toContain('"--ignore-scripts"');
     expect(verifier).toContain('installedCli, "--help"');
+    expect(verifier).toContain("process.env.npm_execpath");
+    expect(verifier).toContain('"lib", "node_modules", "npm"');
   });
 
   it("requires provenance and package verification in every npm publish path", () => {

--- a/tests/release-package.test.ts
+++ b/tests/release-package.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const read = (path: string) => readFileSync(join(root, path), "utf8");
+
+describe("npm release package verification", () => {
+  it("checks the actual tarball and an isolated CLI installation before publication", () => {
+    const packageJson = JSON.parse(read("package.json"));
+    const verifier = read("scripts/verify-npm-package.mjs");
+
+    expect(packageJson.scripts["pack:check"]).toBe("node scripts/verify-npm-package.mjs");
+    expect(verifier).toContain('"package/dist/index.js"');
+    expect(verifier).toContain('"package/cep-plugin/CSXS/manifest.xml"');
+    expect(verifier).toContain('"package/uxp-plugin/manifest.json"');
+    expect(verifier).toContain('"--ignore-scripts"');
+    expect(verifier).toContain('installedCli, "--help"');
+  });
+
+  it("requires provenance and package verification in every npm publish path", () => {
+    const publish = read(".github/workflows/npm-publish.yml");
+    const crossPlatform = read(".github/workflows/cross-platform.yml");
+
+    expect(publish).toContain("npm publish --provenance --access public");
+    expect(publish).toContain("npm run pack:check");
+    expect(crossPlatform).toContain("npm run pack:check");
+  });
+});


### PR DESCRIPTION
## Why\nThe competitor comparison exposed release-integrity gaps: claimed npm provenance was not requested, package checks did not validate the tarball or an installed CLI, and the CLI help count drifted from canonical release metadata.\n\n## Changes\n- require npm provenance for manual npm publishes\n- verify required tarball contents and a clean isolated CLI --help install on each supported CI platform\n- align CLI help with canonical default-profile tool count\n- add release package workflow-contract tests\n\n## Validation\n- 
pm run build\n- 
pm run pack:check\n- 
px vitest run tests/release-metadata.test.ts tests/release-package.test.ts\n- 
pm run check\n- git diff --check\n\nNo package was published, release was created, deployment occurred, or Premiere host was touched.