### PR TITLE
fix(release): gate assets on canonical release tag

### DIFF
--- a/.github/workflows/cep-release.yml
+++ b/.github/workflows/cep-release.yml
@@ -12,6 +12,18 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      - run: npm run check
+      - name: Verify release identity
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: node scripts/verify-release-tag.mjs
       - name: Build and verify signed connector
         shell: pwsh
         run: ./scripts/build-signed-cep.ps1

--- a/.github/workflows/claude-desktop-bundle.yml
+++ b/.github/workflows/claude-desktop-bundle.yml
@@ -14,11 +14,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           package-manager-cache: false
       - run: npm ci
+      - run: npm run check
+      - name: Verify release identity
+        if: ${{ github.event_name == 'release' }}
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: node scripts/verify-release-tag.mjs
       - run: npm run build:claude
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/.github/workflows/uxp-package.yml
+++ b/.github/workflows/uxp-package.yml
@@ -30,11 +30,19 @@ jobs:
       UXP_MARKETPLACE_PLUGIN_ID: ${{ inputs.marketplace_plugin_id }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.sha }}
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
           package-manager-cache: false
       - run: npm ci
+      - run: npm run check
+      - name: Verify release identity
+        if: ${{ github.event_name == 'release' }}
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: node scripts/verify-release-tag.mjs
       - run: node scripts/validate-distribution.mjs --uxp
       - run: node scripts/build-uxp-ccx.mjs
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7

--- a/scripts/verify-release-tag.mjs
+++ b/scripts/verify-release-tag.mjs
@@ -1,0 +1,36 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const read = (path) => readFileSync(join(root, path), "utf8");
+const readJson = (path) => JSON.parse(read(path));
+const release = readJson("release-metadata.json");
+const tag = process.env.RELEASE_TAG;
+const expectedTag = `v${release.version}`;
+
+if (tag !== expectedTag) {
+  throw new Error(`Release tag must be exactly ${expectedTag}; received ${tag || "(missing)"}`);
+}
+
+const versionedJson = [
+  "package.json",
+  "claude-desktop/manifest.json",
+  "uxp-plugin/manifest.json",
+  "plugins/premiere-pro/.codex-plugin/plugin.json",
+  "claude-plugins/premiere-pro/.claude-plugin/plugin.json",
+];
+for (const path of versionedJson) {
+  if (readJson(path).version !== release.version) {
+    throw new Error(`${path} does not match release metadata version ${release.version}`);
+  }
+}
+
+const cepManifest = read("cep-plugin/CSXS/manifest.xml");
+if (!cepManifest.includes(`ExtensionBundleVersion="${release.version}"`)) {
+  throw new Error("CEP bundle version does not match release metadata");
+}
+
+console.log(`Release tag and distributable manifests verified for ${expectedTag}`);

--- a/tests/release-tag.test.ts
+++ b/tests/release-tag.test.ts
@@ -1,0 +1,46 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const read = (path: string) => readFileSync(join(root, path), "utf8");
+const release = JSON.parse(read("release-metadata.json"));
+
+function verify(tag?: string) {
+  return spawnSync(process.execPath, ["scripts/verify-release-tag.mjs"], {
+    cwd: root,
+    encoding: "utf8",
+    env: { ...process.env, RELEASE_TAG: tag ?? "" },
+  });
+}
+
+describe("release tag verification", () => {
+  it("accepts only the exact canonical tag and aligned distributable manifests", () => {
+    expect(verify(`v${release.version}`)).toMatchObject({
+      status: 0,
+      stdout: expect.stringContaining(`v${release.version}`),
+    });
+    expect(verify(`v${release.version}.1`)).toMatchObject({
+      status: 1,
+      stderr: expect.stringContaining("Release tag must be exactly"),
+    });
+    expect(verify()).toMatchObject({
+      status: 1,
+      stderr: expect.stringContaining("Release tag must be exactly"),
+    });
+  });
+
+  it("gates every release attachment workflow on the matching release tag", () => {
+    for (const workflow of [
+      ".github/workflows/cep-release.yml",
+      ".github/workflows/uxp-package.yml",
+      ".github/workflows/claude-desktop-bundle.yml",
+    ]) {
+      const source = read(workflow);
+      expect(source).toContain("npm run check");
+      expect(source).toContain("RELEASE_TAG: ${{ github.event.release.tag_name }}");
+      expect(source).toContain("node scripts/verify-release-tag.mjs");
+    }
+  });
+});


### PR DESCRIPTION
## Why\nRelease asset workflows built from an implicit checkout and did not prove that the published release tag matched all distributable manifests.\n\n## Changes\n- explicitly check out the release tag for CEP, UXP, and Claude Desktop assets\n- run the full project check before every release asset build\n- reject missing, malformed, or version-mismatched release tags and manifests\n- cover valid and invalid release-identity checks in Vitest\n\n## Validation\n- $env:RELEASE_TAG='v1.13.0'; node scripts/verify-release-tag.mjs\n- 
px vitest run tests/release-tag.test.ts\n- 
pm run check\n- git diff --check\n\nNo release was created, asset uploaded, deployment performed, or Premiere host accessed.