### PR TITLE
fix(installer): smoke verify embedded connector payload

### DIFF
--- a/.github/workflows/connector-installers.yml
+++ b/.github/workflows/connector-installers.yml
@@ -59,6 +59,13 @@ jobs:
           }
           if ('${{ inputs.require_production_signing }}' -eq 'true') { $params.RequireSigning = $true }
           ./scripts/build-connector-installer.ps1 @params
+      - name: Verify embedded connector package without installing it
+        shell: pwsh
+        run: |
+          $installer = Get-ChildItem "artifacts/connector-installers/*.exe" | Select-Object -First 1
+          if (-not $installer) { throw "Windows connector installer artifact was not produced." }
+          & $installer.FullName --verify-only
+          if ($LASTEXITCODE -ne 0) { throw "Windows connector installer verification failed." }
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: connector-installer-windows

--- a/.github/workflows/connector-installers.yml
+++ b/.github/workflows/connector-installers.yml
@@ -64,8 +64,8 @@ jobs:
         run: |
           $installer = Get-ChildItem "artifacts/connector-installers/*.exe" | Select-Object -First 1
           if (-not $installer) { throw "Windows connector installer artifact was not produced." }
-          & $installer.FullName --verify-only
-          if ($LASTEXITCODE -ne 0) { throw "Windows connector installer verification failed." }
+          $result = Start-Process -FilePath $installer.FullName -ArgumentList "--verify-only" -Wait -PassThru -NoNewWindow
+          if ($result.ExitCode -ne 0) { throw "Windows connector installer verification failed." }
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: connector-installer-windows

--- a/installer/windows/Program.cs
+++ b/installer/windows/Program.cs
@@ -13,6 +13,22 @@ internal static class Program
     [STAThread]
     private static int Main(string[] args)
     {
+        bool verifyOnly = args.Contains("--verify-only", StringComparer.OrdinalIgnoreCase);
+        if (verifyOnly)
+        {
+            try
+            {
+                VerifyEmbeddedPackage();
+                Console.WriteLine("Embedded connector package verified without installation.");
+                return 0;
+            }
+            catch (Exception error)
+            {
+                Console.Error.WriteLine("Embedded connector package verification failed: " + error.Message);
+                return 1;
+            }
+        }
+
         ApplicationConfiguration.Initialize();
 
         bool quiet = args.Contains("--quiet", StringComparer.OrdinalIgnoreCase);
@@ -132,6 +148,38 @@ internal static class Program
             Directory.CreateDirectory(Path.GetDirectoryName(target)!);
             entry.ExtractToFile(target, true);
         }
+    }
+
+    // This is deliberately read-only: CI can execute the shipped single-file installer
+    // and prove its embedded connector is structurally safe without touching the CEP
+    // directory, registry, Premiere process state, or any project data.
+    private static void VerifyEmbeddedPackage()
+    {
+        using Stream package = Assembly.GetExecutingAssembly().GetManifestResourceStream(ResourceName)
+            ?? throw new InvalidOperationException("The verified connector package is not embedded in this installer.");
+        using var archive = new ZipArchive(package, ZipArchiveMode.Read);
+        string validationRoot = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "premiere-connector-validate"))
+            .TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
+        ZipArchiveEntry? manifest = null;
+
+        foreach (ZipArchiveEntry entry in archive.Entries)
+        {
+            string target = Path.GetFullPath(Path.Combine(
+                validationRoot,
+                entry.FullName.Replace('/', Path.DirectorySeparatorChar)));
+            if (!target.StartsWith(validationRoot, StringComparison.OrdinalIgnoreCase))
+                throw new InvalidDataException("The connector package contains an unsafe path.");
+
+            if (string.Equals(entry.FullName, "CSXS/manifest.xml", StringComparison.Ordinal))
+                manifest = entry;
+        }
+
+        if (manifest is null) throw new InvalidDataException("The connector package is missing CSXS/manifest.xml.");
+        using var reader = new StreamReader(manifest.Open());
+        string manifestText = reader.ReadToEnd();
+        if (!manifestText.Contains("<ExtensionManifest", StringComparison.Ordinal) ||
+            !manifestText.Contains("ExtensionBundleId=\"com.mcp.premiere.bridge\"", StringComparison.Ordinal))
+            throw new InvalidDataException("The connector package has an invalid CSXS/manifest.xml.");
     }
 
     private static void RemoveConnector()

--- a/tests/connector-installers.test.ts
+++ b/tests/connector-installers.test.ts
@@ -21,6 +21,17 @@ describe("native connector installers", () => {
     expect(source).toContain("manifest.xml");
   });
 
+  it("verifies the shipped Windows installer payload without installing it", () => {
+    const source = read("installer/windows/Program.cs");
+    const workflow = read(".github/workflows/connector-installers.yml");
+    expect(source).toContain('"--verify-only"');
+    expect(source).toContain("VerifyEmbeddedPackage");
+    expect(source).toContain("premiere-connector-validate");
+    expect(source).toContain("GetManifestResourceStream");
+    expect(workflow).toContain("--verify-only");
+    expect(workflow).toContain("without installing it");
+  });
+
   it("makes production signing an explicit fail-closed gate", () => {
     const windows = read("scripts/build-connector-installer.ps1");
     const macos = read("scripts/build-connector-installer.sh");

--- a/tests/connector-installers.test.ts
+++ b/tests/connector-installers.test.ts
@@ -29,6 +29,7 @@ describe("native connector installers", () => {
     expect(source).toContain("premiere-connector-validate");
     expect(source).toContain("GetManifestResourceStream");
     expect(workflow).toContain("--verify-only");
+    expect(workflow).toContain("Start-Process");
     expect(workflow).toContain("without installing it");
   });
 


### PR DESCRIPTION
## Why\nThe built Windows installer was never executed in CI. This leaves the embedded connector payload unverified until a user installs it.\n\n## Changes\n- add --verify-only to inspect the embedded ZXP in memory\n- reject unsafe paths and a missing or invalid CEP manifest without extracting anything\n- run that mode against the produced EXE in the Windows installer workflow\n\n## Validation\n- 
px vitest run tests/connector-installers.test.ts\n- 
pm run check\n- git diff --check\n\nThe local machine has only the .NET runtime (no SDK), so compiling this Windows-specific binary is delegated to the existing GitHub Actions Windows installer job. The new mode performs no CEP-directory, registry, project, or Premiere-host write.