### PR TITLE
feat(marketing): add Project Intake conversion funnel

### DIFF
--- a/.agents/analytics-tracking-plan.md
+++ b/.agents/analytics-tracking-plan.md
@@ -20,11 +20,12 @@
 
 | Event | Properties | Trigger | Decision |
 | --- | --- | --- | --- |
-| `marketing_cta_clicked` | `location`, `destination` | Hero or navigation CTA | Which top-level path earns intent? |
+| `primary_cta_clicked` | `location`, `destination` | Hero, final, and guide CTA | Which top-level path earns intent? |
 | `marketing_demo_played` | `demo` | First playback per page view | Does the walkthrough support evaluation? |
 | `onboarding_assistant_selected` | `assistant` | Assistant route selected | Which setup path is demanded? |
 | `onboarding_download_started` | `route` | Bundle, guide, or connector action | Which routes progress to distribution? |
 | `onboarding_safe_prompt_copied` | none | Safe prompt copied | Is the visitor preparing to verify? |
+| `onboarding_project_intake_prompt_copied` | `prompt_kind` | Project Intake guide prompt copied | Does the outcome-specific route earn an attempted workflow preview? |
 | `onboarding_advanced_opened` | none | Advanced setup opened | How often does guided setup fall short? |
 | `onboarding_recovery_opened` | none | Recovery help opened | Where does setup friction appear? |
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 # MCP for Adobe Premiere Pro
 
+<!-- mcp-name: io.github.leancoderkavy/premiere-pro -->
+
 [![MCP Toplist](https://mcptoplist.com/badge/glama%2Fleancoderkavy%2Fpremiere-pro-mcp.svg)](https://mcptoplist.com/server/glama%2Fleancoderkavy%2Fpremiere-pro-mcp)
 
 **Give compatible AI assistants structured control over supported Adobe Premiere Pro workflows.**

--- a/docs/marketing/mcp-registry-readiness.md
+++ b/docs/marketing/mcp-registry-readiness.md
@@ -6,7 +6,7 @@ The official MCP Registry is a separate public listing. A repository change, an 
 
 Before a future submission:
 
-1. Release a new npm package version containing any required registry metadata.
+1. Release a new npm package version containing the required `mcpName` metadata and the matching README marker. The published npm version—not merely this repository checkout—must contain those values.
 2. Generate and inspect the registry manifest from the exact released package.
 3. Confirm the listing describes the published local stdio/server route accurately; do not present the local Premiere bridge as a hosted service.
 4. Validate the manifest and package version before authenticating.

--- a/landing/app/layout.tsx
+++ b/landing/app/layout.tsx
@@ -100,7 +100,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="scroll-smooth">
+    <html lang="en" className="scroll-smooth" data-scroll-behavior="smooth">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/landing/app/project-intake/page.tsx
+++ b/landing/app/project-intake/page.tsx
@@ -1,0 +1,222 @@
+import type { Metadata } from "next"
+import Image from "next/image"
+import Link from "next/link"
+import { ArrowRight, CheckCircle2, ClipboardCheck, FileSearch, ShieldCheck } from "lucide-react"
+import { Footer } from "@/components/sections/footer"
+import { ProjectIntakePrompts } from "./project-intake-prompts"
+
+const pageUrl = "https://premiere-pro-mcp.com/project-intake/"
+
+export const metadata: Metadata = {
+  title: "Premiere Pro Project Intake: Run a Read-Only Workflow Review",
+  description:
+    "Prepare a bounded, read-only Premiere Pro Project Intake preview with a safe connection check, an approved template, and a path-redacted review report.",
+  alternates: { canonical: "/project-intake/" },
+  keywords: [
+    "Premiere Pro project intake workflow",
+    "Premiere Pro project organization review",
+    "assistant editor project handoff",
+    "read-only Premiere Pro project preview",
+  ],
+  openGraph: {
+    title: "Premiere Pro Project Intake: Run a Read-Only Workflow Review",
+    description:
+      "Start with a safe connection check, then preview a path-redacted Project Intake report before anyone changes a Premiere project.",
+    url: "/project-intake/",
+    type: "website",
+    images: [
+      {
+        url: "/marketing/premiere-pro-mcp-social-square-v1.png",
+        width: 1254,
+        height: 1254,
+        alt: "MCP for Adobe Premiere Pro — reviewable Project Intake workflow",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Premiere Pro Project Intake: Run a Read-Only Workflow Review",
+    description:
+      "Start with a safe connection check, then preview a path-redacted Project Intake report before anyone changes a Premiere project.",
+    images: ["/marketing/premiere-pro-mcp-social-square-v1.png"],
+  },
+}
+
+const faqs = [
+  {
+    question: "Does Project Intake change a Premiere project?",
+    answer:
+      "No. The Project Intake preview returns a path-redacted report and proposed organization actions. It does not change Premiere or persist the facility template.",
+  },
+  {
+    question: "What should I use as the first test project?",
+    answer:
+      "Use a copied or non-sensitive project with an active sequence. A read-only connection check confirms only the current local setup; it is not a universal host-compatibility guarantee.",
+  },
+  {
+    question: "Does the report prove a project is ready for delivery?",
+    answer:
+      "No. It reports the bounded checks in the approved template. A human owner still reviews exceptions, truncated findings, and any later change before relying on the result.",
+  },
+]
+
+const structuredData = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebPage",
+      "@id": `${pageUrl}#webpage`,
+      name: "Premiere Pro Project Intake: Run a Read-Only Workflow Review",
+      description:
+        "Prepare a bounded, read-only Premiere Pro Project Intake preview with a safe connection check, an approved template, and a path-redacted review report.",
+      url: pageUrl,
+      isPartOf: { "@id": "https://premiere-pro-mcp.com/#website" },
+      about: { "@id": "https://premiere-pro-mcp.com/#software" },
+      inLanguage: "en-US",
+    },
+    {
+      "@type": "FAQPage",
+      "@id": `${pageUrl}#faq`,
+      mainEntity: faqs.map((faq) => ({
+        "@type": "Question",
+        name: faq.question,
+        acceptedAnswer: { "@type": "Answer", text: faq.answer },
+      })),
+    },
+    {
+      "@type": "BreadcrumbList",
+      "@id": `${pageUrl}#breadcrumb`,
+      itemListElement: [
+        { "@type": "ListItem", position: 1, name: "MCP for Adobe Premiere Pro", item: "https://premiere-pro-mcp.com/" },
+        { "@type": "ListItem", position: 2, name: "Project Intake", item: pageUrl },
+      ],
+    },
+  ],
+}
+
+const steps = [
+  {
+    icon: ShieldCheck,
+    title: "Confirm the local path",
+    description: "Check the selected bridge, an open project, and an active sequence before requesting a workflow.",
+  },
+  {
+    icon: FileSearch,
+    title: "Preview an approved template",
+    description: "Ask for a narrow, path-redacted review with explicit organization proposals and no mutation.",
+  },
+  {
+    icon: ClipboardCheck,
+    title: "Review before anyone changes work",
+    description: "A human owner accepts, escalates, or stops. A proposal is never permission to mutate the project.",
+  },
+]
+
+export default function ProjectIntakePage() {
+  return (
+    <>
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }} />
+      <header className="border-b border-zinc-800 bg-black/90 px-5 py-4 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl items-center justify-between gap-4">
+          <Link href="/" className="inline-flex items-center gap-3 text-sm font-semibold text-white">
+            <Image src="/marketing/premiere-pro-mcp-mark-v1.png" alt="" width={32} height={32} className="h-8 w-8 object-contain" />
+            <span>premiere-pro-mcp</span>
+          </Link>
+          <Link href="/#install" className="inline-flex min-h-11 items-center rounded-md border border-zinc-700 px-4 py-2 text-sm font-semibold text-zinc-100 transition-colors hover:border-zinc-500 hover:bg-zinc-900">
+            Install first
+          </Link>
+        </div>
+      </header>
+      <main id="main-content" className="min-h-screen bg-black text-zinc-100">
+        <section className="border-b border-zinc-900 px-5 pb-16 pt-14 sm:pb-24 sm:pt-20">
+          <div className="mx-auto max-w-4xl">
+            <nav aria-label="Breadcrumb" className="text-sm text-zinc-500">
+              <Link href="/" className="hover:text-purple-200">MCP for Adobe Premiere Pro</Link> <span aria-hidden="true">/</span> Project Intake
+            </nav>
+            <p className="mt-10 font-mono text-xs font-semibold uppercase tracking-[0.18em] text-purple-300">Project Intake · preview-only workflow</p>
+            <h1 className="mt-5 max-w-4xl text-balance text-4xl font-bold tracking-[-0.045em] text-white sm:text-6xl">
+              Turn a project handoff into a <span className="text-purple-300">reviewable intake.</span>
+            </h1>
+            <p className="mt-6 max-w-3xl text-lg leading-8 text-zinc-400 sm:text-xl">
+              For assistant editors and post leads who need to inspect an open Premiere project against an approved template before anyone reorganizes it.
+            </p>
+            <a href="#try" className="mt-8 inline-flex min-h-12 items-center gap-2 rounded-lg bg-purple-300 px-5 py-3 text-sm font-semibold text-black transition-colors hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-300 focus-visible:ring-offset-2 focus-visible:ring-offset-black">
+              Copy the safe first prompt <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </a>
+            <p className="mt-4 text-sm text-zinc-500">Free, local-first setup · no account or card required · use a copied test project first</p>
+          </div>
+        </section>
+
+        <section className="px-5 py-14 sm:py-20" aria-labelledby="workflow-heading">
+          <div className="mx-auto max-w-6xl">
+            <div className="max-w-3xl">
+              <p className="font-mono text-xs font-semibold uppercase tracking-[0.16em] text-purple-300">What the workflow does</p>
+              <h2 id="workflow-heading" className="mt-4 text-3xl font-bold tracking-tight text-white sm:text-5xl">A clear decision before a project changes.</h2>
+              <p className="mt-5 text-lg leading-8 text-zinc-400">The review gives a supervisor and assistant editor a common record of what the template checked, what needs attention, and what must remain a human decision.</p>
+            </div>
+            <div className="mt-10 grid gap-4 md:grid-cols-3">
+              {steps.map((step, index) => (
+                <article key={step.title} className="border border-zinc-800 bg-[#08080a] p-6 sm:p-7">
+                  <p className="font-mono text-xs font-semibold tracking-[0.14em] text-zinc-500">0{index + 1}</p>
+                  <step.icon className="mt-8 h-6 w-6 text-purple-300" strokeWidth={1.6} aria-hidden="true" />
+                  <h3 className="mt-5 text-xl font-semibold tracking-tight text-white">{step.title}</h3>
+                  <p className="mt-3 leading-7 text-zinc-400">{step.description}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section id="try" className="border-y border-zinc-900 bg-[#050506] px-5 py-14 sm:py-20" aria-labelledby="try-heading">
+          <div className="mx-auto max-w-4xl">
+            <p className="font-mono text-xs font-semibold uppercase tracking-[0.16em] text-purple-300">Try the read-only path</p>
+            <h2 id="try-heading" className="mt-4 text-3xl font-bold tracking-tight text-white sm:text-5xl">Copy the prompts. Keep the boundary visible.</h2>
+            <p className="mt-5 max-w-3xl text-lg leading-8 text-zinc-400">The first prompt checks the connection only. The second requests an intake preview only after you have an approved template and a ready local connection.</p>
+            <div className="mt-10"><ProjectIntakePrompts /></div>
+          </div>
+        </section>
+
+        <section className="px-5 py-14 sm:py-20" aria-labelledby="boundary-heading">
+          <div className="mx-auto grid max-w-6xl gap-10 lg:grid-cols-[1fr_1.25fr] lg:items-start">
+            <div>
+              <p className="font-mono text-xs font-semibold uppercase tracking-[0.16em] text-purple-300">Before you rely on it</p>
+              <h2 id="boundary-heading" className="mt-4 text-3xl font-bold tracking-tight text-white sm:text-5xl">A report is evidence, not an editorial approval.</h2>
+            </div>
+            <ul className="space-y-4 text-zinc-300">
+              {[
+                "Use a copied or non-sensitive project while you evaluate a new client, connector, or template.",
+                "Start with deterministic organization rules: expected bins, allowed labels, naming patterns, and allowlisted metadata.",
+                "Review every finding and exception with a human owner. A proposed action is not permission to apply it.",
+                "Keep preview, structural verification, playback review, and exported-frame verification as separate evidence classes.",
+              ].map((item) => (
+                <li key={item} className="flex gap-3 border-b border-zinc-900 pb-4 last:border-b-0">
+                  <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-purple-300" aria-hidden="true" />
+                  <span className="leading-7">{item}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </section>
+
+        <section className="border-y border-zinc-900 bg-[#050506] px-5 py-14 sm:py-20" aria-labelledby="faq-heading">
+          <div className="mx-auto max-w-4xl">
+            <p className="font-mono text-xs font-semibold uppercase tracking-[0.16em] text-purple-300">Questions before a handoff</p>
+            <h2 id="faq-heading" className="mt-4 text-3xl font-bold tracking-tight text-white sm:text-5xl">Straight answers about the preview boundary.</h2>
+            <div className="mt-10 divide-y divide-zinc-800 border-y border-zinc-800">
+              {faqs.map((faq) => (
+                <details key={faq.question} className="group py-5">
+                  <summary className="cursor-pointer list-none pr-8 font-medium text-zinc-100 marker:content-none group-open:text-purple-200">{faq.question}</summary>
+                  <p className="mt-3 max-w-3xl leading-7 text-zinc-400">{faq.answer}</p>
+                </details>
+              ))}
+            </div>
+            <Link href="/blog/premiere-pro-project-intake-checklist/" className="mt-8 inline-flex items-center gap-2 font-medium text-purple-200 hover:text-white">
+              Read the full Project Intake checklist <ArrowRight className="h-4 w-4" aria-hidden="true" />
+            </Link>
+          </div>
+        </section>
+      </main>
+      <Footer />
+    </>
+  )
+}

--- a/landing/app/project-intake/project-intake-prompts.tsx
+++ b/landing/app/project-intake/project-intake-prompts.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import { Check, Copy, TriangleAlert } from "lucide-react"
+import { useState } from "react"
+import { trackOnboardingEvent } from "@/lib/onboarding-events"
+import { projectIntakePreviewPrompt, safeFirstPrompt } from "@/lib/product"
+
+type CopyState = "idle" | "copied" | "unavailable"
+
+type PromptCardProps = {
+  description: string
+  label: string
+  prompt: string
+  promptKind: "safe_check" | "intake_preview"
+  title: string
+}
+
+function PromptCard({ description, label, prompt, promptKind, title }: PromptCardProps) {
+  const [copyState, setCopyState] = useState<CopyState>("idle")
+
+  async function copyPrompt() {
+    try {
+      if (!navigator.clipboard?.writeText) throw new Error("Clipboard API is unavailable")
+      await navigator.clipboard.writeText(prompt)
+      setCopyState("copied")
+      trackOnboardingEvent("onboarding_project_intake_prompt_copied", { prompt_kind: promptKind })
+      window.setTimeout(() => setCopyState("idle"), 2200)
+    } catch {
+      setCopyState("unavailable")
+    }
+  }
+
+  return (
+    <article className="rounded-xl border border-zinc-800 bg-[#08080a] p-5 sm:p-6">
+      <p className="font-mono text-xs font-semibold uppercase tracking-[0.15em] text-purple-300">{label}</p>
+      <h3 className="mt-3 text-xl font-semibold tracking-tight text-white">{title}</h3>
+      <p className="mt-3 max-w-2xl leading-7 text-zinc-400">{description}</p>
+      <code className="mt-5 block overflow-x-auto rounded-lg border border-zinc-800 bg-black px-4 py-4 text-sm leading-7 text-zinc-200 whitespace-pre-wrap">{prompt}</code>
+      <div className="mt-4 flex flex-col items-start gap-3 sm:flex-row sm:items-center">
+        <button
+          type="button"
+          onClick={copyPrompt}
+          className="inline-flex min-h-11 items-center gap-2 rounded-md border border-purple-300 bg-purple-300 px-4 py-2 text-sm font-semibold text-black transition-colors hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#08080a]"
+        >
+          {copyState === "copied" ? <Check className="h-4 w-4" aria-hidden="true" /> : <Copy className="h-4 w-4" aria-hidden="true" />}
+          <span>{copyState === "copied" ? "Copied" : "Copy prompt"}</span>
+        </button>
+        {copyState === "unavailable" ? (
+          <p className="inline-flex items-center gap-2 text-sm text-amber-200" role="status">
+            <TriangleAlert className="h-4 w-4 shrink-0" aria-hidden="true" />
+            Copy is unavailable here. Select the visible prompt and copy it manually.
+          </p>
+        ) : null}
+      </div>
+    </article>
+  )
+}
+
+export function ProjectIntakePrompts() {
+  return (
+    <div className="grid gap-5" aria-label="Project Intake prompts">
+      <PromptCard
+        label="Step 1 · Read-only"
+        title="Confirm the local connection"
+        description="Open a copied or non-sensitive project and an active sequence in Premiere. This check does not change the project."
+        prompt={safeFirstPrompt}
+        promptKind="safe_check"
+      />
+      <PromptCard
+        label="Step 2 · Preview only"
+        title="Request the intake review"
+        description="Use an approved intake template. The result is a path-redacted report and proposed organization actions—not permission to organize the project."
+        prompt={projectIntakePreviewPrompt}
+        promptKind="intake_preview"
+      />
+    </div>
+  )
+}

--- a/landing/app/sitemap.ts
+++ b/landing/app/sitemap.ts
@@ -23,6 +23,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.8,
     },
     {
+      url: `${siteUrl}/project-intake/`,
+      lastModified: new Date("2026-08-26T00:00:00Z"),
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
+    {
       url: `${siteUrl}/blog/`,
       lastModified: latestArticleDate,
       changeFrequency: "weekly",

--- a/landing/components/sections/final-cta.tsx
+++ b/landing/components/sections/final-cta.tsx
@@ -1,4 +1,5 @@
 import { ArrowRight, Github, ShieldCheck } from "lucide-react"
+import { TrackedLink } from "@/components/ui/tracked-link"
 import { product } from "@/lib/product"
 
 export function FinalCtaSection() {
@@ -17,13 +18,15 @@ export function FinalCtaSection() {
               Connect your assistant, safely verify the Premiere connection without changes, then preview your first edit.
             </p>
           </div>
-          <a
+          <TrackedLink
             href="#install"
+            trackingLocation="final_cta"
+            trackingDestination="safe_connection_check"
             className="inline-flex h-12 items-center justify-center gap-2 rounded-lg bg-gradient-to-r from-[#8b7cff] to-[#ef76b9] px-6 text-sm font-semibold text-white shadow-[0_12px_40px_rgba(139,124,255,0.2)] transition-transform hover:-translate-y-0.5"
           >
             Choose your assistant
             <ArrowRight className="h-4 w-4" />
-          </a>
+          </TrackedLink>
         </div>
         <div className="flex flex-col gap-3 pt-6 text-sm text-zinc-500 sm:flex-row sm:items-center sm:gap-8">
           <span className="inline-flex items-center gap-2">

--- a/landing/components/sections/footer.tsx
+++ b/landing/components/sections/footer.tsx
@@ -23,11 +23,11 @@ export function Footer() {
           <div>
             <p className="text-xs font-semibold uppercase tracking-[0.16em] text-zinc-600">Product</p>
             <div className="mt-4 flex flex-col gap-3 text-sm text-zinc-400">
-              <a href="#demo" className="hover:text-white">Demo</a>
-              <a href="#features" className="hover:text-white">Features</a>
-              <a href="#how-it-works" className="hover:text-white">How it works</a>
-              <a href="#install" className="hover:text-white">Install</a>
-              <a href="#faq" className="hover:text-white">FAQ</a>
+              <Link href="/#demo" className="hover:text-white">Demo</Link>
+              <Link href="/#features" className="hover:text-white">Features</Link>
+              <Link href="/#how-it-works" className="hover:text-white">How it works</Link>
+              <Link href="/#install" className="hover:text-white">Install</Link>
+              <Link href="/#faq" className="hover:text-white">FAQ</Link>
               <Link href="/facts/" className="hover:text-white">Canonical facts</Link>
               <Link href="/blog/" className="hover:text-white">Guides</Link>
               <a href="/docs/" className="hover:text-white">Documentation</a>

--- a/landing/components/sections/hero.tsx
+++ b/landing/components/sections/hero.tsx
@@ -10,6 +10,7 @@ const navItems = [
   { label: "Demo", href: "#demo" },
   { label: "Features", href: "#features" },
   { label: "How it works", href: "#how-it-works" },
+  { label: "Project Intake", href: "/project-intake/" },
   { label: "Install", href: "#install" },
   { label: "FAQ", href: "#faq" },
   { label: "Guides", href: "/blog/" },
@@ -92,12 +93,12 @@ export function HeroSection() {
                 <Package className="h-4 w-4" /> Run a safe connection check
               </TrackedLink>
               <TrackedLink
-                href="/docs/#project-context-heading"
+                href="/project-intake/"
                 trackingLocation="hero"
-                trackingDestination="project_context_docs"
+                trackingDestination="project_intake_workflow"
                 className="inline-flex h-12 items-center justify-center gap-2 rounded-lg border border-zinc-700 bg-zinc-950/80 px-6 text-sm font-semibold text-zinc-100 transition-colors hover:border-zinc-500 hover:bg-zinc-900"
               >
-                <ShieldCheck className="h-4 w-4" /> See the workflow boundary
+                <ShieldCheck className="h-4 w-4" /> See Project Intake
               </TrackedLink>
             </div>
             <p className="hero-enter hero-enter-3 mt-4 text-sm text-zinc-500">

--- a/landing/components/sections/mobile-nav.tsx
+++ b/landing/components/sections/mobile-nav.tsx
@@ -8,6 +8,7 @@ const mobileLinks = [
   { label: "Demo", href: "#demo" },
   { label: "Features", href: "#features" },
   { label: "How it works", href: "#how-it-works" },
+  { label: "Project Intake", href: "/project-intake/" },
   { label: "Install", href: "#install" },
   { label: "FAQ", href: "#faq" },
   { label: "Guides", href: "/blog/" },

--- a/landing/lib/onboarding-events.ts
+++ b/landing/lib/onboarding-events.ts
@@ -4,6 +4,7 @@ export type OnboardingEvent =
   | "onboarding_assistant_selected"
   | "onboarding_download_started"
   | "onboarding_safe_prompt_copied"
+  | "onboarding_project_intake_prompt_copied"
   | "onboarding_advanced_opened"
   | "onboarding_recovery_opened"
   | "marketing_demo_played"

--- a/landing/lib/product.ts
+++ b/landing/lib/product.ts
@@ -25,3 +25,6 @@ export const product = {
 
 export const safeFirstPrompt =
   "Safely check my Premiere connection with verify_premiere_connection. Make no changes."
+
+export const projectIntakePreviewPrompt =
+  "Evaluate this open Premiere project against our approved intake template. Return the path-redacted report and proposed organization actions. Do not change Premiere or persist the template."

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "premiere-pro-mcp",
+  "mcpName": "io.github.leancoderkavy/premiere-pro",
   "version": "1.13.0",
   "description": "MCP server for Adobe Premiere Pro with 313 core AI video editing tools and a capability-aware UXP bridge for supported Premiere workflows.",
   "main": "dist/index.js",

--- a/registry/README.md
+++ b/registry/README.md
@@ -1,0 +1,22 @@
+# Official MCP Registry candidate
+
+`server.json` is a prepared, unpublished registry record for the local stdio
+package. It does not create a public listing.
+
+The next npm release must contain the matching `mcpName` field in
+`package.json` and the `mcp-name` marker in the package README before this
+record can be published. The already-published `premiere-pro-mcp@1.13.0`
+package predates that metadata, so do not submit this exact file for v1.13.0.
+
+Before a future owner-approved publish:
+
+1. Bump the npm package and this manifest to the same new version.
+2. Publish and independently inspect the npm tarball.
+3. Run `mcp-publisher validate registry/server.json`.
+4. Confirm the package and manifest agree on the MCP name, local `stdio`
+   transport, repository, version, and capability-limited wording.
+5. Obtain action-time approval, then authenticate and publish once.
+6. Query the public registry for the returned exact listing URL.
+
+The Registry has immutable version metadata and currently does not offer an
+unpublish path. Do not replace these steps with a repository-only check.

--- a/registry/server.json
+++ b/registry/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "name": "io.github.leancoderkavy/premiere-pro",
+  "title": "MCP for Adobe Premiere Pro",
+  "description": "Free, MIT-licensed local MCP server for supported Adobe Premiere Pro workflows. Begin with a read-only connection check; supported operations remain capability- and host-dependent.",
+  "repository": {
+    "url": "https://github.com/leancoderkavy/premiere-pro-mcp",
+    "source": "github"
+  },
+  "version": "1.13.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "premiere-pro-mcp",
+      "version": "1.13.0",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Adds an indexable, preview-only Project Intake page with safe prompt-copy conversion, event coverage, navigation, and sitemap discovery. Prepares MCP Registry metadata for the next package release without publishing or claiming a live listing. Validation: root npm run check; landing lint/build/performance; strict marketing audit; browser QA at 360/390/430/1440px with zero console errors or warnings.