### PR TITLE
chore(release): prepare v1.14.0

### DIFF
--- a/.agents/product-marketing.md
+++ b/.agents/product-marketing.md
@@ -1,7 +1,7 @@
 # Product Marketing Context
 
 **Document version:** v9
-**Last updated:** 2026-08-23
+**Last updated:** 2026-08-27
 
 ## Product Overview
 
@@ -137,7 +137,7 @@
 
 ## Proof Points
 
-**Release facts:** v1.13.0 registers 319 core tools; the default profile exposes 317; an authenticated compatible UXP host can add 50 capability-gated tools for a 367-tool connected surface. The release also declares 37 modules, 4 MCP resources, and 11 workflow prompts. These are catalog and packaging facts from `release-metadata.json`, not a promise that a particular host operation will work.
+**Release facts:** v1.14.0 registers 319 core tools; the default profile exposes 317; an authenticated compatible UXP host can add 50 capability-gated tools for a 367-tool connected surface. The release also declares 37 modules, 4 MCP resources, and 11 workflow prompts. It adds focused tool packs, explicit output schemas, and a read-only review report. These are catalog and packaging facts from `release-metadata.json`, not a promise that a particular host operation will work.
 
 **Compatibility boundary:** The release targets Premiere Pro 2020–2026; UXP workflows require a compatible Premiere Pro 25.6.0+ host and advertised capabilities. CEP remains the default compatibility route. A compatibility range, package validation, CI pass, HTTP health check, or local build is not real-host proof.
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "premiere-pro",
       "source": "./claude-plugins/premiere-pro",
       "description": "Inspect, edit, verify, and export local Premiere Pro projects through MCP.",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "category": "creative",
       "tags": ["premiere-pro", "video-editing", "mcp"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.14.0] - 2026-08-27
+
+### Added
+
+- Added focused `essential`, `inspection`, `delivery`, and `captions` tool packs
+  so compatible MCP clients can begin with a smaller task-specific catalog.
+- Added `inspect_sequence_review_report`, a read-only, handoff-oriented sequence
+  report, and explicit MCP output schemas for every registered tool.
+
+### Safety
+
+- Tool packs change discoverability, not authority. Review reports redact media
+  paths by default and include marker comments only with explicit opt-in.
+- Package and response-contract checks remain distinct from licensed Premiere
+  host verification.
+
 ## [1.13.0] - 2026-08-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -33,17 +33,18 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 
 The AI handles the entire workflow through 319 core tools spanning the supported ExtendScript, QE DOM, local media and interchange analysis, revisioned project-context retrieval, safe edit-planning, project-intake preview, review handoff, and connection-verification surfaces. A compatible, authenticated UXP panel adds 50 documented, capability-gated tools without replacing the production CEP bridge.
 
-### Latest release: 1.13.0
+### Latest release: 1.14.0
 
-- **MOGRT text and graphics:** `set_effect_property` now accepts string-backed
-  parameters with safe serialization and readback status.
-- **Effect discovery clarity:** an empty legacy QE effect catalog now returns a
-  no-mutation capability response and directs connected hosts to the documented
-  UXP catalog/add workflow.
-- **Verification clarity:** property readback remains distinct from playback or
-  exported-frame verification in a licensed Premiere Pro host.
+- **Focused discovery:** compatible MCP clients can select essential,
+  inspection, delivery, or captions tool packs instead of beginning with the
+  full catalog.
+- **Review handoff:** `inspect_sequence_review_report` returns a read-only,
+  path-redacted sequence report, with marker comments only when requested.
+- **Interoperability:** all registered MCP tools now declare explicit output
+  schemas; this release does not substitute automated checks for licensed-host
+  verification.
 
-See the [v1.13.0 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.13.0)
+See the [v1.14.0 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.14.0)
 for complete details. Live installation in Premiere Pro still requires host verification.
 
 ---
@@ -72,9 +73,9 @@ inspection request, and ends with the same read-only connection check.
 
 ### Easiest supported path: Claude Desktop
 
-1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.13.0/premiere-pro-mcp-1.13.0.mcpb).
+1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.0/premiere-pro-mcp-1.14.0.mcpb).
 2. In Claude Desktop, open **Settings > Extensions > Advanced settings > Install Extension**, select the downloaded bundle, and restart Claude Desktop.
-3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.13.0/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
+3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.0/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
 4. Restart Premiere, open a project, then open **Window > Extensions > MCP for Adobe Premiere Pro**.
 5. In Claude, enter: `Safely check my Premiere connection with verify_premiere_connection. Make no changes.`
 
@@ -321,11 +322,11 @@ From a clone of this repository:
 ```bash
 codex plugin marketplace add .
 codex plugin add premiere-pro@premiere-pro-mcp
-npx -y premiere-pro-mcp@1.13.0 --install-cep
+npx -y premiere-pro-mcp@1.14.0 --install-cep
 ```
 
 Restart Premiere Pro and start a new Codex session after installation. The plugin
-launches `premiere-pro-mcp@1.13.0` through `npx`; the separate CEP installation is
+launches `premiere-pro-mcp@1.14.0` through `npx`; the separate CEP installation is
 required because the MCP server communicates with the running Premiere host through
 the local bridge.
 
@@ -345,7 +346,7 @@ For Claude Code, add this repository as a marketplace and install the plugin:
 Then install the Premiere bridge and start a new Claude Code session:
 
 ```bash
-npx -y premiere-pro-mcp@1.13.0 --install-cep
+npx -y premiere-pro-mcp@1.14.0 --install-cep
 ```
 
 The Claude Code package lives in

--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.13.0" ExtensionBundleName="MCP for Adobe Premiere Pro">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.14.0" ExtensionBundleName="MCP for Adobe Premiere Pro">
   <ExtensionList>
-    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.13.0"/>
-    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.13.0"/>
+    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.14.0"/>
+    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.14.0"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/cep-plugin/index.html
+++ b/cep-plugin/index.html
@@ -81,7 +81,7 @@
     <section class="update-section" aria-live="polite">
       <div class="update-copy">
         <span class="section-label">Connector updates</span>
-        <strong id="updateTitle">Version 1.13.0</strong>
+        <strong id="updateTitle">Version 1.14.0</strong>
         <span id="updateDetail">Checking for updates…</span>
       </div>
       <button id="btnUpdate" class="button button-update" onclick="handleUpdateClick()" type="button" disabled>

--- a/cep-plugin/updater.cjs
+++ b/cep-plugin/updater.cjs
@@ -7,7 +7,7 @@
 })(this, function () {
   "use strict";
 
-  var CURRENT_VERSION = "1.13.0";
+  var CURRENT_VERSION = "1.14.0";
   var LATEST_RELEASE_API =
     "https://api.github.com/repos/leancoderkavy/premiere-pro-mcp/releases/latest";
   var RELEASES_URL =

--- a/claude-desktop/manifest.json
+++ b/claude-desktop/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "premiere-pro-mcp",
   "display_name": "MCP for Adobe Premiere Pro",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Control a local Adobe Premiere Pro project through MCP.",
   "long_description": "Inspect projects, assemble and modify timelines, manage media, effects, audio and captions, and export deliverables through a local bridge to Adobe Premiere Pro.",
   "author": {

--- a/claude-plugins/premiere-pro/.claude-plugin/plugin.json
+++ b/claude-plugins/premiere-pro/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "premiere-pro",
   "displayName": "Premiere Pro MCP",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Inspect, edit, verify, and export local Adobe Premiere Pro projects through MCP.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/claude-plugins/premiere-pro/.mcp.json
+++ b/claude-plugins/premiere-pro/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "premiere-pro": {
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.13.0"]
+      "args": ["-y", "premiere-pro-mcp@1.14.0"]
     }
   }
 }

--- a/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.13.0 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.14.0 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -5,6 +5,27 @@ import { product } from "@/lib/product"
 
 const releases = [
   {
+    version: "1.14.0",
+    date: "2026-08-27",
+    label: "Focused workflow packs and review handoff",
+    groups: [
+      {
+        title: "Added",
+        items: [
+          "Added focused tool packs for essential work, inspection, delivery, and captions so compatible clients can start with a smaller, task-specific catalog.",
+          "Added a read-only sequence review report for editorial handoff, plus declared MCP output schemas for the registered tool surface.",
+        ],
+      },
+      {
+        title: "Safety",
+        items: [
+          "Tool packs reduce discoverability only; they do not grant new authority. Review reports redact media paths by default and include marker comments only when explicitly requested.",
+          "Automated checks validate the package and response contracts. Licensed-Premiere host execution remains a separate verification gate.",
+        ],
+      },
+    ],
+  },
+  {
     version: "1.13.0",
     date: "2026-08-22",
     label: "Preview-only project intake for assistant editors",

--- a/landing/lib/product.ts
+++ b/landing/lib/product.ts
@@ -1,7 +1,7 @@
 export const product = {
   name: "MCP for Adobe Premiere Pro",
-  version: "1.13.0",
-  releaseDate: "2026-08-22",
+  version: "1.14.0",
+  releaseDate: "2026-08-27",
   coreToolCount: 319,
   defaultProfileToolCount: 317,
   connectedUxpToolCount: 367,
@@ -10,10 +10,10 @@ export const product = {
   uxpMinimumVersion: "25.6",
   downloads: {
     claudeBundle:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.13.0/premiere-pro-mcp-1.13.0.mcpb",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.0/premiere-pro-mcp-1.14.0.mcpb",
     signedCepConnector:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.13.0/MCPBridgeCEP.zxp",
-    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.13.0",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.0/MCPBridgeCEP.zxp",
+    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.14.0",
   },
   links: {
     repository: "https://github.com/leancoderkavy/premiere-pro-mcp",

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -19,7 +19,7 @@ Guide: Premiere Pro delivery QC and loudness checklist: https://premiere-pro-mcp
 Source: https://github.com/leancoderkavy/premiere-pro-mcp
 npm: https://www.npmjs.com/package/premiere-pro-mcp
 License: MIT
-Current release: 1.13.0
+Current release: 1.14.0
 
 ## What it does
 

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -38,7 +38,7 @@ For a local project, a shared-storage Adobe Production, or a remote Adobe Team P
 
 ## Verified facts
 
-- Current project release: 1.13.0.
+- Current project release: 1.14.0.
 - Tool surface: 319 core structured MCP tools are registered; the default profile exposes 317. With an authenticated compatible UXP panel, 50 additional capability-gated tools bring the connected surface to 367. The server also exposes 4 resources and 11 workflow prompts.
 - Supported desktop platforms: Windows and macOS.
 - Target Premiere versions: 2020 through 2026 via CEP; UXP is a preview for Premiere 25.6 and newer.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "premiere-pro-mcp",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "premiere-pro-mcp",
   "mcpName": "io.github.leancoderkavy/premiere-pro",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "MCP server for Adobe Premiere Pro with 319 core AI video editing tools and a capability-aware UXP bridge for supported Premiere workflows.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/premiere-pro/.codex-plugin/plugin.json
+++ b/plugins/premiere-pro/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Plan, execute, verify, and export video edits in Adobe Premiere Pro through the Premiere Pro MCP server.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/plugins/premiere-pro/.mcp.json
+++ b/plugins/premiere-pro/.mcp.json
@@ -4,7 +4,7 @@
       "title": "Premiere Pro MCP",
       "description": "Inspect and edit a local Adobe Premiere Pro project through the Premiere Pro MCP bridge.",
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.13.0"]
+      "args": ["-y", "premiere-pro-mcp@1.14.0"]
     }
   }
 }

--- a/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.13.0 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.14.0 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/registry/README.md
+++ b/registry/README.md
@@ -6,7 +6,7 @@ package. It does not create a public listing.
 The next npm release must contain the matching `mcpName` field in
 `package.json` and the `mcp-name` marker in the package README before this
 record can be published. The already-published `premiere-pro-mcp@1.13.0`
-package predates that metadata, so do not submit this exact file for v1.13.0.
+package predates that metadata and cannot validate this versioned record.
 
 Before a future owner-approved publish:
 

--- a/registry/server.json
+++ b/registry/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/leancoderkavy/premiere-pro-mcp",
     "source": "github"
   },
-  "version": "1.13.0",
+  "version": "1.14.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "premiere-pro-mcp",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "transport": {
         "type": "stdio"
       }

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.13.0",
+  "version": "1.14.0",
   "coreTools": 319,
   "defaultProfileTools": 317,
   "uxpAdditionalTools": 50,

--- a/uxp-plugin/manifest.json
+++ b/uxp-plugin/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.ppmcp.premiere.uxp",
   "name": "MCP for Adobe Premiere Pro",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "main": "index.html",
   "host": { "app": "premierepro", "minVersion": "25.6.0" },
   "entrypoints": [


### PR DESCRIPTION
## Release scope\n\nPrepares v1.14.0 for the merged workflow-pack and review-handoff work.\n\n- Synchronizes npm, CEP, UXP, Claude Desktop, Codex, and marketplace versions.\n- Updates current download links and release notes to v1.14.0.\n- Documents focused tool packs, explicit MCP output schemas, and the read-only sequence review report.\n- Preserves the boundary that automated checks are not licensed-Premiere host proof.\n\n## Local verification\n\n- 
pm run check (78 test files, 1,765 tests)\n- 
pm run pack:check\n- landing: npm ci && npm run build (including performance budget)\n\nNo MCP Registry submission or marketplace publication is included.