### PR TITLE
fix(release): publish v1.14.1 with current npm CLI

### DIFF
--- a/.agents/product-marketing.md
+++ b/.agents/product-marketing.md
@@ -137,7 +137,7 @@
 
 ## Proof Points
 
-**Release facts:** v1.14.0 registers 319 core tools; the default profile exposes 317; an authenticated compatible UXP host can add 50 capability-gated tools for a 367-tool connected surface. The release also declares 37 modules, 4 MCP resources, and 11 workflow prompts. It adds focused tool packs, explicit output schemas, and a read-only review report. These are catalog and packaging facts from `release-metadata.json`, not a promise that a particular host operation will work.
+**Release facts:** v1.14.1 registers 319 core tools; the default profile exposes 317; an authenticated compatible UXP host can add 50 capability-gated tools for a 367-tool connected surface. The release also declares 37 modules, 4 MCP resources, and 11 workflow prompts. It includes focused tool packs, explicit output schemas, a read-only review report, and npm package verification compatible with the current npm CLI. These are catalog and packaging facts from `release-metadata.json`, not a promise that a particular host operation will work.
 
 **Compatibility boundary:** The release targets Premiere Pro 2020–2026; UXP workflows require a compatible Premiere Pro 25.6.0+ host and advertised capabilities. CEP remains the default compatibility route. A compatibility range, package validation, CI pass, HTTP health check, or local build is not real-host proof.
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "premiere-pro",
       "source": "./claude-plugins/premiere-pro",
       "description": "Inspect, edit, verify, and export local Premiere Pro projects through MCP.",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "category": "creative",
       "tags": ["premiere-pro", "video-editing", "mcp"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.14.1] - 2026-08-27
+
+### Fixed
+
+- Made npm package verification isolate its temporary tarball and select the
+  package matching `package.json`, avoiding a current npm CLI packaging
+  regression before publication.
+
 ## [1.14.0] - 2026-08-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 
 The AI handles the entire workflow through 319 core tools spanning the supported ExtendScript, QE DOM, local media and interchange analysis, revisioned project-context retrieval, safe edit-planning, project-intake preview, review handoff, and connection-verification surfaces. A compatible, authenticated UXP panel adds 50 documented, capability-gated tools without replacing the production CEP bridge.
 
-### Latest release: 1.14.0
+### Latest release: 1.14.1
 
 - **Focused discovery:** compatible MCP clients can select essential,
   inspection, delivery, or captions tool packs instead of beginning with the
@@ -43,8 +43,11 @@ The AI handles the entire workflow through 319 core tools spanning the supported
 - **Interoperability:** all registered MCP tools now declare explicit output
   schemas; this release does not substitute automated checks for licensed-host
   verification.
+- **Reliable packaging:** npm package verification now isolates its temporary
+  tarball, keeping the validated distribution path compatible with the current
+  npm CLI.
 
-See the [v1.14.0 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.14.0)
+See the [v1.14.1 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.14.1)
 for complete details. Live installation in Premiere Pro still requires host verification.
 
 ---
@@ -73,9 +76,9 @@ inspection request, and ends with the same read-only connection check.
 
 ### Easiest supported path: Claude Desktop
 
-1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.0/premiere-pro-mcp-1.14.0.mcpb).
+1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.1/premiere-pro-mcp-1.14.1.mcpb).
 2. In Claude Desktop, open **Settings > Extensions > Advanced settings > Install Extension**, select the downloaded bundle, and restart Claude Desktop.
-3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.0/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
+3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.1/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
 4. Restart Premiere, open a project, then open **Window > Extensions > MCP for Adobe Premiere Pro**.
 5. In Claude, enter: `Safely check my Premiere connection with verify_premiere_connection. Make no changes.`
 
@@ -322,11 +325,11 @@ From a clone of this repository:
 ```bash
 codex plugin marketplace add .
 codex plugin add premiere-pro@premiere-pro-mcp
-npx -y premiere-pro-mcp@1.14.0 --install-cep
+npx -y premiere-pro-mcp@1.14.1 --install-cep
 ```
 
 Restart Premiere Pro and start a new Codex session after installation. The plugin
-launches `premiere-pro-mcp@1.14.0` through `npx`; the separate CEP installation is
+launches `premiere-pro-mcp@1.14.1` through `npx`; the separate CEP installation is
 required because the MCP server communicates with the running Premiere host through
 the local bridge.
 
@@ -346,7 +349,7 @@ For Claude Code, add this repository as a marketplace and install the plugin:
 Then install the Premiere bridge and start a new Claude Code session:
 
 ```bash
-npx -y premiere-pro-mcp@1.14.0 --install-cep
+npx -y premiere-pro-mcp@1.14.1 --install-cep
 ```
 
 The Claude Code package lives in

--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.14.0" ExtensionBundleName="MCP for Adobe Premiere Pro">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.14.1" ExtensionBundleName="MCP for Adobe Premiere Pro">
   <ExtensionList>
-    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.14.0"/>
-    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.14.0"/>
+    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.14.1"/>
+    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.14.1"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/cep-plugin/index.html
+++ b/cep-plugin/index.html
@@ -81,7 +81,7 @@
     <section class="update-section" aria-live="polite">
       <div class="update-copy">
         <span class="section-label">Connector updates</span>
-        <strong id="updateTitle">Version 1.14.0</strong>
+        <strong id="updateTitle">Version 1.14.1</strong>
         <span id="updateDetail">Checking for updates…</span>
       </div>
       <button id="btnUpdate" class="button button-update" onclick="handleUpdateClick()" type="button" disabled>

--- a/cep-plugin/updater.cjs
+++ b/cep-plugin/updater.cjs
@@ -7,7 +7,7 @@
 })(this, function () {
   "use strict";
 
-  var CURRENT_VERSION = "1.14.0";
+  var CURRENT_VERSION = "1.14.1";
   var LATEST_RELEASE_API =
     "https://api.github.com/repos/leancoderkavy/premiere-pro-mcp/releases/latest";
   var RELEASES_URL =

--- a/claude-desktop/manifest.json
+++ b/claude-desktop/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "premiere-pro-mcp",
   "display_name": "MCP for Adobe Premiere Pro",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Control a local Adobe Premiere Pro project through MCP.",
   "long_description": "Inspect projects, assemble and modify timelines, manage media, effects, audio and captions, and export deliverables through a local bridge to Adobe Premiere Pro.",
   "author": {

--- a/claude-plugins/premiere-pro/.claude-plugin/plugin.json
+++ b/claude-plugins/premiere-pro/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "premiere-pro",
   "displayName": "Premiere Pro MCP",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Inspect, edit, verify, and export local Adobe Premiere Pro projects through MCP.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/claude-plugins/premiere-pro/.mcp.json
+++ b/claude-plugins/premiere-pro/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "premiere-pro": {
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.14.0"]
+      "args": ["-y", "premiere-pro-mcp@1.14.1"]
     }
   }
 }

--- a/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.14.0 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.14.1 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -5,6 +5,19 @@ import { product } from "@/lib/product"
 
 const releases = [
   {
+    version: "1.14.1",
+    date: "2026-08-27",
+    label: "Reliable npm package verification",
+    groups: [
+      {
+        title: "Fixed",
+        items: [
+          "Made package verification isolate its temporary npm tarball and select the package that matches package.json, keeping release validation stable with the current npm CLI.",
+        ],
+      },
+    ],
+  },
+  {
     version: "1.14.0",
     date: "2026-08-27",
     label: "Focused workflow packs and review handoff",

--- a/landing/lib/product.ts
+++ b/landing/lib/product.ts
@@ -1,6 +1,6 @@
 export const product = {
   name: "MCP for Adobe Premiere Pro",
-  version: "1.14.0",
+  version: "1.14.1",
   releaseDate: "2026-08-27",
   coreToolCount: 319,
   defaultProfileToolCount: 317,
@@ -10,10 +10,10 @@ export const product = {
   uxpMinimumVersion: "25.6",
   downloads: {
     claudeBundle:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.0/premiere-pro-mcp-1.14.0.mcpb",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.1/premiere-pro-mcp-1.14.1.mcpb",
     signedCepConnector:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.0/MCPBridgeCEP.zxp",
-    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.14.0",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.1/MCPBridgeCEP.zxp",
+    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.14.1",
   },
   links: {
     repository: "https://github.com/leancoderkavy/premiere-pro-mcp",

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -19,7 +19,7 @@ Guide: Premiere Pro delivery QC and loudness checklist: https://premiere-pro-mcp
 Source: https://github.com/leancoderkavy/premiere-pro-mcp
 npm: https://www.npmjs.com/package/premiere-pro-mcp
 License: MIT
-Current release: 1.14.0
+Current release: 1.14.1
 
 ## What it does
 

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -38,7 +38,7 @@ For a local project, a shared-storage Adobe Production, or a remote Adobe Team P
 
 ## Verified facts
 
-- Current project release: 1.14.0.
+- Current project release: 1.14.1.
 - Tool surface: 319 core structured MCP tools are registered; the default profile exposes 317. With an authenticated compatible UXP panel, 50 additional capability-gated tools bring the connected surface to 367. The server also exposes 4 resources and 11 workflow prompts.
 - Supported desktop platforms: Windows and macOS.
 - Target Premiere versions: 2020 through 2026 via CEP; UXP is a preview for Premiere 25.6 and newer.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "premiere-pro-mcp",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "premiere-pro-mcp",
   "mcpName": "io.github.leancoderkavy/premiere-pro",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "MCP server for Adobe Premiere Pro with 319 core AI video editing tools and a capability-aware UXP bridge for supported Premiere workflows.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/premiere-pro/.codex-plugin/plugin.json
+++ b/plugins/premiere-pro/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "description": "Plan, execute, verify, and export video edits in Adobe Premiere Pro through the Premiere Pro MCP server.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/plugins/premiere-pro/.mcp.json
+++ b/plugins/premiere-pro/.mcp.json
@@ -4,7 +4,7 @@
       "title": "Premiere Pro MCP",
       "description": "Inspect and edit a local Adobe Premiere Pro project through the Premiere Pro MCP bridge.",
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.14.0"]
+      "args": ["-y", "premiere-pro-mcp@1.14.1"]
     }
   }
 }

--- a/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.14.0 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.14.1 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/registry/server.json
+++ b/registry/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/leancoderkavy/premiere-pro-mcp",
     "source": "github"
   },
-  "version": "1.14.0",
+  "version": "1.14.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "premiere-pro-mcp",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "transport": {
         "type": "stdio"
       }

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.14.0",
+  "version": "1.14.1",
   "coreTools": 319,
   "defaultProfileTools": 317,
   "uxpAdditionalTools": 50,

--- a/scripts/verify-npm-package.mjs
+++ b/scripts/verify-npm-package.mjs
@@ -65,14 +65,30 @@ function runNpm(args, options = {}) {
 
 let tarball;
 let installDir;
+let packDir;
 
 try {
-  const packed = JSON.parse(runNpm(["pack", "--json", "--ignore-scripts"]));
-  if (!Array.isArray(packed) || packed.length !== 1 || typeof packed[0]?.filename !== "string") {
-    throw new Error("npm pack did not return exactly one package filename");
+  packDir = mkdtempSync(join(tmpdir(), "premiere-pro-mcp-pack-output-"));
+  const packed = JSON.parse(
+    runNpm(["pack", "--json", "--ignore-scripts", "--pack-destination", packDir]),
+  );
+  const packageJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+  const packEntries = Array.isArray(packed)
+    ? packed
+    : packed && typeof packed === "object"
+      ? Object.values(packed)
+      : [];
+  const matchingPackages = packEntries.filter(
+    (entry) =>
+      entry?.name === packageJson.name &&
+      entry?.version === packageJson.version &&
+      typeof entry?.filename === "string",
+  );
+  if (matchingPackages.length !== 1) {
+    throw new Error("npm pack did not return exactly one package matching package.json");
   }
 
-  tarball = resolve(root, packed[0].filename);
+  tarball = resolve(packDir, matchingPackages[0].filename);
   const entries = tarEntries(tarball);
   const missing = requiredFiles.filter((path) => !entries.has(path));
   if (missing.length > 0) {
@@ -93,8 +109,11 @@ try {
     throw new Error("installed CLI --help did not return the expected usage text");
   }
 
-  console.log(`Verified npm package contents and isolated CLI install: ${packed[0].filename}`);
+  console.log(
+    `Verified npm package contents and isolated CLI install: ${matchingPackages[0].filename}`,
+  );
 } finally {
   if (installDir) rmSync(installDir, { recursive: true, force: true });
   if (tarball) rmSync(tarball, { force: true });
+  if (packDir) rmSync(packDir, { recursive: true, force: true });
 }

--- a/tests/release-package.test.ts
+++ b/tests/release-package.test.ts
@@ -15,6 +15,8 @@ describe("npm release package verification", () => {
     expect(verifier).toContain('"package/cep-plugin/CSXS/manifest.xml"');
     expect(verifier).toContain('"package/uxp-plugin/manifest.json"');
     expect(verifier).toContain('"--ignore-scripts"');
+    expect(verifier).toContain('"--pack-destination"');
+    expect(verifier).toContain("Object.values(packed)");
     expect(verifier).toContain('installedCli, "--help"');
     expect(verifier).toContain("process.env.npm_execpath");
     expect(verifier).toContain('"lib", "node_modules", "npm"');

--- a/uxp-plugin/manifest.json
+++ b/uxp-plugin/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.ppmcp.premiere.uxp",
   "name": "MCP for Adobe Premiere Pro",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "main": "index.html",
   "host": { "app": "premierepro", "minVersion": "25.6.0" },
   "entrypoints": [


### PR DESCRIPTION
## Why\n\nThe v1.14.0 npm workflow stopped before publication because npm 12 changes 
pm pack --json from an array to an object keyed by package name. GitHub release assets and Fly deployment completed, but npm latest remained v1.13.0.\n\n## Fix\n\n- Isolate 
pm pack output in a temporary directory.\n- Accept the supported array and keyed-object JSON shapes, then select the one entry matching package.json.\n- Retain tarball-content and isolated-CLI checks; add regression assertions.\n- Prepare a patch release v1.14.1 with synchronized distribution metadata.\n\n## Evidence\n\n- Reproduced the failure with 
pm@12.0.2.\n- 
px -y npm@latest run pack:check passed after the fix.\n- 
pm run check passed (78 files, 1,765 tests).\n- landing: npm run build passed, including performance budget.\n- Default 
pm run pack:check passed.\n\nNo registry or marketplace publication is included.