### PR TITLE
feat(bridge): add CEP liveness heartbeats

### DIFF
--- a/cep-plugin/main.js
+++ b/cep-plugin/main.js
@@ -8,6 +8,8 @@ var pollInterval = null;
 var commandCount = 0;
 var tempDir = "";
 var POLL_MS = 200;
+var HEARTBEAT_MS = 1000;
+var heartbeatInterval = null;
 
 // ---- Logging ----
 function log(msg, cls) {
@@ -157,6 +159,36 @@ function deleteFile(filePath) {
   } catch (e) {}
 }
 
+// The heartbeat carries only protocol state. It is published by rename so a
+// server never observes partial JSON, and an older server can ignore it.
+function writeBridgeHeartbeat() {
+  if (!tempDir) return;
+  var heartbeatPath = path.join(tempDir, "bridge-heartbeat.json");
+  var stagedPath = heartbeatPath + "." + ENGINE_ID + ".staged";
+  try {
+    fs.writeFileSync(stagedPath, JSON.stringify({
+      protocolVersion: 1,
+      state: bridgeRunning ? "running" : "waiting"
+    }), "utf-8");
+    fs.renameSync(stagedPath, heartbeatPath);
+  } catch (e) {
+    deleteFile(stagedPath);
+  }
+}
+
+function startBridgeHeartbeat() {
+  if (heartbeatInterval) clearInterval(heartbeatInterval);
+  writeBridgeHeartbeat();
+  heartbeatInterval = setInterval(writeBridgeHeartbeat, HEARTBEAT_MS);
+}
+
+function stopBridgeHeartbeat() {
+  if (heartbeatInterval) clearInterval(heartbeatInterval);
+  heartbeatInterval = null;
+  // Keep the last heartbeat in place. Its age lets newer servers diagnose a
+  // stopped connector, while concurrent visible/headless panels stay isolated.
+}
+
 // ---- Script Execution ----
 function executeScript(script, callback) {
   // Script is already wrapped in an IIFE by the MCP server's buildScript(),
@@ -264,6 +296,7 @@ function startBridge() {
 
   ensureDir(tempDir);
   bridgeRunning = true;
+  startBridgeHeartbeat();
   setStatus("waiting", "Connector running");
   log("Connector started and ready for safe checks.", "ok");
 
@@ -279,6 +312,8 @@ function startBridge() {
 
 function stopBridge() {
   bridgeRunning = false;
+  writeBridgeHeartbeat();
+  stopBridgeHeartbeat();
   if (pollInterval) clearInterval(pollInterval);
   pollInterval = null;
 
@@ -438,6 +473,7 @@ function handleUpdateClick() {
   // one to click Start, and macOS periodically purges the temp dir — so create it
   // rather than gating auto-start on its existence.
   ensureDir(tempDir);
+  startBridgeHeartbeat();
   log("Auto-starting bridge...");
   setTimeout(startBridge, 500);
   setTimeout(checkForUpdates, 1200);

--- a/docs/supported-actions.md
+++ b/docs/supported-actions.md
@@ -128,7 +128,7 @@ operation” when the tool has no enum-based mode.
 | `get_all_project_paths` | Default profile | Single operation | Get all unique media file paths used in the project. Useful for asset management and archiving. |
 | `get_av_feature_support` | Default profile | Single operation | Report the documented automation boundary for advanced audio and modern color management, including actionable reasons for UI-only features. |
 | `get_bin_contents` | Default profile | Single operation | Get detailed contents of a specific bin (folder) including all nested items, media paths, offline status, color labels, and metadata. Searches by bin name or node ID. |
-| `get_bridge_telemetry` | Default profile | Single operation | Inspect privacy-preserving aggregate bridge health: pending command/response counts, busy operations, and queue age without returning project or personal data. |
+| `get_bridge_telemetry` | Default profile | Single operation | Inspect privacy-preserving aggregate bridge health: pending command/response counts, busy operations, queue age, and CEP heartbeat state without returning project or personal data. |
 | `get_capabilities` | Default profile | Single operation | Report Windows/macOS support, Premiere Pro backend coverage, enabled authority, and whether live host verification is still required. |
 | `get_clip_adjustment_layer` | Default profile | Single operation | Check if a clip is an adjustment layer |
 | `get_clip_at_playhead` | Default profile | `track_type`: `video`, `audio`, `both` | Get all clips at the current playhead position across all tracks. |

--- a/src/bridge/file-bridge.ts
+++ b/src/bridge/file-bridge.ts
@@ -7,16 +7,31 @@ import { getHelpersSource, helpersFileName, buildBootstrap } from "./script-buil
 const DEFAULT_TEMP_DIR = join(tmpdir(), "premiere-mcp-bridge");
 const POLL_FALLBACK_MS = 250;
 const DEFAULT_TIMEOUT_MS = 30000;
+export const BRIDGE_HEARTBEAT_FILE = "bridge-heartbeat.json";
+export const BRIDGE_HEARTBEAT_STALE_MS = 3_000;
 
 export interface BridgeOptions {
   tempDir?: string;
   timeoutMs?: number;
+  /**
+   * Reject a health-style command without publishing it when a current CEP
+   * connector explicitly reports that it is waiting or its heartbeat is stale.
+   * A missing heartbeat remains compatible with older installed connectors.
+   */
+  failFastOnUnreadyHeartbeat?: boolean;
 }
 
 export interface CommandResult {
   success: boolean;
   data?: unknown;
   error?: string;
+}
+
+export type BridgeLivenessState = "running" | "waiting" | "stale" | "unknown";
+
+export interface BridgeLiveness {
+  state: BridgeLivenessState;
+  ageMs: number | null;
 }
 
 /**
@@ -64,6 +79,54 @@ export function getTempDir(options?: BridgeOptions): string {
 }
 
 /**
+ * Inspect the CEP panel's small, content-free heartbeat. This never creates a
+ * directory or reads command, response, project, or media data. Unknown is
+ * intentionally non-fatal so a server upgrade stays compatible with older CEP
+ * panels that do not publish a heartbeat yet.
+ */
+export function getBridgeLiveness(
+  options?: BridgeOptions,
+  nowMs = Date.now(),
+): BridgeLiveness {
+  const heartbeatPath = join(getTempDir(options), BRIDGE_HEARTBEAT_FILE);
+  try {
+    if (!existsSync(heartbeatPath)) return { state: "unknown", ageMs: null };
+    const raw = readFileSync(heartbeatPath, "utf-8");
+    const heartbeat = JSON.parse(raw) as Record<string, unknown>;
+    if (
+      heartbeat.protocolVersion !== 1 ||
+      (heartbeat.state !== "running" && heartbeat.state !== "waiting")
+    ) {
+      return { state: "unknown", ageMs: null };
+    }
+    const ageMs = Math.max(0, nowMs - statSync(heartbeatPath).mtimeMs);
+    return ageMs > BRIDGE_HEARTBEAT_STALE_MS
+      ? { state: "stale", ageMs }
+      : { state: heartbeat.state, ageMs };
+  } catch {
+    return { state: "unknown", ageMs: null };
+  }
+}
+
+function heartbeatFailure(liveness: BridgeLiveness): CommandResult | null {
+  if (liveness.state === "waiting") {
+    return {
+      success: false,
+      error:
+        "The CEP connector is open but not running. In Premiere Pro, open Window > Extensions > MCP Bridge, wait for it to finish starting, then retry once.",
+    };
+  }
+  if (liveness.state === "stale") {
+    return {
+      success: false,
+      error:
+        "The CEP connector heartbeat is stale. Reopen Window > Extensions > MCP Bridge in Premiere Pro, dismiss any blocking dialog, and retry once after it reports running.",
+    };
+  }
+  return null;
+}
+
+/**
  * Make sure this server version's helpers file exists in the temp dir, and return
  * the bootstrap line each command must carry so the CEP-side engine loads it once.
  */
@@ -91,6 +154,11 @@ export async function sendCommand(
   const tempDir = getTempDir(options);
   const timeoutMs = options?.timeoutMs || DEFAULT_TIMEOUT_MS;
   ensureDir(tempDir);
+
+  if (options?.failFastOnUnreadyHeartbeat) {
+    const failure = heartbeatFailure(getBridgeLiveness(options));
+    if (failure) return failure;
+  }
 
   const id = randomUUID();
   const cmdFile = join(tempDir, `cmd_${id}.jsx`);
@@ -151,6 +219,11 @@ export async function sendRawCommand(
   const tempDir = getTempDir(options);
   const timeoutMs = options?.timeoutMs || DEFAULT_TIMEOUT_MS;
   ensureDir(tempDir);
+
+  if (options?.failFastOnUnreadyHeartbeat) {
+    const failure = heartbeatFailure(getBridgeLiveness(options));
+    if (failure) return failure;
+  }
 
   const id = randomUUID();
   const cmdFile = join(tempDir, `cmd_${id}.jsx`);

--- a/src/tools/health.ts
+++ b/src/tools/health.ts
@@ -113,7 +113,11 @@ export function getHealthTools(
             activeSequence: activeSeq
           });
         `);
-        return sendCommand(script, { ...bridgeOptions, timeoutMs: 5000 });
+        return sendCommand(script, {
+          ...bridgeOptions,
+          timeoutMs: 5000,
+          failFastOnUnreadyHeartbeat: true,
+        });
       },
     },
     verify_premiere_connection: {
@@ -161,7 +165,11 @@ export function getHealthTools(
               var sequenceOpen = !!(projectOpen && app.project.activeSequence);
               return __result({ projectOpen: projectOpen, sequenceOpen: sequenceOpen });
             `);
-            const response = await sendCommand(script, { ...bridgeOptions, timeoutMs: 5000 });
+            const response = await sendCommand(script, {
+              ...bridgeOptions,
+              timeoutMs: 5000,
+              failFastOnUnreadyHeartbeat: true,
+            });
             const data = response.success && response.data && typeof response.data === "object"
               ? response.data as Record<string, unknown>
               : {};

--- a/src/tools/recovery.ts
+++ b/src/tools/recovery.ts
@@ -11,6 +11,7 @@ import { basename, dirname, extname, join, resolve } from "node:path";
 import { buildToolScript } from "../bridge/script-builder.js";
 import {
   getTempDir,
+  getBridgeLiveness,
   sendCommand,
   type BridgeOptions,
   type CommandResult,
@@ -142,6 +143,7 @@ export function collectBridgeTelemetry(
   nowMs = Date.now(),
 ) {
   const directory = getTempDir(bridgeOptions);
+  const heartbeat = getBridgeLiveness(bridgeOptions, nowMs);
   const counts = { pendingCommands: 0, pendingResponses: 0, busyOperations: 0 };
   let oldestPendingAgeMs: number | null = null;
   let directoryAccessible = false;
@@ -172,6 +174,7 @@ export function collectBridgeTelemetry(
     directoryAccessible,
     ...counts,
     oldestPendingAgeMs,
+    heartbeat,
     healthy:
       directoryAccessible &&
       counts.busyOperations === 0 &&
@@ -276,7 +279,7 @@ export function getRecoveryTools(bridgeOptions: BridgeOptions) {
 
     get_bridge_telemetry: {
       description:
-        "Inspect privacy-preserving aggregate bridge health: pending command/response counts, busy operations, and queue age without returning project or personal data.",
+        "Inspect privacy-preserving aggregate bridge health: pending command/response counts, busy operations, queue age, and CEP heartbeat state without returning project or personal data.",
       parameters: {},
       handler: async () => ({
         success: true,

--- a/tests/bridge/file-bridge.test.ts
+++ b/tests/bridge/file-bridge.test.ts
@@ -15,6 +15,7 @@ import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import {
   getTempDir,
+  getBridgeLiveness,
   sendCommand,
   sendRawCommand,
   cleanupTempDir,
@@ -281,6 +282,51 @@ describe("sendCommand", () => {
     expect(result.error).toContain("CEP plugin");
   });
 
+  it("fails health-style commands before publication when a current connector is waiting", async () => {
+    vi.setSystemTime(new Date(10_000));
+    mockedExistsSync.mockImplementation((path) => String(path).includes("bridge-heartbeat"));
+    mockedReadFileSync.mockReturnValue('{"protocolVersion":1,"state":"waiting"}');
+    mockedStatSync.mockReturnValue({
+      uid: myUid,
+      mode: 0o700,
+      mtimeMs: 9_500,
+    } as unknown as ReturnType<typeof statSync>);
+
+    await expect(sendCommand("var health = true;", {
+      tempDir: "/tmp/test-bridge",
+      failFastOnUnreadyHeartbeat: true,
+    })).resolves.toMatchObject({ success: false, error: expect.stringContaining("not running") });
+    expect(mockedRenameSync).not.toHaveBeenCalled();
+  });
+
+  it("fails health-style commands before publication when a known connector heartbeat is stale", async () => {
+    vi.setSystemTime(new Date(10_000));
+    mockedExistsSync.mockImplementation((path) => String(path).includes("bridge-heartbeat"));
+    mockedReadFileSync.mockReturnValue('{"protocolVersion":1,"state":"running"}');
+    mockedStatSync.mockReturnValue({
+      uid: myUid,
+      mode: 0o700,
+      mtimeMs: 1_000,
+    } as unknown as ReturnType<typeof statSync>);
+
+    await expect(sendCommand("var health = true;", {
+      tempDir: "/tmp/test-bridge",
+      failFastOnUnreadyHeartbeat: true,
+    })).resolves.toMatchObject({ success: false, error: expect.stringContaining("heartbeat is stale") });
+    expect(mockedRenameSync).not.toHaveBeenCalled();
+  });
+
+  it("falls back to normal command delivery when no heartbeat exists", async () => {
+    mockedExistsSync.mockImplementation((path) => String(path).includes("res_"));
+    mockedReadFileSync.mockReturnValue('{"success":true}');
+
+    await expect(sendCommand("var legacy = true;", {
+      tempDir: "/tmp/test-bridge",
+      failFastOnUnreadyHeartbeat: true,
+    })).resolves.toEqual({ success: true });
+    expect(mockedRenameSync).toHaveBeenCalled();
+  });
+
   it("cleans up command and response files after success", async () => {
     let responseExists = false;
     mockedExistsSync.mockImplementation((path) => {
@@ -323,6 +369,38 @@ describe("sendCommand", () => {
     await expect(
       sendCommand(largeScript, { tempDir: "/tmp/test-bridge" })
     ).rejects.toThrow("500KB size limit");
+  });
+});
+
+describe("getBridgeLiveness", () => {
+  it("reports fresh, stale, and unknown states without exposing heartbeat contents", () => {
+    mockedExistsSync.mockReturnValue(true);
+    mockedReadFileSync.mockReturnValue('{"protocolVersion":1,"state":"running"}');
+    mockedStatSync.mockReturnValue({ mtimeMs: 9_000 } as ReturnType<typeof statSync>);
+    expect(getBridgeLiveness({ tempDir: "/tmp/test-bridge" }, 10_000)).toEqual({
+      state: "running",
+      ageMs: 1_000,
+    });
+
+    mockedStatSync.mockReturnValue({ mtimeMs: 1_000 } as ReturnType<typeof statSync>);
+    expect(getBridgeLiveness({ tempDir: "/tmp/test-bridge" }, 10_000)).toEqual({
+      state: "stale",
+      ageMs: 9_000,
+    });
+
+    mockedReadFileSync.mockReturnValue('{"state":"running"}');
+    expect(getBridgeLiveness({ tempDir: "/tmp/test-bridge" }, 10_000)).toEqual({
+      state: "unknown",
+      ageMs: null,
+    });
+
+    // This module-level fs mock is shared with the following raw-command
+    // suite, which exercises the POSIX ownership guard.
+    mockedStatSync.mockReturnValue({
+      uid: myUid,
+      mode: 0o700,
+      mtimeMs: Date.now(),
+    } as unknown as ReturnType<typeof statSync>);
   });
 });
 

--- a/tests/cep-install.test.ts
+++ b/tests/cep-install.test.ts
@@ -59,6 +59,9 @@ describe("CEP installation metadata", () => {
     expect(panelLogic).toContain("Download update");
     expect(panelLogic).toContain("writeResponseFile(resFilePath, response)");
     expect(panelLogic).toContain("fs.renameSync(stagedPath, filePath)");
+    expect(panelLogic).toContain('"bridge-heartbeat.json"');
+    expect(panelLogic).toContain("protocolVersion: 1");
+    expect(panelLogic).toContain("startBridgeHeartbeat()");
   });
 
   it("copies the macOS plugin for npm installs and supports diagnostics", () => {

--- a/tests/tools/recovery.test.ts
+++ b/tests/tools/recovery.test.ts
@@ -76,6 +76,10 @@ describe("privacy-preserving bridge telemetry", () => {
     writeFileSync(join(directory, "cmd_secret.jsx"), "private project script");
     writeFileSync(join(directory, "res_secret.json"), '{"project":"Private"}');
     writeFileSync(join(directory, "busy_secret.json"), "{}");
+    writeFileSync(join(directory, "bridge-heartbeat.json"), JSON.stringify({
+      protocolVersion: 1,
+      state: "running",
+    }));
     writeFileSync(join(directory, "helpers_ignored.jsx"), "helper");
 
     const telemetry = collectBridgeTelemetry(
@@ -87,6 +91,7 @@ describe("privacy-preserving bridge telemetry", () => {
       pendingCommands: 1,
       pendingResponses: 1,
       busyOperations: 1,
+      heartbeat: { state: "running" },
       healthy: false,
     });
     const serialized = JSON.stringify(telemetry);

--- a/tests/tools/tool-modules.test.ts
+++ b/tests/tools/tool-modules.test.ts
@@ -222,6 +222,7 @@ describe("Tool Handler Behavior", () => {
       expect(callArgs[0]).toContain("app.version");
       // Should use a 5-second timeout override
       expect(callArgs[1]?.timeoutMs).toBe(5000);
+      expect(callArgs[1]?.failFastOnUnreadyHeartbeat).toBe(true);
     });
 
     it("generates script that checks connectivity", async () => {
@@ -258,6 +259,7 @@ describe("Tool Handler Behavior", () => {
       });
       expect(script).toContain("projectOpen");
       expect(script).toContain("sequenceOpen");
+      expect(mockedSendCommand.mock.calls[0][1]?.failFastOnUnreadyHeartbeat).toBe(true);
       expect(script).not.toContain("projectName");
       expect(script).not.toContain("project.path");
       expect(events).toEqual([


### PR DESCRIPTION
## Summary

- publish a CEP heartbeat atomically with explicit `running` or `waiting` state
- fail `ping` and `verify_premiere_connection` before publishing a command only when a current connector reports waiting or stale; missing heartbeats retain older-connector fallback behavior
- surface privacy-preserving heartbeat status in `get_bridge_telemetry` without paths, filenames, project data, or script contents
- regenerate the supported-actions catalog and cover fresh, waiting, stale, unknown, and fallback paths

## Verification

- `npm ci && npm run check` (79 files, 1,770 tests)
- `npm run pack:check`
- `npm audit --omit=dev` (0 vulnerabilities)
- `git diff --check`

## Boundary

- no npm publication, release, deployment, or licensed-Premiere host session is included; the CEP behavior is contract- and source-tested only
