### PR TITLE
feat(growth): add Project Intake starter templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ guide](https://premiere-pro-mcp.com/premiere-pro-collaboration-workflow/) before
 you evaluate an MCP path. It links the relevant Adobe guidance, makes no project
 inspection request, and ends with the same read-only connection check.
 
+For a concrete first Project Intake preview, choose one of the three
+[schema-checked, no-sensitive-data starter templates](https://premiere-pro-mcp.com/project-intake/#starter-template).
+They are evaluation samples only: a human policy owner must review and replace
+their bins, media rules, and organization rules before a facility uses one.
+
 ---
 
 ## Quick Start

--- a/landing/app/project-intake/page.tsx
+++ b/landing/app/project-intake/page.tsx
@@ -4,13 +4,14 @@ import Link from "next/link"
 import { ArrowRight, CheckCircle2, ClipboardCheck, FileSearch, ShieldCheck } from "lucide-react"
 import { Footer } from "@/components/sections/footer"
 import { ProjectIntakePrompts } from "./project-intake-prompts"
+import { ProjectIntakeTemplateBuilder } from "./project-intake-template-builder"
 
 const pageUrl = "https://premiere-pro-mcp.com/project-intake/"
 
 export const metadata: Metadata = {
   title: "Premiere Pro Project Intake: Run a Read-Only Workflow Review",
   description:
-    "Prepare a bounded, read-only Premiere Pro Project Intake preview with a safe connection check, an approved template, and a path-redacted review report.",
+    "Prepare a bounded, read-only Premiere Pro Project Intake preview with a safe connection check, a schema-valid starter or approved template, and a path-redacted review report.",
   alternates: { canonical: "/project-intake/" },
   keywords: [
     "Premiere Pro project intake workflow",
@@ -58,6 +59,11 @@ const faqs = [
     answer:
       "No. It reports the bounded checks in the approved template. A human owner still reviews exceptions, truncated findings, and any later change before relying on the result.",
   },
+  {
+    question: "Can I use a starter template as-is?",
+    answer:
+      "Only as a non-sensitive evaluation sample. A human policy owner must review and replace the starter's bins, media rules, frame rates, proxy policy, and organization rules before relying on it for a facility workflow.",
+  },
 ]
 
 const structuredData = {
@@ -68,7 +74,7 @@ const structuredData = {
       "@id": `${pageUrl}#webpage`,
       name: "Premiere Pro Project Intake: Run a Read-Only Workflow Review",
       description:
-        "Prepare a bounded, read-only Premiere Pro Project Intake preview with a safe connection check, an approved template, and a path-redacted review report.",
+        "Prepare a bounded, read-only Premiere Pro Project Intake preview with a safe connection check, a schema-valid starter or approved template, and a path-redacted review report.",
       url: pageUrl,
       isPartOf: { "@id": "https://premiere-pro-mcp.com/#website" },
       about: { "@id": "https://premiere-pro-mcp.com/#software" },
@@ -170,9 +176,10 @@ export default function ProjectIntakePage() {
         <section id="try" className="border-y border-zinc-900 bg-[#050506] px-5 py-14 sm:py-20" aria-labelledby="try-heading">
           <div className="mx-auto max-w-4xl">
             <p className="font-mono text-xs font-semibold uppercase tracking-[0.16em] text-purple-300">Try the read-only path</p>
-            <h2 id="try-heading" className="mt-4 text-3xl font-bold tracking-tight text-white sm:text-5xl">Copy the prompts. Keep the boundary visible.</h2>
-            <p className="mt-5 max-w-3xl text-lg leading-8 text-zinc-400">The first prompt checks the connection only. The second requests an intake preview only after you have an approved template and a ready local connection.</p>
+            <h2 id="try-heading" className="mt-4 text-3xl font-bold tracking-tight text-white sm:text-5xl">Copy the safe prompt. Then choose a starter policy.</h2>
+            <p className="mt-5 max-w-3xl text-lg leading-8 text-zinc-400">The first prompt checks the connection only. Then choose a schema-valid starter policy or use your approved template for a path-redacted intake preview.</p>
             <div className="mt-10"><ProjectIntakePrompts /></div>
+            <div id="starter-template"><ProjectIntakeTemplateBuilder /></div>
           </div>
         </section>
 
@@ -185,6 +192,7 @@ export default function ProjectIntakePage() {
             <ul className="space-y-4 text-zinc-300">
               {[
                 "Use a copied or non-sensitive project while you evaluate a new client, connector, or template.",
+                "Starter templates deliberately omit approved media paths. Add any path policy only after a human owner reviews and approves it.",
                 "Start with deterministic organization rules: expected bins, allowed labels, naming patterns, and allowlisted metadata.",
                 "Review every finding and exception with a human owner. A proposed action is not permission to apply it.",
                 "Keep preview, structural verification, playback review, and exported-frame verification as separate evidence classes.",

--- a/landing/app/project-intake/project-intake-prompts.tsx
+++ b/landing/app/project-intake/project-intake-prompts.tsx
@@ -67,7 +67,7 @@ export function ProjectIntakePrompts() {
         promptKind="safe_check"
       />
       <PromptCard
-        label="Step 2 · Preview only"
+        label="Existing policy · Preview only"
         title="Request the intake review"
         description="Use an approved intake template. The result is a path-redacted report and proposed organization actions—not permission to organize the project."
         prompt={projectIntakePreviewPrompt}

--- a/landing/app/project-intake/project-intake-template-builder.tsx
+++ b/landing/app/project-intake/project-intake-template-builder.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import { Check, Copy, ShieldCheck, TriangleAlert } from "lucide-react"
+import { useState } from "react"
+import { trackOnboardingEvent } from "@/lib/onboarding-events"
+import {
+  formatProjectIntakeStarterRequest,
+  projectIntakeStarterTemplates,
+  type ProjectIntakeStarterTemplate,
+} from "@/lib/project-intake-starter-templates"
+
+type CopyState = "idle" | "copied" | "unavailable"
+
+export function ProjectIntakeTemplateBuilder() {
+  const [selected, setSelected] = useState<ProjectIntakeStarterTemplate | null>(null)
+  const [copyState, setCopyState] = useState<CopyState>("idle")
+
+  function selectTemplate(starter: ProjectIntakeStarterTemplate) {
+    setSelected(starter)
+    setCopyState("idle")
+    trackOnboardingEvent("onboarding_project_intake_template_selected", { template_kind: starter.key })
+  }
+
+  async function copyRequest() {
+    if (!selected) return
+    try {
+      if (!navigator.clipboard?.writeText) throw new Error("Clipboard API is unavailable")
+      await navigator.clipboard.writeText(formatProjectIntakeStarterRequest(selected))
+      setCopyState("copied")
+      trackOnboardingEvent("onboarding_project_intake_template_copied", { template_kind: selected.key })
+      window.setTimeout(() => setCopyState("idle"), 2200)
+    } catch {
+      setCopyState("unavailable")
+    }
+  }
+
+  return (
+    <div className="mt-10 border border-zinc-800 bg-[#08080a] p-5 sm:p-7">
+      <fieldset>
+        <legend className="text-xl font-semibold tracking-tight text-white">Choose a no-sensitive-data starter policy</legend>
+        <p className="mt-3 max-w-3xl leading-7 text-zinc-400">Each sample is valid for <code>preview_project_intake</code>, has no approved media paths, and requests a preview only. A policy owner must review and replace its bins, media rules, and checks before real use.</p>
+        <div className="mt-6 grid gap-3">
+          {projectIntakeStarterTemplates.map((starter) => {
+            const isSelected = selected?.key === starter.key
+            return (
+              <label
+                key={starter.key}
+                className={`block cursor-pointer rounded-lg border p-4 transition-colors focus-within:outline-none focus-within:ring-2 focus-within:ring-purple-300 ${isSelected ? "border-purple-300 bg-purple-300/10" : "border-zinc-800 bg-black hover:border-zinc-600"}`}
+              >
+                <input
+                  type="radio"
+                  name="project-intake-starter-template"
+                  value={starter.key}
+                  checked={isSelected}
+                  onChange={() => selectTemplate(starter)}
+                  className="sr-only"
+                />
+                <span className="flex items-start gap-3">
+                  <span className={`mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border ${isSelected ? "border-purple-300 bg-purple-300 text-black" : "border-zinc-600"}`} aria-hidden="true">
+                    {isSelected ? <Check className="h-3.5 w-3.5" strokeWidth={3} /> : null}
+                  </span>
+                  <span>
+                    <span className="block font-semibold text-white">{starter.label}</span>
+                    <span className="mt-1 block leading-6 text-zinc-400">{starter.description}</span>
+                  </span>
+                </span>
+              </label>
+            )
+          })}
+        </div>
+      </fieldset>
+
+      {selected ? (
+        <section className="mt-7 border-t border-zinc-800 pt-7" aria-live="polite" aria-labelledby="starter-request-heading">
+          <div className="flex items-start gap-3">
+            <ShieldCheck className="mt-0.5 h-5 w-5 shrink-0 text-purple-300" aria-hidden="true" />
+            <div>
+              <h3 id="starter-request-heading" className="font-semibold text-white">{selected.label} request</h3>
+              <ul className="mt-3 space-y-1 text-sm leading-6 text-zinc-400">
+                {selected.checks.map((check) => <li key={check}>• {check}</li>)}
+              </ul>
+            </div>
+          </div>
+          <pre className="mt-5 overflow-x-auto rounded-lg border border-zinc-800 bg-black p-4 text-sm leading-6 text-zinc-200"><code>{formatProjectIntakeStarterRequest(selected)}</code></pre>
+          <div className="mt-4 flex flex-col items-start gap-3 sm:flex-row sm:items-center">
+            <button
+              type="button"
+              onClick={copyRequest}
+              className="inline-flex min-h-11 items-center gap-2 rounded-md border border-purple-300 bg-purple-300 px-4 py-2 text-sm font-semibold text-black transition-colors hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-purple-300 focus-visible:ring-offset-2 focus-visible:ring-offset-[#08080a]"
+            >
+              {copyState === "copied" ? <Check className="h-4 w-4" aria-hidden="true" /> : <Copy className="h-4 w-4" aria-hidden="true" />}
+              <span>{copyState === "copied" ? "Copied" : "Copy starter request"}</span>
+            </button>
+            {copyState === "unavailable" ? (
+              <p className="inline-flex items-center gap-2 text-sm text-amber-200" role="status">
+                <TriangleAlert className="h-4 w-4 shrink-0" aria-hidden="true" />
+                Copy is unavailable here. Select the visible request and copy it manually.
+              </p>
+            ) : null}
+          </div>
+        </section>
+      ) : null}
+    </div>
+  )
+}

--- a/landing/lib/onboarding-events.ts
+++ b/landing/lib/onboarding-events.ts
@@ -5,6 +5,8 @@ export type OnboardingEvent =
   | "onboarding_download_started"
   | "onboarding_safe_prompt_copied"
   | "onboarding_project_intake_prompt_copied"
+  | "onboarding_project_intake_template_selected"
+  | "onboarding_project_intake_template_copied"
   | "onboarding_workflow_guide_recommendation_viewed"
   | "onboarding_workflow_guide_prompt_copied"
   | "onboarding_advanced_opened"

--- a/landing/lib/project-intake-starter-templates.json
+++ b/landing/lib/project-intake-starter-templates.json
@@ -1,0 +1,92 @@
+{
+  "templates": [
+    {
+      "key": "editorial_handoff",
+      "label": "Editorial handoff",
+      "description": "A small, repeatable review for common editorial source media before a handoff.",
+      "checks": [
+        "Footage, Audio, and Sequences bins",
+        "MOV, MP4, or MXF source media",
+        "Offline-media evidence and missing-proxy warnings"
+      ],
+      "template": {
+        "schemaVersion": 1,
+        "id": "starter-editorial-handoff",
+        "version": "1.0.0",
+        "requiredBins": [
+          { "name": "Footage" },
+          { "name": "Audio" },
+          { "name": "Sequences" }
+        ],
+        "allowedExtensions": ["mov", "mp4", "mxf"],
+        "allowedFrameRates": [],
+        "proxyPolicy": "report_missing",
+        "approvedPathPrefixes": [],
+        "requiredEvidence": ["extension", "offline"],
+        "organizationRules": [
+          {
+            "id": "source-video",
+            "destinationBinName": "Footage",
+            "match": { "extensions": ["mov", "mp4", "mxf"] }
+          }
+        ]
+      }
+    },
+    {
+      "key": "proxy_ready",
+      "label": "Proxy-ready editorial",
+      "description": "A bounded starting point for a handoff where every evaluated source clip should have a proxy.",
+      "checks": [
+        "Footage and Sequences bins",
+        "MOV, MP4, or MXF source media",
+        "Required proxy, offline-media, and extension evidence"
+      ],
+      "template": {
+        "schemaVersion": 1,
+        "id": "starter-proxy-ready-editorial",
+        "version": "1.0.0",
+        "requiredBins": [
+          { "name": "Footage" },
+          { "name": "Sequences" }
+        ],
+        "allowedExtensions": ["mov", "mp4", "mxf"],
+        "allowedFrameRates": [],
+        "proxyPolicy": "require",
+        "approvedPathPrefixes": [],
+        "requiredEvidence": ["extension", "offline", "proxy"],
+        "organizationRules": [
+          {
+            "id": "proxy-source-video",
+            "destinationBinName": "Footage",
+            "match": { "extensions": ["mov", "mp4", "mxf"] }
+          }
+        ]
+      }
+    },
+    {
+      "key": "delivery_preflight",
+      "label": "Delivery preflight",
+      "description": "A simple source-and-sequence check to adapt before a controlled delivery review.",
+      "checks": [
+        "Source and Sequences bins",
+        "Common editorial frame rates",
+        "Extension, frame-rate, and offline-media evidence"
+      ],
+      "template": {
+        "schemaVersion": 1,
+        "id": "starter-delivery-preflight",
+        "version": "1.0.0",
+        "requiredBins": [
+          { "name": "Source" },
+          { "name": "Sequences" }
+        ],
+        "allowedExtensions": ["mov", "mp4", "mxf"],
+        "allowedFrameRates": [23.976, 24, 25, 29.97, 30],
+        "proxyPolicy": "ignore",
+        "approvedPathPrefixes": [],
+        "requiredEvidence": ["extension", "frame_rate", "offline"],
+        "organizationRules": []
+      }
+    }
+  ]
+}

--- a/landing/lib/project-intake-starter-templates.ts
+++ b/landing/lib/project-intake-starter-templates.ts
@@ -1,0 +1,20 @@
+import templateData from "./project-intake-starter-templates.json"
+
+export type ProjectIntakeStarterTemplate = {
+  key: "editorial_handoff" | "proxy_ready" | "delivery_preflight"
+  label: string
+  description: string
+  checks: string[]
+  template: Record<string, unknown>
+}
+
+export const projectIntakeStarterTemplates = templateData.templates as ProjectIntakeStarterTemplate[]
+
+export function formatProjectIntakeStarterRequest(starter: ProjectIntakeStarterTemplate) {
+  return [
+    "Run preview_project_intake with this exact template. Return the path-redacted report and proposed organization actions.",
+    "Do not set include_paths. Do not change Premiere or persist the template.",
+    "",
+    JSON.stringify({ template: starter.template }, null, 2),
+  ].join("\n")
+}

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -6,6 +6,7 @@ Canonical website: https://premiere-pro-mcp.com/
 Documentation: https://premiere-pro-mcp.com/docs/
 Guides: https://premiere-pro-mcp.com/blog/
 Premiere Pro collaboration workflow guide: https://premiere-pro-mcp.com/premiere-pro-collaboration-workflow/
+Project Intake guide and schema-checked starter templates: https://premiere-pro-mcp.com/project-intake/
 Guide: What is an MCP server for Adobe Premiere Pro?: https://premiere-pro-mcp.com/blog/what-is-a-premiere-pro-mcp-server/
 Guide: AI video editing with Premiere Pro: https://premiere-pro-mcp.com/blog/ai-video-editing-with-premiere-pro/
 Guide: Premiere Pro workflow automation: https://premiere-pro-mcp.com/blog/premiere-pro-workflow-automation/
@@ -32,6 +33,10 @@ The recommended configuration is local. An MCP client starts the Node.js server 
 ## Collaboration workflow fit
 
 Premiere projects can be evaluated in different collaboration contexts. Adobe documents Productions for shared-storage, multi-project workflows and Team Projects for cloud-managed collaboration. The workflow-fit guide at https://premiere-pro-mcp.com/premiere-pro-collaboration-workflow/ routes readers to the relevant Adobe documentation and the same no-change local connection check. It does not inspect or store project data, grant Team Project permissions, create a Production policy, or prove future host behavior.
+
+## Project Intake starter templates
+
+The Project Intake guide at https://premiere-pro-mcp.com/project-intake/ includes three schema-checked starter templates for `preview_project_intake`: editorial handoff, proxy-ready editorial, and delivery preflight. They contain no approved media paths and request a path-redacted, non-mutating preview only. They are evaluation samples, not facility policy: a human owner must review and replace their bins, media rules, frame rates, proxy policy, and organization rules before use.
 
 ## Compatibility
 

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -10,6 +10,7 @@ MCP for Adobe Premiere Pro registers 319 core structured tools for timeline edit
 - Documentation: https://premiere-pro-mcp.com/docs/
 - Guides: https://premiere-pro-mcp.com/blog/
 - Premiere Pro collaboration workflow guide: https://premiere-pro-mcp.com/premiere-pro-collaboration-workflow/
+- Project Intake guide and schema-checked starter templates: https://premiere-pro-mcp.com/project-intake/
 - What is an MCP server for Adobe Premiere Pro?: https://premiere-pro-mcp.com/blog/what-is-a-premiere-pro-mcp-server/
 - AI video editing with Premiere Pro: https://premiere-pro-mcp.com/blog/ai-video-editing-with-premiere-pro/
 - Premiere Pro workflow automation: https://premiere-pro-mcp.com/blog/premiere-pro-workflow-automation/
@@ -35,6 +36,8 @@ MCP for Adobe Premiere Pro registers 319 core structured tools for timeline edit
 The recommended setup runs the MCP server and CEP bridge locally. Project media stays on the editor's machine. Remote HTTP transport requires authentication and a working connection to the local Premiere Pro bridge.
 
 For a local project, a shared-storage Adobe Production, or a remote Adobe Team Project, first use https://premiere-pro-mcp.com/premiere-pro-collaboration-workflow/ to keep the Adobe collaboration decision separate from the local MCP connection check. The guide does not inspect or store a project and does not claim Team Project permissions or Production-policy support.
+
+The Project Intake guide includes no-sensitive-data starter templates for a path-redacted preview. They do not include approved media paths, change Premiere, persist a template, or replace human policy review.
 
 ## Verified facts
 

--- a/tests/project-intake-starter-templates.test.ts
+++ b/tests/project-intake-starter-templates.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { validateFacilityIntakeTemplate } from "../src/intake/project-intake.js";
+
+type StarterTemplateFile = {
+  templates: Array<{
+    key: string;
+    label: string;
+    description: string;
+    checks: string[];
+    template: unknown;
+  }>;
+};
+
+const starters = JSON.parse(
+  readFileSync(join(process.cwd(), "landing", "lib", "project-intake-starter-templates.json"), "utf8"),
+) as StarterTemplateFile;
+
+describe("Project Intake starter templates", () => {
+  it("keeps every public starter template valid for the real preview tool", () => {
+    expect(starters.templates.map((starter) => starter.key)).toEqual([
+      "editorial_handoff",
+      "proxy_ready",
+      "delivery_preflight",
+    ]);
+
+    for (const starter of starters.templates) {
+      expect(starter.label).not.toHaveLength(0);
+      expect(starter.description).not.toHaveLength(0);
+      expect(starter.checks.length).toBeGreaterThan(0);
+      const template = validateFacilityIntakeTemplate(starter.template);
+      expect(template.approvedPathPrefixes).toEqual([]);
+      expect(JSON.stringify(template)).not.toMatch(/[A-Za-z]:[\\/]|\\\\/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add three no-sensitive-data Project Intake starter templates: editorial handoff, proxy-ready editorial, and delivery preflight
- validate every public template with the real `validateFacilityIntakeTemplate` engine before it can drift from the tool schema
- make the Project Intake landing flow select-and-copy the bounded request, while retaining explicit human-review, no-path, and no-mutation boundaries
- surface the reusable entry point in the README and AI-readable references; record selection/copy only by static template kind

## Verification
- `npm run check` — 80 files / 1,767 tests passed
- `npm --prefix landing run lint`
- `npm --prefix landing run build` — static export and performance budget passed
- static-browser check: selection reveals the proxy-ready request; no horizontal overflow at 360, 390, 430, and 1280px; no console errors

No registry publication, paid promotion, or social posting is included.