### PR TITLE
fix(bridge): normalize numeric host IDs

### DIFF
--- a/src/bridge/script-builder.ts
+++ b/src/bridge/script-builder.ts
@@ -63,9 +63,10 @@ function __pad(n) {
 
 function __findSequence(idOrName) {
   var project = app.project;
+  var wantedId = String(idOrName);
   for (var i = 0; i < project.sequences.numSequences; i++) {
     var seq = project.sequences[i];
-    if (seq.sequenceID === idOrName || seq.name === idOrName) {
+    if (String(seq.sequenceID) === wantedId || seq.name === idOrName) {
       return seq;
     }
   }
@@ -74,9 +75,10 @@ function __findSequence(idOrName) {
 
 function __findProjectItem(nodeIdOrName, rootItem) {
   if (!rootItem) rootItem = app.project.rootItem;
+  var wantedId = String(nodeIdOrName);
   for (var i = 0; i < rootItem.children.numItems; i++) {
     var item = rootItem.children[i];
-    if (item.nodeId === nodeIdOrName || item.name === nodeIdOrName) {
+    if (String(item.nodeId) === wantedId || item.name === nodeIdOrName) {
       return item;
     }
     if (item.type === 2) { // Bin
@@ -90,13 +92,14 @@ function __findProjectItem(nodeIdOrName, rootItem) {
 function __findClip(nodeId) {
   var seq = app.project.activeSequence;
   if (!seq) return null;
+  var wantedId = String(nodeId);
 
   // Search video tracks
   for (var t = 0; t < seq.videoTracks.numTracks; t++) {
     var track = seq.videoTracks[t];
     for (var c = 0; c < track.clips.numItems; c++) {
       var clip = track.clips[c];
-      if (clip.nodeId === nodeId) {
+      if (String(clip.nodeId) === wantedId) {
         return { clip: clip, trackIndex: t, clipIndex: c, trackType: "video" };
       }
     }
@@ -107,7 +110,7 @@ function __findClip(nodeId) {
     var track = seq.audioTracks[t];
     for (var c = 0; c < track.clips.numItems; c++) {
       var clip = track.clips[c];
-      if (clip.nodeId === nodeId) {
+      if (String(clip.nodeId) === wantedId) {
         return { clip: clip, trackIndex: t, clipIndex: c, trackType: "audio" };
       }
     }

--- a/tests/bridge/script-builder.test.ts
+++ b/tests/bridge/script-builder.test.ts
@@ -123,6 +123,16 @@ describe("generated script structure", () => {
     expect(result).toContain("var found = __findProjectItem(nodeIdOrName, item);");
   });
 
+  it("normalizes numeric host IDs without changing exact name matching", () => {
+    const result = getHelpersSource();
+    expect(result).toContain("var wantedId = String(idOrName);");
+    expect(result).toContain("String(seq.sequenceID) === wantedId || seq.name === idOrName");
+    expect(result).toContain("var wantedId = String(nodeIdOrName);");
+    expect(result).toContain("String(item.nodeId) === wantedId || item.name === nodeIdOrName");
+    expect(result).toContain("var wantedId = String(nodeId);");
+    expect(result).toContain("String(clip.nodeId) === wantedId");
+  });
+
   it("__findClip searches both video and audio tracks", () => {
     const result = getHelpersSource();
     expect(result).toContain("seq.videoTracks.numTracks");


### PR DESCRIPTION
## Summary

- normalize sequence, project-item, and timeline-clip IDs through `String(...)` in the shared ExtendScript helper layer
- retain exact name comparisons, avoiding case folding or fuzzy matching
- cover stringified numeric host IDs in the generated-helper contract

## Verification

- `npm ci && npm run check` (79 files, 1,767 tests)
- `npm run pack:check`
- `npm audit --omit=dev` (0 vulnerabilities)
- `git diff --check`

## Boundary

- no host API is added and no licensed-Premiere run is claimed; this is a compatibility fix for existing helper lookups