### PR TITLE
fix: fail closed for duplicate, reverse, and XMP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,8 +627,7 @@ the tables below are a shorter workflow-oriented overview.
 | `ripple_delete` | Remove clip and close gap (QE) |
 | `roll_edit` / `slide_edit` / `slip_edit` | Professional trim modes (QE) |
 | `move_clip_to_track` | Move between tracks (QE) |
-| `reverse_clip` | Reverse direction (QE, host-dependent) |
-| `speed_change` / `set_clip_speed_qe` | Unavailable: Premiere has no supported scripting API for changing clip speed |
+| `reverse_clip` / `speed_change` / `set_clip_speed_qe` | Unavailable: Premiere has no supported scripting API for changing a timeline clip's speed or direction |
 | `split_clip` / `trim_clip` / `move_clip` | Basic edits; trim verifies source points and visible timeline edges |
 | `set_clip_properties` | Opacity, scale, rotation, position (speed requests fail before mutation) |
 | `link_selection` / `unlink_selection` | Link/unlink A/V |
@@ -642,8 +641,8 @@ the tables below are a shorter workflow-oriented overview.
 > to blend adjacent source frames. See [issue #21](https://github.com/leancoderkavy/premiere-pro-mcp/issues/21).
 
 > **Speed, caption, and visual-keyframe boundaries:** Premiere Pro 26.3 exposes no supported
-> scripting setter or Time Remapping component for timeline-clip speed. `speed_change`,
-> `set_clip_speed_qe`, and `set_clip_properties` with `speed` now stop before host mutation;
+> scripting setter or Time Remapping component for timeline-clip speed or direction. `reverse_clip`,
+> `speed_change`, `set_clip_speed_qe`, and `set_clip_properties` with `speed` now stop before host mutation;
 > use the Speed/Duration UI or pre-render retimed media. `add_text_overlay` likewise stops
 > before mutation because a raw-text-to-caption API is not exposed; import an `.srt`/`.vtt`
 > and use `create_caption_track`, or use a MOGRT/PNG overlay. Keyframe and caption-track
@@ -744,7 +743,7 @@ than presenting UI-only operations as available tools.
 | `set_offline` / `has_proxy` / `detach_proxy` | Offline/proxy management |
 | `set_override_frame_rate` | Override FPS |
 | `set_scale_to_frame_size` | Auto-scale to sequence frame |
-| `get_xmp_metadata` / `set_xmp_metadata` | Raw XMP access |
+| `get_xmp_metadata` / `set_xmp_metadata` | Raw XMP access; writes merge a well-formed patch without removing unrelated fields |
 | `get_color_space` | Color space info |
 
 ### Sequence Management (11)

--- a/docs/supported-actions.md
+++ b/docs/supported-actions.md
@@ -74,7 +74,7 @@ operation” when the tool has no enum-based mode.
 | `color_correct` | Default profile | Single operation | Apply basic color correction to a clip using Lumetri Color |
 | `compare_cmx3600_edls` | Default profile | Single operation | Compare two local CMX 3600 EDLs by event number and report bounded added, removed, and changed editorial events. Read-only; it does not alter either interchange file or Premiere. |
 | `consolidate_and_transfer` | Default profile | Single operation | Consolidate, copy, or transcode project media using the Project Manager. Useful for archiving or transferring projects. |
-| `consolidate_duplicates` | Default profile | Single operation | Consolidate duplicate project items |
+| `consolidate_duplicates` | Default profile | Single operation | Consolidate duplicate project items and report success only when duplicate media groups decrease. |
 | `copy_effect_values` | Default profile | Single operation | Copy all property values from one effect to the matching effect on another clip. Both clips must already have the same effect applied. |
 | `copy_effects_between_clips` | Default profile | Single operation | Copy all effects (or a specific effect) from one clip to another. Does not copy intrinsic properties like Motion/Opacity unless specified. |
 | `create_bars_and_tone` | Default profile | Single operation | Create a Bars and Tone synthetic media item in the project (useful for leader/calibration) |
@@ -263,7 +263,7 @@ operation” when the tool has no enum-based mode.
 | `rename_track` | Default profile | `track_type`: `video`, `audio` | Rename a video or audio track. |
 | `replace_clip` | Default profile | Single operation | Replace a clip on the timeline with a different project item, preserving position and duration |
 | `replace_clip_media` | Default profile | Single operation | Replace the source media of a clip on the timeline with a different project item, keeping the clip's position and duration. |
-| `reverse_clip` | Default profile | Single operation | Reverse a clip's playback direction. Uses QE DOM. |
+| `reverse_clip` | Default profile | Single operation | Unavailable: Premiere does not expose a supported scripting API for reversing a timeline clip's playback direction. |
 | `ripple_delete` | Default profile | Single operation | Ripple delete a clip (removes clip and closes the gap). Uses QE DOM. |
 | `roll_edit` | Default profile | Single operation | Perform a roll edit on a clip (adjusts the edit point between two adjacent clips). Uses QE DOM. |
 | `save_project` | Default profile | Single operation | Save the current Premiere Pro project |
@@ -330,7 +330,7 @@ operation” when the tool has no enum-based mode.
 | `set_uniform_scale` | Default profile | Single operation | Toggle uniform scale on a clip's Motion effect. When enabled, Scale Width and Scale Height are linked. |
 | `set_work_area` | Default profile | Single operation | Set the work area (bar) in and out points |
 | `set_workspace` | Default profile | Single operation | Switch to a specific workspace layout (e.g., 'Editing', 'Color', 'Audio', 'Effects', 'Graphics') |
-| `set_xmp_metadata` | Default profile | Single operation | Set raw XMP metadata on a project item (provide complete XMP XML string) |
+| `set_xmp_metadata` | Default profile | Single operation | Merge a raw XMP XML patch into a project item's existing XMP metadata without removing unrelated fields. |
 | `set_zero_point` | Default profile | Single operation | Set the starting timecode (zero point) of a sequence |
 | `setup_ducking` | Default profile | Single operation | Build a verified Volume > Level keyframe curve for one audio clip. Ducking-window times are relative to that clip's start; overlapping or out-of-range windows are rejected before any keyframe write. |
 | `slide_edit` | Default profile | Single operation | Perform a slide edit on a clip (moves clip without changing its duration, adjusting adjacent clips). Uses QE DOM. |

--- a/src/tools/advanced.ts
+++ b/src/tools/advanced.ts
@@ -322,7 +322,8 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
     },
 
     reverse_clip: {
-      description: "Reverse a clip's playback direction. Uses QE DOM.",
+      description:
+        "Unavailable: Premiere does not expose a supported scripting API for reversing a timeline clip's playback direction.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -338,25 +339,12 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
         required: ["node_id"],
       },
       handler: async (args: { node_id: string; reverse?: boolean }) => {
-        const rev = args.reverse !== false;
-        const script = buildToolScript(`
-          app.enableQE();
-          var qeSeq = qe.project.getActiveSequence();
-          if (!qeSeq) return __error("No active sequence (QE)");
-          
-          var result = __findClip("${escapeForExtendScript(args.node_id)}");
-          if (!result) return __error("Clip not found");
-          
-          var qeTrack = result.trackType === "video"
-            ? qeSeq.getVideoTrackAt(result.trackIndex)
-            : qeSeq.getAudioTrackAt(result.trackIndex);
-          var qeClip = qeTrack.getItemAt(result.clipIndex);
-          if (!qeClip) return __error("QE clip not found");
-          
-          qeClip.setReverse(${rev});
-          return __result({ reversed: ${rev}, clipName: result.clip.name });
-        `);
-        return sendCommand(script, bridgeOptions);
+        void args;
+        return {
+          success: false,
+          error:
+            "Reversing a timeline clip is not exposed by Premiere's supported ExtendScript or UXP APIs. No mutation was attempted. Use Premiere's Speed/Duration UI or pre-render retimed media before import.",
+        };
       },
     },
 

--- a/src/tools/metadata.ts
+++ b/src/tools/metadata.ts
@@ -225,7 +225,8 @@ export function getMetadataTools(bridgeOptions: BridgeOptions) {
     },
 
     set_xmp_metadata: {
-      description: "Set raw XMP metadata on a project item (provide complete XMP XML string)",
+      description:
+        "Merge a raw XMP XML patch into a project item's existing XMP metadata without removing unrelated fields.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -235,7 +236,7 @@ export function getMetadataTools(bridgeOptions: BridgeOptions) {
           },
           xmp_xml: {
             type: "string",
-            description: "Complete XMP metadata XML string to set",
+            description: "Well-formed XMP XML containing only the fields to add or replace",
           },
         },
         required: ["item_id", "xmp_xml"],
@@ -244,9 +245,42 @@ export function getMetadataTools(bridgeOptions: BridgeOptions) {
         const script = buildToolScript(`
           var item = __findProjectItem("${escapeForExtendScript(args.item_id)}");
           if (!item) return __error("Item not found");
-          
-          item.setXMPMetadata("${escapeForExtendScript(args.xmp_xml)}");
-          return __result({ updated: true, item: item.name });
+
+          try {
+            if (ExternalObject.AdobeXMPScript === undefined) {
+              ExternalObject.AdobeXMPScript = new ExternalObject("lib:AdobeXMPScript");
+            }
+          } catch (e) {
+            return __error("Premiere could not load the Adobe XMP library; no metadata was changed: " + e.toString());
+          }
+          if (typeof XMPMeta !== "function" || typeof XMPUtils === "undefined" || typeof XMPUtils.appendProperties !== "function") {
+            return __error("Premiere's XMP merge APIs are unavailable; no metadata was changed.");
+          }
+
+          try {
+            var existingPacket = String(item.getXMPMetadata() || "");
+            if (!existingPacket) return __error("The project item has no readable XMP packet; no metadata was changed.");
+            var existingXmp = new XMPMeta(existingPacket);
+            var patchXmp = new XMPMeta("${escapeForExtendScript(args.xmp_xml)}");
+            // Copy every supplied top-level field into the existing packet, replacing
+            // only fields named by the patch and retaining unrelated metadata.
+            XMPUtils.appendProperties(patchXmp, existingXmp, true, true, false);
+            item.setXMPMetadata(existingXmp.serialize());
+
+            // Reparse the host readback so a malformed or rejected packet never
+            // reports success. Exact serialized XML formatting is host-dependent.
+            var writtenPacket = String(item.getXMPMetadata() || "");
+            if (!writtenPacket) return __error("Premiere wrote no readable XMP packet; inspect the item before retrying.");
+            new XMPMeta(writtenPacket);
+            return __result({
+              updated: true,
+              merged: true,
+              item: item.name,
+              verification: "readback_xmp_packet_reparsed"
+            });
+          } catch (e) {
+            return __error("Premiere could not merge XMP metadata; no success is reported: " + e.toString());
+          }
         `);
         return sendCommand(script, bridgeOptions);
       },

--- a/src/tools/project.ts
+++ b/src/tools/project.ts
@@ -113,12 +113,67 @@ export function getProjectTools(bridgeOptions: BridgeOptions) {
     },
 
     consolidate_duplicates: {
-      description: "Consolidate duplicate project items",
+      description:
+        "Consolidate duplicate project items and report success only when duplicate media groups decrease.",
       parameters: {},
       handler: async () => {
         const script = buildToolScript(`
-          app.project.consolidateDuplicates();
-          return __result({ consolidated: true });
+          function __duplicateMediaStats() {
+            var pathMap = {};
+            function scan(bin) {
+              for (var i = 0; i < bin.children.numItems; i++) {
+                var item = bin.children[i];
+                try {
+                  var mediaPath = item.getMediaPath();
+                  if (mediaPath) {
+                    if (!pathMap[mediaPath]) pathMap[mediaPath] = 0;
+                    pathMap[mediaPath]++;
+                  }
+                } catch (e) {}
+                if (item.type === 2) scan(item);
+              }
+            }
+            scan(app.project.rootItem);
+
+            var duplicateGroupCount = 0;
+            var duplicateItemCount = 0;
+            for (var path in pathMap) {
+              if (pathMap.hasOwnProperty(path) && pathMap[path] > 1) {
+                duplicateGroupCount++;
+                duplicateItemCount += pathMap[path] - 1;
+              }
+            }
+            return {
+              duplicateGroupCount: duplicateGroupCount,
+              duplicateItemCount: duplicateItemCount
+            };
+          }
+
+          var before = __duplicateMediaStats();
+          if (before.duplicateGroupCount === 0) {
+            return __result({
+              consolidated: false,
+              changed: false,
+              reason: "No duplicate media groups were found before consolidation.",
+              before: before,
+              after: before
+            });
+          }
+          if (typeof app.project.consolidateDuplicates !== "function") {
+            return __error("This Premiere build does not expose project.consolidateDuplicates; no duplicate items were changed.");
+          }
+
+          try {
+            app.project.consolidateDuplicates();
+          } catch (e) {
+            return __error("Premiere could not consolidate duplicate project items: " + e.toString());
+          }
+
+          var after = __duplicateMediaStats();
+          if (after.duplicateGroupCount >= before.duplicateGroupCount && after.duplicateItemCount >= before.duplicateItemCount) {
+            return __error("Premiere completed consolidateDuplicates but duplicate media groups did not decrease. No consolidation success is reported; inspect the project and use get_duplicate_media to review the unchanged groups.");
+          }
+          return __result({ consolidated: true, changed: true, verified: true, before: before, after: after });
         `);
         return sendCommand(script, bridgeOptions);
       },

--- a/tests/tools/tool-modules.test.ts
+++ b/tests/tools/tool-modules.test.ts
@@ -330,6 +330,48 @@ describe("Tool Handler Behavior", () => {
     });
   });
 
+  describe("reported tool regressions", () => {
+    beforeEach(() => mockedSendCommand.mockClear());
+
+    it("does not report duplicate consolidation as successful without a reduced duplicate scan", async () => {
+      const tools = getProjectTools(bridgeOptions);
+      await tools.consolidate_duplicates.handler({});
+
+      const script = mockedSendCommand.mock.calls[0][0];
+      expect(script).toContain("function __duplicateMediaStats()");
+      expect(script).toContain("var before = __duplicateMediaStats()");
+      expect(script).toContain("var after = __duplicateMediaStats()");
+      expect(script).toContain("duplicate media groups did not decrease");
+      expect(script).toContain("verified: true");
+    });
+
+    it("fails reverse_clip locally with an actionable unsupported-capability error", async () => {
+      const tools = getAdvancedTools(bridgeOptions);
+      const result = await tools.reverse_clip.handler({ node_id: "clip-1" });
+
+      expect(result).toEqual({
+        success: false,
+        error: expect.stringContaining("not exposed by Premiere's supported ExtendScript or UXP APIs"),
+      });
+      expect(mockedSendCommand).not.toHaveBeenCalled();
+    });
+
+    it("merges XMP patches through AdobeXMPScript and reparses host readback", async () => {
+      const tools = getMetadataTools(bridgeOptions);
+      await tools.set_xmp_metadata.handler({
+        item_id: "source-1",
+        xmp_xml: '<x:xmpmeta xmlns:x="adobe:ns:meta/"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/></x:xmpmeta>',
+      });
+
+      const script = mockedSendCommand.mock.calls[0][0];
+      expect(script).toContain('new ExternalObject("lib:AdobeXMPScript")');
+      expect(script).toContain("var existingXmp = new XMPMeta(existingPacket)");
+      expect(script).toContain("XMPUtils.appendProperties(patchXmp, existingXmp, true, true, false)");
+      expect(script).toContain("var writtenPacket = String(item.getXMPMetadata() || \"\")");
+      expect(script).toContain('verification: "readback_xmp_packet_reparsed"');
+    });
+  });
+
   describe("health.get_capabilities", () => {
     it("reports platform support without requiring Premiere to be running", async () => {
       const tools = getHealthTools(bridgeOptions);


### PR DESCRIPTION
## Summary
- make `consolidate_duplicates` compare duplicate-media scans before and after the host call, so an unchanged project returns an actionable failure instead of false success
- make `reverse_clip` fail locally before any host mutation because Premiere has no supported ExtendScript or UXP reverse-speed API
- merge raw XMP patches with AdobeXMPScript, retain unrelated fields, and reparse the host readback before reporting success
- refresh generated supported-actions documentation and regression coverage

Fixes #245
Fixes #246
Fixes #248

## Verification
- `npm ci`
- `npx vitest run tests/tools/tool-modules.test.ts`
- `npm run check`
- `git diff --check`

## Licensed-host limitation
The automated suite validates local handler behavior and generated CEP/ExtendScript safeguards. A licensed Premiere host was not available in this run, so it does not prove that Premiere 26.3 reduces the reported duplicate groups or accepts and persists a merged XMP packet. `reverse_clip` deliberately performs no host call.