### PR TITLE
fix: preserve a single extension in UXP frame exports

### DIFF
--- a/tests/uxp/commands.test.ts
+++ b/tests/uxp/commands.test.ts
@@ -10,12 +10,18 @@ function host(options: { transitions?: boolean; commit?: boolean } = {}) {
   const remove = vi.fn(() => ({ kind: "remove" }));
   const clip = { createAddVideoTransitionAction: add, createRemoveVideoTransitionAction: remove };
   const track = { getTrackItems: vi.fn(async () => [clip]) };
+  const exportedFrames: string[] = [];
+  const exportSequenceFrame = vi.fn(async (_sequence: unknown, _position: unknown, filename: string) => {
+    exportedFrames.push(filename);
+    return true;
+  });
   const sequence = {
     guid: "sequence-1",
     name: "Timeline",
     getVideoTrackCount: vi.fn(async () => 1),
     getVideoTrack: vi.fn(async () => track),
-    getPlayerPosition: vi.fn(async () => ({ seconds: 3 }))
+    getPlayerPosition: vi.fn(async () => ({ seconds: 3 })),
+    getFrameSize: vi.fn(async () => ({ width: 1920, height: 1080 }))
   };
   const project = {
     guid: "project-1",
@@ -60,9 +66,10 @@ function host(options: { transitions?: boolean; commit?: boolean } = {}) {
       setSidecarXMPEnabled: vi.fn(async () => true),
       startBatchEncode: vi.fn(async () => true),
     },
+    Exporter: { exportSequenceFrame },
     ...transitionApis
   };
-  return { registry: Commands.createCommandRegistry({ ppro, fs: {}, Protocol }), ppro, project, sequence, track, clip, add, remove, addAction, optionValues };
+  return { registry: Commands.createCommandRegistry({ ppro, fs: {}, Protocol }), ppro, project, sequence, track, clip, add, remove, addAction, optionValues, exportSequenceFrame, exportedFrames };
 }
 
 describe("UXP command registry", () => {
@@ -101,6 +108,25 @@ describe("UXP command registry", () => {
     await expect(host().registry.dispatch("transition.video.list", {})).resolves.toEqual({
       matchNames: ["CrossDissolve", "DipToBlack"], count: 2
     });
+  });
+
+  it("exports a PNG with a bare host filename and a one-extension returned path", async () => {
+    const value = host();
+    await expect(value.registry.dispatch("frame.export", {
+      outputDirectory: "C:/approved", filename: "frame.png",
+    })).resolves.toMatchObject({ path: "C:/approved/frame.png", exporterResult: true });
+    expect(value.exportSequenceFrame).toHaveBeenCalledWith(
+      value.sequence, { seconds: 3 }, "frame", "C:/approved", 1920, 1080,
+    );
+    expect(value.exportedFrames).toEqual(["frame"]);
+  });
+
+  it("does not report a frame path when Premiere rejects the export", async () => {
+    const value = host();
+    value.exportSequenceFrame.mockResolvedValueOnce(false);
+    await expect(value.registry.dispatch("frame.export", {
+      outputDirectory: "C:/approved", filename: "frame.png",
+    })).rejects.toMatchObject({ code: "UXP_VERIFICATION_FAILED" });
   });
 
   it("returns a stable compact project snapshot", async () => {

--- a/tests/uxp/protocol.test.ts
+++ b/tests/uxp/protocol.test.ts
@@ -64,9 +64,18 @@ describe("UXP bridge protocol", () => {
     expect(() => protocol.safeFilename("../shot.png")).toThrow();
     expect(() => protocol.safeFilename("shot.jpg")).toThrow();
   });
+  it("passes a bare frame stem to Premiere while retaining the public PNG filename", () => {
+    expect(protocol.exporterFrameName("shot-01.png")).toBe("shot-01");
+    expect(protocol.exporterFrameName("Frame.PNG")).toBe("Frame");
+  });
   it("joins Windows and POSIX-style output paths", () => {
     expect(protocol.joinPath("C:/temp", "a.png")).toBe("C:/temp/a.png");
     expect(protocol.joinPath("C:/temp/", "a.png")).toBe("C:/temp/a.png");
+  });
+  it("keeps the one-extension normalization in the panel's direct frame-export path", () => {
+    const panel = readFileSync(new URL("../../uxp-plugin/index.cjs", import.meta.url), "utf8");
+    expect(panel).toContain("const exporterFilename = Protocol.exporterFrameName(filename);");
+    expect(panel).toContain("exportSequenceFrame(sequence, position, exporterFilename, outputDirectory, width, height)");
   });
 
   it("describes verification, undo, transaction, and cancellation boundaries", () => {

--- a/uxp-plugin/README.md
+++ b/uxp-plugin/README.md
@@ -83,7 +83,7 @@ native-acceleration change must first pass the documented Windows x64, macOS x64
 and macOS arm64 Release evidence gate; see
 [the hybrid benchmark procedure](../docs/uxp-hybrid-benchmark.md).
 
-`frame.export` uses Adobe's supported `Exporter.exportSequenceFrame()` and verifies the file exists before reporting success. Example:
+`frame.export` uses Adobe's supported `Exporter.exportSequenceFrame()`. The public request and returned path include one `.png` extension; the panel passes the bare stem to Premiere because its exporter appends the extension. Premiere must confirm the export request before a path is reported. A licensed-host file check remains required to prove the artifact exists on disk. Example:
 
 ```json
 {"type":"command","requestId":"42","command":"frame.export","args":{"outputDirectory":"C:/temp","filename":"frame.png"}}

--- a/uxp-plugin/commands.cjs
+++ b/uxp-plugin/commands.cjs
@@ -345,10 +345,12 @@
       if (!args.outputDirectory) throw commandError("UXP_INVALID_ARGUMENT", "outputDirectory is required");
       const outputDirectory = await allowedPath(args.outputDirectory, "outputDirectory", "directory");
       const filename = Protocol.safeFilename(args.filename);
+      const exporterFilename = Protocol.exporterFrameName(filename);
       const position = args.seconds == null ? await context.sequence.getPlayerPosition() : await tickTime(args.seconds, "seconds");
       const size = await context.sequence.getFrameSize();
       const width = positiveInt(args.width, size.width, "width"), height = positiveInt(args.height, size.height, "height");
-      const returned = await ppro.Exporter.exportSequenceFrame(context.sequence, position, filename, outputDirectory, width, height);
+      const returned = await ppro.Exporter.exportSequenceFrame(context.sequence, position, exporterFilename, outputDirectory, width, height);
+      if (returned !== true) throw commandError("UXP_VERIFICATION_FAILED", "Premiere did not confirm frame export; no output path is reported");
       const path = Protocol.joinPath(outputDirectory, filename);
       return { path, width, height, seconds: position.seconds, exporterResult: returned };
     }

--- a/uxp-plugin/index.cjs
+++ b/uxp-plugin/index.cjs
@@ -240,13 +240,15 @@ async function exportFrame(args, operation) {
   if (!args.outputDirectory) throw new Error("outputDirectory is required");
   const outputDirectory = await workspaceBroker.assertPathAllowed(args.outputDirectory, { label: "outputDirectory", kind: "directory" });
   const filename = Protocol.safeFilename(args.filename);
+  const exporterFilename = Protocol.exporterFrameName(filename);
   const position = args.seconds == null ? await sequence.getPlayerPosition() : await tickTime(args.seconds);
   const size = await sequence.getFrameSize();
   const width = positiveInt(args.width, size.width), height = positiveInt(args.height, size.height);
   assertNotCancelled(operation);
   operation.phase = "host_call";
   publishOperation("progress", operation, { phase: "host_call", progress: 0.4, cancellable: false });
-  const returned = await ppro.Exporter.exportSequenceFrame(sequence, position, filename, outputDirectory, width, height);
+  const returned = await ppro.Exporter.exportSequenceFrame(sequence, position, exporterFilename, outputDirectory, width, height);
+  if (returned !== true) throw new Error("Premiere did not confirm frame export; no output path is reported");
   const path = Protocol.joinPath(outputDirectory, filename);
   return {
     path, width, height, seconds: position.seconds, exporterResult: returned,

--- a/uxp-plugin/protocol.cjs
+++ b/uxp-plugin/protocol.cjs
@@ -129,6 +129,10 @@
     if (!/^[A-Za-z0-9][A-Za-z0-9._-]*\.png$/i.test(name)) throw new Error("filename must be a simple .png name");
     return name;
   }
+  // Premiere's frame exporter selects PNG from the name and appends that extension
+  // itself. Keep the public, fully qualified filename for reporting, but pass the
+  // bare stem to the host so `frame.png` does not become `frame.png.png`.
+  function exporterFrameName(value) { return safeFilename(value).replace(/\.png$/i, ""); }
   function joinPath(dir, name) { return /[\\\/]$/.test(dir) ? dir + name : dir + "/" + name; }
   return {
     PROTOCOL_VERSION,
@@ -143,6 +147,7 @@
     operationSemantics,
     createOperationTracker,
     safeFilename,
+    exporterFrameName,
     joinPath
   };
 });


### PR DESCRIPTION
## Summary
- preserve the public `frame.png` request/response name, but pass `frame` to Premiere's frame exporter because it appends the PNG extension itself
- reject a false exporter return instead of reporting an output path
- cover the normalized host filename, returned single-extension path, rejection path, and panel direct-export implementation
- correct the panel documentation to distinguish exporter acknowledgement from on-disk artifact proof

Fixes #247

## Verification
- `npm ci`
- `npx vitest run tests/uxp/protocol.test.ts tests/uxp/commands.test.ts`
- `npm run lint`
- `npm run build`
- `npm run check`
- `git diff --check`

## Licensed-host limitation
Automated tests exercise the panel command registry with a mocked exporter and inspect the direct panel path. No licensed Premiere host or writable host workspace was available, so this PR does not claim a real on-disk `frame.png` artifact. It should be confirmed in Premiere 25.6+ by exporting `frame.png` and checking that `frame.png` exists while `frame.png.png` does not.