### PR TITLE
fix(release): restore Claude Desktop MCPB build

### DIFF
--- a/scripts/validate-distribution.mjs
+++ b/scripts/validate-distribution.mjs
@@ -104,10 +104,12 @@ export async function validateClaudeStage(stage) {
     path.join(stage, "server", "dist", "index.js"),
     "Claude bundle stage is missing server/dist/index.js; run the TypeScript build first",
   );
-  await assertFile(
-    path.join(stage, "node_modules", "@modelcontextprotocol", "sdk", "package.json"),
-    "Claude bundle stage is missing production dependencies",
-  );
+  for (const dependency of Object.keys(packageJson.dependencies ?? {})) {
+    await assertFile(
+      path.join(stage, "node_modules", dependency, "package.json"),
+      `Claude bundle stage is missing production dependency ${dependency}`,
+    );
+  }
   return { manifest, packageJson };
 }
 

--- a/tests/release-package.test.ts
+++ b/tests/release-package.test.ts
@@ -30,4 +30,12 @@ describe("npm release package verification", () => {
     expect(publish).toContain("npm run pack:check");
     expect(crossPlatform).toContain("npm run pack:check");
   });
+
+  it("validates the Claude bundle against its declared production dependencies", () => {
+    const validator = read("scripts/validate-distribution.mjs");
+
+    expect(validator).toContain("Object.keys(packageJson.dependencies ?? {})");
+    expect(validator).toContain("node_modules\", dependency, \"package.json");
+    expect(validator).not.toContain('"@modelcontextprotocol", "sdk"');
+  });
 });


### PR DESCRIPTION
## Summary
- validate every production dependency declared by the staged Claude bundle
- remove the stale v1 SDK package assertion after the split SDK migration
- add regression coverage for the dependency validation contract

## Verification
- npx vitest run tests/release-package.test.ts
- npm run build:claude (built premiere-pro-mcp-1.14.2.mcpb)
- npm run check (81 files, 1,826 tests)
- git diff --check

Repairs the failed v1.14.2 Claude Desktop release asset workflow.