### PR TITLE
fix(intake): preserve malformed frame-rate evidence

### DIFF
--- a/docs/industry/project-intake-workflow.md
+++ b/docs/industry/project-intake-workflow.md
@@ -62,6 +62,13 @@ The workflow MUST begin read-only. A template check whose required host field is
 not exposed by the selected capability MUST report `unsupported` or
 `not_inspected`; it MUST NOT be inferred as a pass.
 
+Frame-rate evidence follows the same fail-closed rule. A non-finite or out-of-range
+host value becomes an item-level `FRAME_RATE_UNSUPPORTED` finding and makes the
+report incomplete; it does not abort inspection of unrelated items. Valid decimal
+readings are matched after snapping values within 0.005 fps of a canonical timebase,
+then using a maximum 0.05 fps tolerance for non-canonical Premiere measurements.
+Canonical rates such as 23.976 and 24 remain distinct.
+
 ### Non-goals
 
 Project Intake v0.1 MUST NOT:

--- a/src/intake/project-intake.ts
+++ b/src/intake/project-intake.ts
@@ -7,6 +7,11 @@ export const MAX_PROJECT_INTAKE_RULES = 64;
 // A clip can produce six independent findings (extension, frame rate, offline,
 // proxy, path, and ambiguous organization), plus bounded project-level findings.
 export const MAX_PROJECT_INTAKE_FINDINGS = 12_200;
+// Premiere's footage interpretation can expose a measured decimal that drifts
+// slightly from the source timebase. Keep canonical rates distinct, then allow
+// a bounded tolerance for non-canonical host readings.
+export const FRAME_RATE_CANONICAL_SNAP_TOLERANCE_FPS = 0.005;
+export const FRAME_RATE_MATCH_TOLERANCE_FPS = 0.05;
 
 export type IntakeCertainty = "observed" | "unavailable" | "not_checked";
 export type IntakeSeverity = "error" | "warning" | "info";
@@ -57,6 +62,8 @@ export interface ProjectIntakeItem {
   offline?: boolean;
   hasProxy?: boolean;
   frameRate?: number;
+  /** Derived during snapshot validation; never accepted as caller authority. */
+  frameRateUnsupported?: true;
 }
 
 export interface ProjectIntakeSnapshot {
@@ -256,6 +263,26 @@ function isRequired(template: FacilityIntakeTemplate, evidence: "extension" | "f
     || (evidence === "path" && template.approvedPathPrefixes.length > 0);
 }
 
+const CANONICAL_FRAME_RATES = [
+  23.976, 24, 25, 29.97, 30, 47.952, 48, 50, 59.94, 60, 100, 119.88, 120,
+];
+
+function canonicalFrameRate(value: number): number | undefined {
+  return CANONICAL_FRAME_RATES.find((rate) =>
+    Math.abs(rate - value) <= FRAME_RATE_CANONICAL_SNAP_TOLERANCE_FPS);
+}
+
+function frameRateMatches(observed: number, allowed: number): boolean {
+  const observedCanonical = canonicalFrameRate(observed);
+  const allowedCanonical = canonicalFrameRate(allowed);
+  if (observedCanonical !== undefined || allowedCanonical !== undefined) {
+    if (observedCanonical !== undefined && allowedCanonical !== undefined) {
+      return observedCanonical === allowedCanonical;
+    }
+  }
+  return Math.abs(allowed - observed) <= FRAME_RATE_MATCH_TOLERANCE_FPS;
+}
+
 function findingSort(left: ProjectIntakeFinding, right: ProjectIntakeFinding): number {
   const severity = { error: 0, warning: 1, info: 2 } as const;
   return severity[left.severity] - severity[right.severity]
@@ -370,9 +397,8 @@ export function validateProjectIntakeSnapshot(value: unknown): ProjectIntakeSnap
     if (typeof item.type !== "string" || !ITEM_TYPES.has(item.type)) {
       throw new Error(`snapshot.items[${index}].type must be clip, bin, sequence, or other`);
     }
-    if (item.frameRate !== undefined && (typeof item.frameRate !== "number" || !Number.isFinite(item.frameRate) || item.frameRate < 1 || item.frameRate > 240)) {
-      throw new Error(`snapshot.items[${index}].frameRate must be a finite frame rate from 1 through 240`);
-    }
+    const frameRateSupported = item.frameRate === undefined
+      || (typeof item.frameRate === "number" && Number.isFinite(item.frameRate) && item.frameRate >= 1 && item.frameRate <= 240);
     return {
       id: requiredText(item.id, `snapshot.items[${index}].id`, 512),
       name: requiredText(item.name, `snapshot.items[${index}].name`, 255),
@@ -382,7 +408,9 @@ export function validateProjectIntakeSnapshot(value: unknown): ProjectIntakeSnap
       ...(optionalText(item.mediaPath, `snapshot.items[${index}].mediaPath`, 4096) ? { mediaPath: optionalText(item.mediaPath, `snapshot.items[${index}].mediaPath`, 4096) } : {}),
       ...(optionalBoolean(item.offline, `snapshot.items[${index}].offline`) === undefined ? {} : { offline: optionalBoolean(item.offline, `snapshot.items[${index}].offline`) }),
       ...(optionalBoolean(item.hasProxy, `snapshot.items[${index}].hasProxy`) === undefined ? {} : { hasProxy: optionalBoolean(item.hasProxy, `snapshot.items[${index}].hasProxy`) }),
-      ...(item.frameRate === undefined ? {} : { frameRate: Number((item.frameRate as number).toFixed(6)) }),
+      ...(item.frameRate === undefined || !frameRateSupported
+        ? (frameRateSupported ? {} : { frameRateUnsupported: true as const })
+        : { frameRate: Number((item.frameRate as number).toFixed(6)) }),
     };
   });
   if (new Set(items.map((item) => item.id)).size !== items.length) throw new Error("snapshot.items contains duplicate ids");
@@ -514,7 +542,16 @@ export function buildProjectIntakeReport(
     }
 
     if (template.allowedFrameRates.length || isRequired(template, "frame_rate")) {
-      if (item.frameRate === undefined) {
+      if (item.frameRateUnsupported === true) {
+        requiredUnavailable.add("frame_rate");
+        pushFinding(findings, {
+          code: "FRAME_RATE_UNSUPPORTED",
+          severity: "error",
+          certainty: "unavailable",
+          itemId: item.id,
+          expected: { allowedFrameRates: template.allowedFrameRates },
+        });
+      } else if (item.frameRate === undefined) {
         requiredUnavailable.add("frame_rate");
         pushFinding(findings, {
           code: "FRAME_RATE_UNAVAILABLE",
@@ -523,7 +560,7 @@ export function buildProjectIntakeReport(
           itemId: item.id,
           expected: { allowedFrameRates: template.allowedFrameRates },
         });
-      } else if (!template.allowedFrameRates.some((rate) => Math.abs(rate - item.frameRate!) <= 0.000001)) {
+      } else if (!template.allowedFrameRates.some((rate) => frameRateMatches(item.frameRate!, rate))) {
         pushFinding(findings, {
           code: "FRAME_RATE_NOT_ALLOWED",
           severity: "error",

--- a/tests/project-intake.test.ts
+++ b/tests/project-intake.test.ts
@@ -99,6 +99,40 @@ describe("project intake engine", () => {
     expect(JSON.stringify(disclosed)).toContain("D:/Unapproved/INT_A_001.mp4");
   });
 
+  it("normalizes noisy Premiere frame-rate evidence without conflating canonical timebases", () => {
+    const noisy = buildProjectIntakeReport({
+      ...snapshot,
+      items: snapshot.items.map((item) => item.id === "clip-1" ? { ...item, frameRate: 29.93295 } : item),
+    }, { ...template, allowedFrameRates: [29.97] });
+    expect(noisy.findings.some((finding) => finding.code === "FRAME_RATE_NOT_ALLOWED")).toBe(false);
+
+    const distinctCanonical = buildProjectIntakeReport({
+      ...snapshot,
+      items: snapshot.items.map((item) => item.id === "clip-1" ? { ...item, frameRate: 23.976 } : item),
+    }, { ...template, allowedFrameRates: [24] });
+    expect(distinctCanonical.findings).toContainEqual(expect.objectContaining({
+      code: "FRAME_RATE_NOT_ALLOWED",
+      itemId: "clip-1",
+    }));
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, 0, 241, null])(
+    "keeps malformed frame-rate evidence as an item-level unsupported finding: %s",
+    (frameRate) => {
+      const report = buildProjectIntakeReport({
+        ...snapshot,
+        items: snapshot.items.map((item) => item.id === "clip-1" ? { ...item, frameRate } : item),
+      }, template);
+      expect(report.status).toBe("incomplete");
+      expect(report.capture.itemCount).toBe(snapshot.items.length);
+      expect(report.findings).toContainEqual(expect.objectContaining({
+        code: "FRAME_RATE_UNSUPPORTED",
+        certainty: "unavailable",
+        itemId: "clip-1",
+      }));
+    },
+  );
+
   it("returns incomplete when required evidence is unavailable and distinguishes optional checks not performed", () => {
     const incomplete = buildProjectIntakeReport({
       project: { id: "project-2" },
@@ -200,7 +234,7 @@ describe("project intake engine", () => {
     expect(suffixMatched.findings.some((finding) => finding.code.startsWith("REQUIRED_BIN_"))).toBe(false);
   });
 
-  it("bounds snapshots and rejects malformed evidence before evaluation", () => {
+  it("bounds snapshots and rejects malformed structural evidence before evaluation", () => {
     expect(() => validateProjectIntakeSnapshot({
       project: { id: "project" }, items: [{ id: "one", name: "One", type: "clip" }, { id: "one", name: "Two", type: "clip" }],
       truncated: false, unavailableEvidence: [],
@@ -212,10 +246,6 @@ describe("project intake engine", () => {
       project: { id: "project" }, items: [{ id: "one", name: "One", type: "asset" }],
       truncated: false, unavailableEvidence: [],
     })).toThrow("type must be clip, bin, sequence, or other");
-    expect(() => validateProjectIntakeSnapshot({
-      project: { id: "project" }, items: [{ id: "one", name: "One", type: "clip", frameRate: 0 }],
-      truncated: false, unavailableEvidence: [],
-    })).toThrow("finite frame rate");
   });
 
   it("rejects duplicate and out-of-contract facility rules", () => {

--- a/tests/tools/project-intake.test.ts
+++ b/tests/tools/project-intake.test.ts
@@ -43,6 +43,32 @@ describe("preview_project_intake tool", () => {
     expect(JSON.stringify(result)).not.toContain("D:/Secret");
   });
 
+  it("does not abort the preview when one host item has malformed frame-rate evidence", async () => {
+    const captureSnapshot = vi.fn(async () => ({
+      success: true,
+      data: {
+        project: { id: "project-1", name: "Feature" },
+        items: [{ id: "clip-1", name: "A001.mov", type: "clip", frameRate: null }],
+        truncated: false,
+        unavailableEvidence: [],
+      },
+    }));
+    const tools = getProjectIntakeTools({}, { captureSnapshot });
+    const result = await tools.preview_project_intake.handler({
+      template: { ...template, allowedFrameRates: [29.97], requiredEvidence: ["frame_rate"] },
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        status: "incomplete",
+        findings: expect.arrayContaining([
+          expect.objectContaining({ code: "FRAME_RATE_UNSUPPORTED", itemId: "clip-1" }),
+        ]),
+      },
+    });
+  });
+
   it("propagates bridge failures and rejects invalid bounds before capture", async () => {
     const captureSnapshot = vi.fn(async () => ({ success: false, error: "No project is open" }));
     const tools = getProjectIntakeTools({}, { captureSnapshot });


### PR DESCRIPTION
## Summary
- convert malformed or out-of-range host frame rates into item-level FRAME_RATE_UNSUPPORTED findings instead of aborting the intake preview
- accept bounded Premiere decimal drift while keeping canonical rates such as 23.976 and 24 distinct
- document the fail-closed evidence contract and tolerance

## Testing
1. Focused intake engine/tool tests: 18 passed
2. Intake workflow/host-report/tool contract tests: 324 passed
3. Full repository check before rebase: 81 files / 1,833 tests passed
4. Package dry-run and production dependency audit: package created; 0 vulnerabilities
5. Licensed-host replay: attempted on the disposable Premiere MCP Intake Validation project, but Premiere 26.3.2 reproduced the white-workspace hang before CEP could answer; no project mutation occurred

Post-rebase full repository check: 82 files / 1,841 tests passed.

## Evidence boundary
This fixes and verifies the deterministic intake engine and MCP contract. The licensed-host replay remains blocked by Premiere host startup/workspace responsiveness and is not claimed as passing host evidence.