### PR TITLE
chore: prepare v1.14.3 security hotfix

### DIFF
--- a/.agents/product-marketing.md
+++ b/.agents/product-marketing.md
@@ -137,7 +137,7 @@
 
 ## Proof Points
 
-**Release facts:** v1.14.2 registers 320 core tools; the default profile exposes 318; an authenticated compatible UXP host can add 54 capability-gated tools for a 372-tool connected surface. The release also declares 37 modules, 4 MCP resources, and 11 workflow prompts. It includes focused tool packs, explicit output schemas, a read-only review report, and npm package verification compatible with the current npm CLI. These are catalog and packaging facts from `release-metadata.json`, not a promise that a particular host operation will work.
+**Release facts:** v1.14.3 registers 320 core tools; the default profile exposes 318; an authenticated compatible UXP host can add 54 capability-gated tools for a 372-tool connected surface. The release also declares 37 modules, 4 MCP resources, and 11 workflow prompts. It includes focused tool packs, explicit output schemas, a read-only review report, npm package verification compatible with the current npm CLI, and optional fail-closed OAuth resource-server validation for allowlisted trusted operators. OAuth does not provide public desktop pairing or per-user Premiere routing. These are catalog, packaging, and HTTP authorization facts from the repository, not a promise that a particular host operation will work.
 
 **Compatibility boundary:** The release targets Premiere Pro 2020–2026; UXP workflows require a compatible Premiere Pro 25.6.0+ host and advertised capabilities. CEP remains the default compatibility route. A compatibility range, package validation, CI pass, HTTP health check, or local build is not real-host proof.
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "premiere-pro",
       "source": "./claude-plugins/premiere-pro",
       "description": "Inspect, edit, verify, and export local Premiere Pro projects through MCP.",
-      "version": "1.14.2",
+      "version": "1.14.3",
       "category": "creative",
       "tags": ["premiere-pro", "video-editing", "mcp"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.14.3] - 2026-08-29
+
+### Added
+
+- Added an optional, fail-closed OAuth resource-server mode with RFC 9728
+  protected-resource metadata, remote JWKS verification, exact issuer and
+  audience validation, required scopes, and an explicit trusted-subject
+  allowlist for operator-managed HTTP deployments.
+
+### Security
+
+- Added an IP-keyed admission gate before JWT verification and isolated
+  authenticated rate-limit identities behind random process-local keys.
+- Made partial or mixed OAuth/shared-token configuration fail startup, kept the
+  shared token as an operator-only compatibility mode, and removed internal
+  admission counters from the public health response.
+- Kept public desktop routing deliberately disabled: OAuth does not claim
+  user-to-device pairing or access to a user's local Premiere process.
+
 ## [1.14.2] - 2026-08-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -33,21 +33,21 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 
 The AI handles the entire workflow through 320 core tools spanning the supported ExtendScript, QE DOM, local media and interchange analysis, revisioned project-context retrieval, safe edit-planning, project-intake preview, review handoff, and connection-verification surfaces. A compatible, authenticated UXP panel adds 54 documented, capability-gated tools without replacing the production CEP bridge.
 
-### Latest release: 1.14.2
+### Latest release: 1.14.3
 
-- **Focused discovery:** compatible MCP clients can select essential,
-  inspection, delivery, or captions tool packs instead of beginning with the
-  full catalog.
-- **Review handoff:** `inspect_sequence_review_report` returns a read-only,
-  path-redacted sequence report, with marker comments only when requested.
-- **Interoperability:** all registered MCP tools now declare explicit output
-  schemas; this release does not substitute automated checks for licensed-host
-  verification.
-- **Reliable packaging:** npm package verification now isolates its temporary
-  tarball, keeping the validated distribution path compatible with the current
-  npm CLI.
+- **Trusted-operator OAuth:** HTTP deployments can validate signed access
+  tokens against a pinned issuer and JWKS with exact audience, lifetime,
+  required-scope, and subject-allowlist checks.
+- **MCP discovery:** OAuth mode publishes RFC 9728 protected-resource metadata
+  and returns interoperable `WWW-Authenticate` challenges.
+- **Fail-closed admission:** untrusted requests are bounded before JWT work,
+  mixed authentication modes refuse startup, and authenticated rate-limit keys
+  are opaque and process-local.
+- **Explicit boundary:** this release does not claim public desktop pairing or
+  route OAuth users to local Premiere processes; hosted use remains
+  operator-managed until that separate relay exists.
 
-See the [v1.14.2 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.14.2)
+See the [v1.14.3 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.14.3)
 for complete details. Live installation in Premiere Pro still requires host verification.
 
 ### Current MCP protocol support
@@ -89,9 +89,9 @@ their bins, media rules, and organization rules before a facility uses one.
 
 ### Easiest supported path: Claude Desktop
 
-1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.2/premiere-pro-mcp-1.14.2.mcpb).
+1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.3/premiere-pro-mcp-1.14.3.mcpb).
 2. In Claude Desktop, open **Settings > Extensions > Advanced settings > Install Extension**, select the downloaded bundle, and restart Claude Desktop.
-3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.2/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
+3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.3/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
 4. Restart Premiere, open a project, then open **Window > Extensions > MCP for Adobe Premiere Pro**.
 5. In Claude, enter: `Safely check my Premiere connection with verify_premiere_connection. Make no changes.`
 
@@ -338,11 +338,11 @@ From a clone of this repository:
 ```bash
 codex plugin marketplace add .
 codex plugin add premiere-pro@premiere-pro-mcp
-npx -y premiere-pro-mcp@1.14.2 --install-cep
+npx -y premiere-pro-mcp@1.14.3 --install-cep
 ```
 
 Restart Premiere Pro and start a new Codex session after installation. The plugin
-launches `premiere-pro-mcp@1.14.2` through `npx`; the separate CEP installation is
+launches `premiere-pro-mcp@1.14.3` through `npx`; the separate CEP installation is
 required because the MCP server communicates with the running Premiere host through
 the local bridge.
 
@@ -362,7 +362,7 @@ For Claude Code, add this repository as a marketplace and install the plugin:
 Then install the Premiere bridge and start a new Claude Code session:
 
 ```bash
-npx -y premiere-pro-mcp@1.14.2 --install-cep
+npx -y premiere-pro-mcp@1.14.3 --install-cep
 ```
 
 The Claude Code package lives in

--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.14.2" ExtensionBundleName="MCP for Adobe Premiere Pro">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.14.3" ExtensionBundleName="MCP for Adobe Premiere Pro">
   <ExtensionList>
-    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.14.2"/>
-    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.14.2"/>
+    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.14.3"/>
+    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.14.3"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/cep-plugin/index.html
+++ b/cep-plugin/index.html
@@ -81,7 +81,7 @@
     <section class="update-section" aria-live="polite">
       <div class="update-copy">
         <span class="section-label">Connector updates</span>
-        <strong id="updateTitle">Version 1.14.2</strong>
+        <strong id="updateTitle">Version 1.14.3</strong>
         <span id="updateDetail">Checking for updates…</span>
       </div>
       <button id="btnUpdate" class="button button-update" onclick="handleUpdateClick()" type="button" disabled>

--- a/cep-plugin/updater.cjs
+++ b/cep-plugin/updater.cjs
@@ -7,7 +7,7 @@
 })(this, function () {
   "use strict";
 
-  var CURRENT_VERSION = "1.14.2";
+  var CURRENT_VERSION = "1.14.3";
   var LATEST_RELEASE_API =
     "https://api.github.com/repos/leancoderkavy/premiere-pro-mcp/releases/latest";
   var RELEASES_URL =

--- a/claude-desktop/manifest.json
+++ b/claude-desktop/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "premiere-pro-mcp",
   "display_name": "MCP for Adobe Premiere Pro",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "description": "Control a local Adobe Premiere Pro project through MCP.",
   "long_description": "Inspect projects, assemble and modify timelines, manage media, effects, audio and captions, and export deliverables through a local bridge to Adobe Premiere Pro.",
   "author": {

--- a/claude-plugins/premiere-pro/.claude-plugin/plugin.json
+++ b/claude-plugins/premiere-pro/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "premiere-pro",
   "displayName": "Premiere Pro MCP",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "description": "Inspect, edit, verify, and export local Adobe Premiere Pro projects through MCP.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/claude-plugins/premiere-pro/.mcp.json
+++ b/claude-plugins/premiere-pro/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "premiere-pro": {
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.14.2"]
+      "args": ["-y", "premiere-pro-mcp@1.14.3"]
     }
   }
 }

--- a/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.14.2 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.14.3 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -5,6 +5,26 @@ import { product } from "@/lib/product"
 
 const releases = [
   {
+    version: "1.14.3",
+    date: "2026-08-29",
+    label: "Fail-closed OAuth for trusted operators",
+    groups: [
+      {
+        title: "Added",
+        items: [
+          "Added optional OAuth resource-server validation with protected-resource discovery, remote JWKS, exact issuer and audience checks, required scopes, and a mandatory trusted-subject allowlist.",
+        ],
+      },
+      {
+        title: "Security",
+        items: [
+          "JWT verification is protected by a pre-auth admission gate, authenticated rate-limit keys are opaque, mixed auth modes fail startup, and the public health response no longer exposes admission counters.",
+          "OAuth remains an operator boundary; this release does not claim public desktop pairing or per-user Premiere routing.",
+        ],
+      },
+    ],
+  },
+  {
     version: "1.14.2",
     date: "2026-08-28",
     label: "Verified host contracts and safer mutation outcomes",

--- a/landing/lib/product.ts
+++ b/landing/lib/product.ts
@@ -1,6 +1,6 @@
 export const product = {
   name: "MCP for Adobe Premiere Pro",
-  version: "1.14.2",
+  version: "1.14.3",
   releaseDate: "2026-08-27",
   coreToolCount: 320,
   defaultProfileToolCount: 318,
@@ -10,10 +10,10 @@ export const product = {
   uxpMinimumVersion: "25.6",
   downloads: {
     claudeBundle:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.2/premiere-pro-mcp-1.14.2.mcpb",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.3/premiere-pro-mcp-1.14.3.mcpb",
     signedCepConnector:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.2/MCPBridgeCEP.zxp",
-    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.14.2",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.3/MCPBridgeCEP.zxp",
+    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.14.3",
   },
   links: {
     repository: "https://github.com/leancoderkavy/premiere-pro-mcp",

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -20,7 +20,7 @@ Guide: Premiere Pro delivery QC and loudness checklist: https://premiere-pro-mcp
 Source: https://github.com/leancoderkavy/premiere-pro-mcp
 npm: https://www.npmjs.com/package/premiere-pro-mcp
 License: MIT
-Current release: 1.14.2
+Current release: 1.14.3
 
 ## What it does
 

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -41,7 +41,7 @@ The Project Intake guide includes no-sensitive-data starter templates for a path
 
 ## Verified facts
 
-- Current project release: 1.14.2.
+- Current project release: 1.14.3.
 - Tool surface: 320 core structured MCP tools are registered; the default profile exposes 318. With an authenticated compatible UXP panel, 54 additional capability-gated tools bring the connected surface to 372. The server also exposes 4 resources and 11 workflow prompts.
 - Supported desktop platforms: Windows and macOS.
 - Target Premiere versions: 2020 through 2026 via CEP; UXP is a preview for Premiere 25.6 and newer.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "premiere-pro-mcp",
-      "version": "1.14.2",
+      "version": "1.14.3",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/node": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "premiere-pro-mcp",
   "mcpName": "io.github.leancoderkavy/premiere-pro",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "description": "MCP server for Adobe Premiere Pro with 320 core AI video editing tools and a capability-aware UXP bridge for supported Premiere workflows.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/premiere-pro/.codex-plugin/plugin.json
+++ b/plugins/premiere-pro/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "description": "Plan, execute, verify, and export video edits in Adobe Premiere Pro through the Premiere Pro MCP server.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/plugins/premiere-pro/.mcp.json
+++ b/plugins/premiere-pro/.mcp.json
@@ -4,7 +4,7 @@
       "title": "Premiere Pro MCP",
       "description": "Inspect and edit a local Adobe Premiere Pro project through the Premiere Pro MCP bridge.",
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.14.2"]
+      "args": ["-y", "premiere-pro-mcp@1.14.3"]
     }
   }
 }

--- a/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.14.2 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.14.3 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/registry/server.json
+++ b/registry/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/leancoderkavy/premiere-pro-mcp",
     "source": "github"
   },
-  "version": "1.14.2",
+  "version": "1.14.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "premiere-pro-mcp",
-      "version": "1.14.2",
+      "version": "1.14.3",
       "transport": {
         "type": "stdio"
       }

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.14.2",
+  "version": "1.14.3",
   "coreTools": 320,
   "defaultProfileTools": 318,
   "uxpAdditionalTools": 54,

--- a/uxp-plugin/manifest.json
+++ b/uxp-plugin/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.ppmcp.premiere.uxp",
   "name": "MCP for Adobe Premiere Pro",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "main": "index.html",
   "host": { "app": "premierepro", "minVersion": "25.6.0" },
   "entrypoints": [


### PR DESCRIPTION
## Summary
- bump all distributable metadata to 1.14.3
- document the trusted-operator OAuth resource-server release and public desktop-routing boundary
- add matching changelog and landing release notes

## Verification
- npm run check (82 files, 1,834 tests)
- npm run pack:check
- RELEASE_TAG=v1.14.3 node scripts/verify-release-tag.mjs
- npm audit (0 vulnerabilities)
- git diff --check