### PR TITLE
fix(razor): pass a timecode string to QE razor() instead of ticks

### DIFF
--- a/src/resources/extendscript-reference.ts
+++ b/src/resources/extendscript-reference.ts
@@ -184,7 +184,7 @@ export const EXTENDSCRIPT_REFERENCE = [
   "qeSeq.getVideoTrackAt(index)          - QETrack",
   "qeSeq.getAudioTrackAt(index)          - QETrack",
   "qeTrack.getItemAt(index)              - QEClip",
-  "qeTrack.razor(tickString)             - split at position",
+  "qeTrack.razor(timecodeString)         - split at position (HH:MM:SS:FF, NOT ticks)",
   "",
   "qeClip.addVideoEffect(qeEffect)",
   "qeClip.addAudioEffect(qeEffect)",

--- a/src/tools/timeline.ts
+++ b/src/tools/timeline.ts
@@ -578,8 +578,21 @@ export function getTimelineTools(bridgeOptions: BridgeOptions) {
             return __error("No clip on the requested ${trackType} track strictly spans ${args.time_seconds}s; no razor was attempted.");
           }
 
+          // QE razor() parses its argument as a timecode string. Handing it a
+          // tick count makes the call succeed and do nothing, which is the
+          // silent no-op reported in #21, #127, #263 and #264. frameTicks is
+          // ticks-per-frame for this sequence, so frames = ticks / frameTicks.
+          var __razorFps = Math.round(TICKS_PER_SECOND / frameTicks);
+          if (!__razorFps || !isFinite(__razorFps) || __razorFps < 1) __razorFps = 30;
+          var __razorFrames = Math.round(cutTicks / frameTicks);
+          function __pad2(n) { return n < 10 ? "0" + n : "" + n; }
+          var __razorTc = __pad2(Math.floor(__razorFrames / (__razorFps * 3600))) + ":" +
+                          __pad2(Math.floor((__razorFrames % (__razorFps * 3600)) / (__razorFps * 60))) + ":" +
+                          __pad2(Math.floor((__razorFrames % (__razorFps * 60)) / __razorFps)) + ":" +
+                          __pad2(__razorFrames % __razorFps);
+
           try {
-            track.razor(cutTicks.toString());
+            track.razor(__razorTc);
           } catch(razorError) {
             return __error("QE razor rejected the request: " + razorError.toString() + ". No verified split was produced.");
           }

--- a/src/tools/track-targeting.ts
+++ b/src/tools/track-targeting.ts
@@ -315,6 +315,18 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
           var eligible = 0;
           var failures = [];
 
+          // QE razor() expects a timecode string, not ticks. See timeline.ts.
+          var __razorFrameTicks = seq && seq.timebase ? parseFloat(seq.timebase) : NaN;
+          if (!__razorFrameTicks || isNaN(__razorFrameTicks)) __razorFrameTicks = 254016000000 / 24;
+          var __razorFps = Math.round(254016000000 / __razorFrameTicks);
+          if (!__razorFps || !isFinite(__razorFps) || __razorFps < 1) __razorFps = 30;
+          var __razorFrames = Math.round(parseFloat(ticks) / __razorFrameTicks);
+          function __pad2(n) { return n < 10 ? "0" + n : "" + n; }
+          var __razorTc = __pad2(Math.floor(__razorFrames / (__razorFps * 3600))) + ":" +
+                          __pad2(Math.floor((__razorFrames % (__razorFps * 3600)) / (__razorFps * 60))) + ":" +
+                          __pad2(Math.floor((__razorFrames % (__razorFps * 60)) / __razorFps)) + ":" +
+                          __pad2(__razorFrames % __razorFps);
+
           if ("${trackType}" !== "audio") {
             for (var t = 0; t < seq.videoTracks.numTracks; t++) {
               var domTrack = seq.videoTracks[t];
@@ -322,7 +334,7 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
               if (wasEligible) eligible++;
               var before = domTrack.clips.numItems;
               try {
-                qeSeq.getVideoTrackAt(t).razor(ticks);
+                qeSeq.getVideoTrackAt(t).razor(__razorTc);
               } catch(e) {
                 if (wasEligible) failures.push("V" + (t + 1) + ": " + e.toString());
                 continue;
@@ -337,7 +349,7 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
               if (wasEligible) eligible++;
               var before = domTrack.clips.numItems;
               try {
-                qeSeq.getAudioTrackAt(t).razor(ticks);
+                qeSeq.getAudioTrackAt(t).razor(__razorTc);
               } catch(e) {
                 if (wasEligible) failures.push("A" + (t + 1) + ": " + e.toString());
                 continue;


### PR DESCRIPTION
> **Attribution:** this fix was identified, authored and verified by Claude (Anthropic), running as an agent on my machine at my direction. I have reproduced the failure and the fix on my own install. Flagging it so maintainers can review with that in mind.

## What does this PR do?

`split_clip` and `razor_all_tracks` pass a **tick count** to QE's `razor()`, which parses its argument as a **timecode string**. QE accepts the call, returns without throwing, and performs no cut — the "reports success, cuts nothing" behaviour in #263, #264, and previously #127 and #21.

This is an argument-format bug, not a Premiere 26.x limitation. Confirmed on **Premiere Pro 26.0.1** by calling QE directly:

```
qe.project.getActiveSequence().getVideoTrackAt(0).razor('00:00:04:00')  -> true
qe.project.getActiveSequence().getAudioTrackAt(0).razor('00:00:04:00')  -> true
```

That produced a correct two-clip split with correct source in/out mapping. The same sequence razored via `split_clip` left the clip count unchanged.

### Changes

- `src/tools/timeline.ts` — convert `cutTicks` to `HH:MM:SS:FF` using `frameTicks` (already in scope, `parseFloat(seq.timebase)` = ticks per frame) before calling `razor()`
- `src/tools/track-targeting.ts` — same conversion, applied once before the track loops, used at both call sites
- `src/resources/extendscript-reference.ts` — the reference resource documented this parameter as `tickString`, which is plausibly where the bug originated

The timecode is derived from the sequence being cut rather than `getActiveSequence()`, so a clip in a 24fps sequence is not razored against a 30fps timebase.

### Verification

After the change, on a 25fps sequence with a 10s clip on V1/A1:

| cut at | timecode | result |
|---|---|---|
| 4s | `00:00:04:00` | `split: true, verified: true, timelineVerified: true` |
| 7s, all tracks | `00:00:07:00` | `razored 2, eligibleTracks 2, failures: []` |
| 3729.44s | `01:02:09:11` | landed at exactly 3729.44s |

The third case exercises the hours and minutes fields, which a short clip never reaches. Read back with `get_sequence_structure` / `get_track_info` each time; all boundaries and source in/out points correct.

The existing verification guards (#69, #255) were left untouched — they are what surfaced this as an honest error rather than a false success, and they now pass instead of firing.

### Known limitation

The conversion is non-drop-frame. Drop-frame sequences (29.97 / 59.94) are untested and may need `;` separator handling. Happy to extend if you would prefer that in the same PR.

## Related Issue

Closes #263
Closes #264

## Type of Change

- [x] Bug fix

## Checklist

- [x] `npx tsc --noEmit` compiles without errors
- [x] ExtendScript uses ES3 syntax (`var`, `function`, string concatenation — no template literals, arrow functions, `let`/`const`)
- [x] No user-provided strings introduced, so no `escapeForExtendScript()` needed
- [x] No new tools, no tool-count or `RESEARCH.md` change
- [x] Tested against Premiere Pro 26.0.1 (CEP backend)