### PR TITLE
fix: verify legacy CEP mutation outcomes

### DIFF
--- a/docs/supported-actions.md
+++ b/docs/supported-actions.md
@@ -73,13 +73,13 @@ operation” when the tool has no enum-based mode.
 | `close_source_monitor` | Default profile | Single operation | Close the clip currently open in the Source Monitor. |
 | `color_correct` | Default profile | Single operation | Apply basic color correction to a clip using Lumetri Color |
 | `compare_cmx3600_edls` | Default profile | Single operation | Compare two local CMX 3600 EDLs by event number and report bounded added, removed, and changed editorial events. Read-only; it does not alter either interchange file or Premiere. |
-| `consolidate_and_transfer` | Default profile | Single operation | Consolidate, copy, or transcode project media using the Project Manager. Useful for archiving or transferring projects. |
+| `consolidate_and_transfer` | Default profile | Single operation | Consolidate, copy, or transcode project media using the Project Manager. Reports success only after a new destination folder contains a copied Premiere project. |
 | `consolidate_duplicates` | Default profile | Single operation | Consolidate duplicate project items and report success only when duplicate media groups decrease. |
 | `copy_effect_values` | Default profile | Single operation | Copy verified scalar effect-property values from one effect to the matching effect on another clip. Both clips must already have the same effect applied. Legacy CEP deliberately refuses Blend Mode because Premiere can corrupt its enum value on cross-clip writes. |
 | `copy_effects_between_clips` | Default profile | Single operation | Copy all effects (or a specific effect) from one clip to another. Does not copy intrinsic properties like Motion/Opacity unless specified. |
 | `create_bars_and_tone` | Default profile | Single operation | Create a Bars and Tone synthetic media item in the project (useful for leader/calibration) |
 | `create_bin` | Default profile | Single operation | Create a new bin (folder) in the project panel |
-| `create_caption_track` | Default profile | Single operation | Create a caption/subtitle track in the active sequence from an imported caption file (e.g., .srt, .vtt). Creation is structural only; verify playback or exported frames before delivery. |
+| `create_caption_track` | Default profile | Single operation | Create a caption/subtitle track in the active sequence from an imported caption file (e.g., .srt, .vtt). Reports structural success only when the host exposes a caption-track readback; otherwise reports an unverified accepted request. |
 | `create_context_edit_plan` | Default profile | `strategy`: `rough_cut`, `select_ranges`, `review` | Create a non-mutating, evidence-backed edit-plan scaffold from indexed Premiere context. It returns ranked source/time candidates and stale-state guards; the model must review them and use preview_edit_plan before any mutation. |
 | `create_editorial_plan` | Default profile | `workflow`: `organize`, `stringout`, `rough_cut`, `caption_review`, `platform_cutdown` | Create a local, evidence-backed editorial workflow plan from captured project context. It never calls an LLM, uploads media, or changes Premiere. |
 | `create_project` | Default profile | Single operation | Create a new Premiere Pro project at the specified path |
@@ -110,7 +110,7 @@ operation” when the tool has no enum-based mode.
 | `enable_disable_clip` | Default profile | Single operation | Enable or disable a clip on the timeline |
 | `encode_file` | Default profile | Single operation | Encode an external file (not in project) using Adobe Media Encoder |
 | `encode_project_item` | Default profile | Single operation | Encode a specific project item (not a sequence) using Adobe Media Encoder |
-| `export_aaf` | Default profile | Single operation | Export the active sequence as an AAF file (for Pro Tools, etc.) |
+| `export_aaf` | Default profile | Single operation | Unavailable on the CEP backend. Use export_aaf_uxp with an authenticated Premiere 26.3+ UXP bridge. |
 | `export_as_fcp_xml` | Default profile | Single operation | Export the active sequence as a Final Cut Pro XML file |
 | `export_as_project` | Default profile | Single operation | Export a sequence as a standalone Premiere Pro project file |
 | `export_frame` | Default profile | Single operation | Export the current frame as an image file |
@@ -228,7 +228,7 @@ operation” when the tool has no enum-based mode.
 | `move_item_to_bin` | Default profile | Single operation | Move a project item to a different bin |
 | `move_items_to_bin` | Default profile | Single operation | Move multiple project items to a target bin at once. |
 | `move_playhead_to_edit` | Default profile | `direction`: `next`, `previous` | Move the playhead to the next or previous edit point. |
-| `multiple_undo` | Default profile | Single operation | Undo multiple steps at once. |
+| `multiple_undo` | Default profile | Single operation | Unavailable: Premiere exposes no supported, observable undo-stack API for multiple scripted undo steps. |
 | `mute_track` | Default profile | Single operation | Mute or unmute an audio track |
 | `nest_clips` | Default profile | Single operation | Unavailable on the legacy CEP backend: Premiere's documented createSubsequence API only creates a separate sequence and cannot safely replace the selected timeline clips with a nested-sequence reference. |
 | `normalize_loudness_file` | Default profile | Single operation | Create a new loudness-normalized media derivative with FFmpeg, then remeasure that exact output using EBU R128. Never overwrites the input or an existing output file. |
@@ -322,7 +322,7 @@ operation” when the tool has no enum-based mode.
 | `set_sequence_in_out_points` | Default profile | Single operation | Set the sequence in and out points (for export range, etc.) |
 | `set_sequence_pixel_aspect_ratio` | Default profile | Single operation | Change the pixel aspect ratio of the active sequence. |
 | `set_sequence_resolution` | Default profile | Single operation | Change the resolution (frame size) of the active sequence. |
-| `set_sequence_settings` | Default profile | Single operation | Modify sequence settings (frame size, frame rate, etc.) |
+| `set_sequence_settings` | Default profile | Single operation | Modify and read back sequence frame-size settings. |
 | `set_source_in_out` | Default profile | Single operation | Set in and/or out points on the clip currently open in the Source Monitor. |
 | `set_start_time` | Default profile | Single operation | Set the start time (timecode offset) for a project item |
 | `set_target_track` | Default profile | `track_type`: `video`, `audio` | Set a track as targeted (active for insert/overwrite edits). Only one video and one audio track can be targeted at a time. |

--- a/src/tools/captions.ts
+++ b/src/tools/captions.ts
@@ -5,7 +5,7 @@ export function getCaptionTools(bridgeOptions: BridgeOptions) {
   return {
     create_caption_track: {
       description:
-        "Create a caption/subtitle track in the active sequence from an imported caption file (e.g., .srt, .vtt). Creation is structural only; verify playback or exported frames before delivery.",
+        "Create a caption/subtitle track in the active sequence from an imported caption file (e.g., .srt, .vtt). Reports structural success only when the host exposes a caption-track readback; otherwise reports an unverified accepted request.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -52,13 +52,42 @@ export function getCaptionTools(bridgeOptions: BridgeOptions) {
           
           var item = __findProjectItem("${escapeForExtendScript(args.item_id)}");
           if (!item) return __error("Caption item not found: ${escapeForExtendScript(args.item_id)}");
-          
+
+          function __captionTrackCount(sequence) {
+            var tracks = null;
+            try {
+              if (typeof sequence.getCaptionTracks === "function") tracks = sequence.getCaptionTracks();
+              else if (sequence.captionTracks) tracks = sequence.captionTracks;
+            } catch (readError) { tracks = null; }
+            if (!tracks) return null;
+            try { return tracks.numTracks !== undefined ? Number(tracks.numTracks) : Number(tracks.length); }
+            catch (countError) { return null; }
+          }
+          var beforeCount = __captionTrackCount(seq);
           var result = seq.createCaptionTrack(item, ${startSeconds}, ${format});
           if (!result) return __error("Failed to create caption track");
+          var afterCount = __captionTrackCount(seq);
+          if (beforeCount !== null && afterCount !== null) {
+            if (afterCount <= beforeCount) {
+              return __error("Premiere accepted caption-track creation but no caption track appeared in host readback. No successful creation is reported.");
+            }
+            return __result({
+              created: true,
+              verified: true,
+              renderVerified: false,
+              verificationScope: "Caption-track count readback only; verify playback or exported frames before delivery.",
+              item: item.name,
+              startSeconds: ${startSeconds},
+              format: "${args.caption_format || "subtitle"}",
+              beforeTrackCount: beforeCount,
+              afterTrackCount: afterCount
+            });
+          }
           return __result({
-            created: true,
+            accepted: true,
+            verified: false,
             renderVerified: false,
-            verificationScope: "Premiere accepted the caption-track creation; verify playback or exported frames before delivery.",
+            verificationScope: "Premiere accepted the caption-track request, but this CEP host exposes no caption-track readback. No structural creation is claimed; verify playback or exported frames before delivery.",
             item: item.name,
             startSeconds: ${startSeconds},
             format: "${args.caption_format || "subtitle"}"

--- a/src/tools/export.ts
+++ b/src/tools/export.ts
@@ -735,7 +735,7 @@ export function getExportTools(bridgeOptions: BridgeOptions) {
     },
 
     export_aaf: {
-      description: "Export the active sequence as an AAF file (for Pro Tools, etc.)",
+      description: "Unavailable on the CEP backend. Use export_aaf_uxp with an authenticated Premiere 26.3+ UXP bridge.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -762,28 +762,17 @@ export function getExportTools(bridgeOptions: BridgeOptions) {
         },
         required: ["output_path"],
       },
-      handler: async (args: {
+      handler: async (_args: {
         output_path: string;
         mix_down_video?: boolean;
         explode_to_mono?: boolean;
         sample_rate?: number;
         bits_per_sample?: number;
       }) => {
-        const script = buildToolScript(`
-          var seq = app.project.activeSequence;
-          if (!seq) return __error("No active sequence");
-          
-          seq.exportAsAAF(
-            "${escapeForExtendScript(args.output_path)}",
-            ${args.mix_down_video !== false ? 1 : 0},
-            ${args.explode_to_mono ? 1 : 0},
-            ${args.sample_rate ?? 48000},
-            ${args.bits_per_sample ?? 16}
-          );
-          
-          return __result({ exported: true, outputPath: "${escapeForExtendScript(args.output_path)}", format: "AAF" });
-        `);
-        return sendCommand(script, bridgeOptions);
+        return {
+          success: false,
+          error: "export_aaf is unavailable on the CEP backend because this Premiere host does not expose Sequence.exportAsAAF. Use export_aaf_uxp with an authenticated Premiere 26.3+ UXP bridge. No export was attempted.",
+        };
       },
     },
 

--- a/src/tools/project-manager.ts
+++ b/src/tools/project-manager.ts
@@ -5,7 +5,7 @@ export function getProjectManagerTools(bridgeOptions: BridgeOptions) {
   return {
     consolidate_and_transfer: {
       description:
-        "Consolidate, copy, or transcode project media using the Project Manager. Useful for archiving or transferring projects.",
+        "Consolidate, copy, or transcode project media using the Project Manager. Reports success only after a new destination folder contains a copied Premiere project.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -64,11 +64,19 @@ export function getProjectManagerTools(bridgeOptions: BridgeOptions) {
         convert_ae_comps?: boolean;
         convert_synthetic?: boolean;
       }) => {
+        const destinationPath = args.destination_path.trim();
+        if (!destinationPath) {
+          return { success: false, error: "destination_path must not be empty" };
+        }
         const script = buildToolScript(`
           var pm = app.projectManager;
           if (!pm) return __error("Project Manager not available");
-          
-          pm.destinationPath = "${escapeForExtendScript(args.destination_path)}";
+
+          var destination = new Folder("${escapeForExtendScript(destinationPath)}");
+          if (destination.exists) {
+            return __error("destination_path must be a new, empty folder so the Project Manager output can be verified: ${escapeForExtendScript(destinationPath)}");
+          }
+          pm.destinationPath = "${escapeForExtendScript(destinationPath)}";
           pm.includeAllSequences = ${args.include_all_sequences !== false ? 1 : 0};
           pm.copyToNewLocation = ${args.copy_to_new_location !== false ? 1 : 0};
           pm.excludeUnused = ${args.exclude_unused !== false ? 1 : 0};
@@ -79,11 +87,20 @@ export function getProjectManagerTools(bridgeOptions: BridgeOptions) {
           pm.convertAEComps = ${args.convert_ae_comps ? 1 : 0};
           pm.convertSyntheticMedia = ${args.convert_synthetic ? 1 : 0};
           
-          pm.process(app.project);
-          
+          var accepted = pm.process(app.project);
+          if (accepted === false) return __error("Premiere rejected the Project Manager request");
+          if (!destination.exists) {
+            return __error("Premiere accepted the Project Manager request but did not create the destination folder. No successful transfer is reported.");
+          }
+          var outputFiles = destination.getFiles("*.prproj");
+          if (!outputFiles || outputFiles.length < 1) {
+            return __error("Premiere created the destination folder but no copied .prproj file was found. No successful transfer is reported.");
+          }
           return __result({
-            started: true,
-            destination: "${escapeForExtendScript(args.destination_path)}"
+            completed: true,
+            verified: true,
+            destination: "${escapeForExtendScript(destinationPath)}",
+            copiedProjectCount: outputFiles.length
           });
         `);
         return sendCommand(script, { ...bridgeOptions, timeoutMs: 300000 }); // 5 min timeout

--- a/src/tools/sequence.ts
+++ b/src/tools/sequence.ts
@@ -168,7 +168,7 @@ export function getSequenceTools(bridgeOptions: BridgeOptions) {
     },
 
     set_sequence_settings: {
-      description: "Modify sequence settings (frame size, frame rate, etc.)",
+      description: "Modify and read back sequence frame-size settings.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -187,20 +187,33 @@ export function getSequenceTools(bridgeOptions: BridgeOptions) {
         },
       },
       handler: async (args: { sequence_id?: string; width?: number; height?: number }) => {
+        if (args.width === undefined && args.height === undefined) {
+          return { success: false, error: "Pass width, height, or both" };
+        }
+        for (const [name, value] of Object.entries({ width: args.width, height: args.height })) {
+          if (value !== undefined && (!Number.isInteger(value) || value < 1 || value > 16384)) {
+            return { success: false, error: `${name} must be an integer from 1 through 16384` };
+          }
+        }
         const seqLookup = args.sequence_id
           ? `var seq = __findSequence("${escapeForExtendScript(args.sequence_id)}"); if (!seq) return __error("Sequence not found");`
           : `var seq = app.project.activeSequence; if (!seq) return __error("No active sequence");`;
 
-        const setters: string[] = [];
-        if (args.width) setters.push(`seq.frameSizeHorizontal = ${args.width};`);
-        if (args.height) setters.push(`seq.frameSizeVertical = ${args.height};`);
-
         const script = buildToolScript(`
           ${seqLookup}
           var settings = seq.getSettings();
-          ${setters.join("\n          ")}
-          seq.setSettings(settings);
-          return __result({ updated: true, name: seq.name });
+          if (!settings) return __error("Could not get sequence settings");
+          ${args.width === undefined ? "" : `settings.videoFrameWidth = ${args.width};`}
+          ${args.height === undefined ? "" : `settings.videoFrameHeight = ${args.height};`}
+          var accepted = seq.setSettings(settings);
+          if (accepted === false) return __error("Premiere rejected the requested sequence settings");
+          var applied = seq.getSettings();
+          if (!applied) return __error("Premiere did not return sequence settings after the update");
+          var appliedWidth = Number(applied.videoFrameWidth);
+          var appliedHeight = Number(applied.videoFrameHeight);
+          ${args.width === undefined ? "" : `if (appliedWidth !== ${args.width}) return __error("Premiere did not apply the requested frame width: expected ${args.width}, got " + appliedWidth);`}
+          ${args.height === undefined ? "" : `if (appliedHeight !== ${args.height}) return __error("Premiere did not apply the requested frame height: expected ${args.height}, got " + appliedHeight);`}
+          return __result({ updated: true, verified: true, name: seq.name, width: appliedWidth, height: appliedHeight });
         `);
         return sendCommand(script, bridgeOptions);
       },

--- a/src/tools/track-targeting.ts
+++ b/src/tools/track-targeting.ts
@@ -1377,7 +1377,7 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
     },
 
     multiple_undo: {
-      description: "Undo multiple steps at once.",
+      description: "Unavailable: Premiere exposes no supported, observable undo-stack API for multiple scripted undo steps.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -1389,17 +1389,13 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
       },
       handler: async (args: { count?: number }) => {
         const count = args.count ?? 1;
-        const script = buildToolScript(`
-          var undone = 0;
-          for (var i = 0; i < ${count}; i++) {
-            try {
-              app.project.undo();
-              undone++;
-            } catch(e) { break; }
-          }
-          return __result({ undone: undone });
-        `);
-        return sendCommand(script, bridgeOptions);
+        if (!Number.isInteger(count) || count < 1 || count > 100) {
+          return { success: false, error: "count must be an integer from 1 through 100" };
+        }
+        return {
+          success: false,
+          error: "multiple_undo is unavailable because Premiere exposes no supported undo-stack API that can verify how many actions were undone. No mutation was attempted.",
+        };
       },
     },
 

--- a/tests/tools/tool-modules.test.ts
+++ b/tests/tools/tool-modules.test.ts
@@ -459,6 +459,29 @@ describe("Tool Handler Behavior", () => {
   });
 
   describe("verified Premiere mutations", () => {
+    it("uses settings fields and readback for set_sequence_settings", async () => {
+      const tools = getSequenceTools(bridgeOptions);
+      await (tools.set_sequence_settings.handler as any)({ sequence_id: "seq-1", width: 1920, height: 1080 });
+      const script = mockedSendCommand.mock.calls[0][0];
+      expect(script).toContain("settings.videoFrameWidth = 1920");
+      expect(script).toContain("settings.videoFrameHeight = 1080");
+      expect(script).toContain("var applied = seq.getSettings()");
+      expect(script).toContain("Premiere did not apply the requested frame width");
+      expect(script).toContain("verified: true");
+
+      vi.clearAllMocks();
+      await expect((tools.set_sequence_settings.handler as any)({})).resolves.toMatchObject({ success: false });
+      expect(mockedSendCommand).not.toHaveBeenCalled();
+    });
+
+    it("fails unsupported legacy AAF and multiple-undo requests before mutation", async () => {
+      const aaf = await (getExportTools(bridgeOptions).export_aaf.handler as any)({ output_path: "/tmp/turnover.aaf" });
+      const undo = await (getTrackTargetingTools(bridgeOptions).multiple_undo.handler as any)({ count: 2 });
+      expect(aaf).toMatchObject({ success: false, error: expect.stringContaining("No export was attempted") });
+      expect(undo).toMatchObject({ success: false, error: expect.stringContaining("No mutation was attempted") });
+      expect(mockedSendCommand).not.toHaveBeenCalled();
+    });
+
     it("converts audio dB to amplitude and verifies the readback", async () => {
       const tools = getAudioTools(bridgeOptions);
       await (tools.adjust_audio_levels.handler as any)({ node_id: "clip-1", level_db: -6 });
@@ -610,14 +633,22 @@ describe("Tool Handler Behavior", () => {
       expect(script).toContain("__result");
       expect(script).toContain("my-srt-file");
       expect(script).toContain("createCaptionTrack");
+      expect(script).toContain("__captionTrackCount");
+      expect(script).toContain("no caption track appeared in host readback");
+      expect(script).toContain("accepted: true");
     });
   });
 
   describe("project-manager tools", () => {
-    it("consolidate_and_transfer exists and is callable", async () => {
+    it("consolidate_and_transfer verifies a copied project in a new destination", async () => {
       const tools = getProjectManagerTools(bridgeOptions);
       expect(tools.consolidate_and_transfer).toBeDefined();
       expect(typeof tools.consolidate_and_transfer.handler).toBe("function");
+      await (tools.consolidate_and_transfer.handler as any)({ destination_path: "/tmp/transfer" });
+      const script = mockedSendCommand.mock.calls[0][0];
+      expect(script).toContain("destination_path must be a new, empty folder");
+      expect(script).toContain('destination.getFiles("*.prproj")');
+      expect(script).toContain("copiedProjectCount");
     });
   });
 });

--- a/tests/tools/tool-modules.test.ts
+++ b/tests/tools/tool-modules.test.ts
@@ -470,15 +470,31 @@ describe("Tool Handler Behavior", () => {
       expect(script).toContain("verified: true");
 
       vi.clearAllMocks();
+      await (tools.set_sequence_settings.handler as any)({ width: 1920 });
+      expect(mockedSendCommand.mock.calls[0][0]).toContain("settings.videoFrameWidth = 1920");
+      expect(mockedSendCommand.mock.calls[0][0]).not.toContain("settings.videoFrameHeight =");
+
+      vi.clearAllMocks();
+      await (tools.set_sequence_settings.handler as any)({ height: 1080 });
+      expect(mockedSendCommand.mock.calls[0][0]).toContain("settings.videoFrameHeight = 1080");
+      expect(mockedSendCommand.mock.calls[0][0]).not.toContain("settings.videoFrameWidth =");
+
+      vi.clearAllMocks();
+      await expect((tools.set_sequence_settings.handler as any)({ width: 0 })).resolves.toMatchObject({ success: false });
+      expect(mockedSendCommand).not.toHaveBeenCalled();
+
       await expect((tools.set_sequence_settings.handler as any)({})).resolves.toMatchObject({ success: false });
       expect(mockedSendCommand).not.toHaveBeenCalled();
     });
 
     it("fails unsupported legacy AAF and multiple-undo requests before mutation", async () => {
       const aaf = await (getExportTools(bridgeOptions).export_aaf.handler as any)({ output_path: "/tmp/turnover.aaf" });
-      const undo = await (getTrackTargetingTools(bridgeOptions).multiple_undo.handler as any)({ count: 2 });
+      const undoTools = getTrackTargetingTools(bridgeOptions);
+      const undo = await (undoTools.multiple_undo.handler as any)({ count: 2 });
+      const invalidUndo = await (undoTools.multiple_undo.handler as any)({ count: 0 });
       expect(aaf).toMatchObject({ success: false, error: expect.stringContaining("No export was attempted") });
       expect(undo).toMatchObject({ success: false, error: expect.stringContaining("No mutation was attempted") });
+      expect(invalidUndo).toMatchObject({ success: false, error: expect.stringContaining("integer from 1 through 100") });
       expect(mockedSendCommand).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
## Summary
- correct set_sequence_settings to modify Sequence.getSettings() frame-size fields and require exact readback
- prevent unsupported CEP AAF export and multi-step undo from reporting work that cannot be verified
- require Project Manager output to include a copied .prproj in a new destination folder
- distinguish verified caption-track creation from an accepted-but-unreadable host request
- regenerate the supported-actions catalog and add regression coverage

Fixes #266
Fixes #269
Fixes #270
Fixes #271
Fixes #272

## Verification
- 
pm test -- --run tests/tools/tool-modules.test.ts tests/tools/regressions.test.ts (353 passed)
- 
px tsc --noEmit
- 
pm run lint
- 
pm run check (82 files, 1,843 tests)
- git diff --check

## Host evidence boundary
These checks validate handler behavior and generated ExtendScript. They do not claim a licensed Premiere host replay. A CEP path now either performs the documented readback or reports an unverified/unsupported outcome rather than claiming a completed mutation.