### PR TITLE
fix: keep stdio available when UXP port is busy

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,14 @@ function debugLog(message: string): void {
   }
 }
 
+function isLoopbackPortInUse(error: unknown): boolean {
+  return Boolean(
+    error
+    && typeof error === "object"
+    && (error as NodeJS.ErrnoException).code === "EADDRINUSE",
+  );
+}
+
 // Handle CLI flags
 const args = process.argv.slice(2);
 
@@ -164,15 +172,23 @@ async function main() {
 
   let uxpBridge: UxpWebSocketBridge | undefined;
   if (process.env.PREMIERE_UXP_TOKEN) {
-    uxpBridge = new UxpWebSocketBridge({
+    const bridge = new UxpWebSocketBridge({
       token: process.env.PREMIERE_UXP_TOKEN,
       port: process.env.PREMIERE_UXP_PORT
         ? parseInt(process.env.PREMIERE_UXP_PORT, 10)
         : undefined,
     });
-    await uxpBridge.start();
-    const address = uxpBridge.address();
-    debugLog(`UXP bridge listening on ws://${address.host}:${address.port}${address.path}`);
+    try {
+      await bridge.start();
+      uxpBridge = bridge;
+      const address = bridge.address();
+      debugLog(`UXP bridge listening on ws://${address.host}:${address.port}${address.path}`);
+    } catch (error) {
+      if (!isLoopbackPortInUse(error)) throw error;
+      console.error(
+        "[premiere-pro-mcp] UXP bridge unavailable because its loopback port is already in use; continuing with CEP-only tools.",
+      );
+    }
   }
 
   const serverHandle = serveStdio(

--- a/tests/entrypoints-unit.test.ts
+++ b/tests/entrypoints-unit.test.ts
@@ -230,6 +230,36 @@ describe("stdio CLI entry point", () => {
     expect(error).toHaveBeenCalledWith(expect.stringContaining("UXP bridge listening"));
   });
 
+  it("continues with CEP-only tools when another MCP instance owns the UXP loopback port", async () => {
+    process.argv = [process.execPath, "index.js"];
+    process.env.PREMIERE_UXP_TOKEN = "a-secure-token-with-length";
+    mocks.uxpStart.mockRejectedValueOnce(Object.assign(new Error("address already in use"), { code: "EADDRINUSE" }));
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await import("../src/index.js");
+
+    await vi.waitFor(() => expect(mocks.serveStdio).toHaveBeenCalledOnce());
+    expect(mocks.connect).toHaveBeenCalledOnce();
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("continuing with CEP-only tools"));
+  });
+
+  it("keeps non-port UXP startup failures fatal", async () => {
+    process.argv = [process.execPath, "index.js"];
+    process.env.PREMIERE_UXP_TOKEN = "a-secure-token-with-length";
+    mocks.uxpStart.mockRejectedValueOnce(Object.assign(new Error("permission denied"), { code: "EACCES" }));
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+
+    await import("../src/index.js");
+
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(1));
+    expect(mocks.serveStdio).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(
+      "[premiere-pro-mcp] Fatal error:",
+      expect.objectContaining({ message: "permission denied" }),
+    );
+  });
+
   it("reports a fatal stdio startup failure", async () => {
     process.argv = [process.execPath, "index.js"];
     mocks.serveStdio.mockImplementationOnce(() => { throw new Error("connect failed"); });


### PR DESCRIPTION
## Summary
- treat only a loopback EADDRINUSE during UXP bridge startup as a non-fatal, CEP-only fallback
- retain fatal startup behavior for other errors such as EACCES
- keep diagnostics on stderr so MCP stdout remains protocol-only

Fixes #279

## Verification
- 
pm test -- --run tests/entrypoints-unit.test.ts tests/uxp/transport.test.ts (46 passed)
- 
px tsc --noEmit
- 
pm run check (83 files, 1,848 tests)
- git diff --check

## Behavior boundary
A second local MCP process now serves the CEP tool surface when the fixed UXP loopback port is already owned. It does not advertise or attempt UXP commands, and it does not broaden the fallback to permission or configuration failures.