### PR TITLE
fix: verify clip pan and rename placeholders

### DIFF
--- a/docs/supported-actions.md
+++ b/docs/supported-actions.md
@@ -284,7 +284,7 @@ operation” when the tool has no enum-based mode.
 | `set_blend_mode` | Default profile | `blend_mode`: `Normal`, `Dissolve`, `Darken`, `Multiply`, `Color Burn`, `Linear Burn`, `Darker Color`, `Lighten`, `Screen`, `Color Dodge`, `Linear Dodge`, `Lighter Color`, `Overlay`, `Soft Light`, `Hard Light`, `Vivid Light`, `Linear Light`, `Pin Light`, `Hard Mix`, `Difference`, `Exclusion`, `Subtract`, `Divide`, `Hue`, `Saturation`, `Color`, `Luminosity` | Set the blend mode on a video clip. Uses the Opacity effect's Blend Mode property. |
 | `set_clip_anchor_point` | Default profile | Single operation | Set the Anchor Point property on a video clip's Motion effect. |
 | `set_clip_opacity` | Default profile | Single operation | Set the opacity of a video clip (0-100). |
-| `set_clip_pan` | Default profile | Single operation | Set the pan (left/right balance) on an audio clip. |
+| `set_clip_pan` | Default profile | Single operation | Set and read back the pan (left/right balance) on an audio clip, including Channel Volume layouts. |
 | `set_clip_position` | Default profile | Single operation | Set the Position property on a video clip's Motion effect. Values are in pixels. |
 | `set_clip_properties` | Default profile | Single operation | Set supported clip properties (opacity, scale, position, rotation). Clip speed is unsupported and fails before mutation. |
 | `set_clip_properties_batch` | Default profile | Single operation | Apply Motion/Opacity values to up to 16 clips after preflighting every target property. The handler reads each requested value back and never reports a partial batch as verified. |

--- a/src/tools/track-targeting.ts
+++ b/src/tools/track-targeting.ts
@@ -963,7 +963,7 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
     },
 
     set_clip_pan: {
-      description: "Set the pan (left/right balance) on an audio clip.",
+      description: "Set and read back the pan (left/right balance) on an audio clip, including Channel Volume layouts.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -980,26 +980,34 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
         required: ["node_id", "pan"],
       },
       handler: async (args: { node_id: string; pan: number }) => {
+        if (!Number.isFinite(args.pan) || args.pan < -100 || args.pan > 100) {
+          return { success: false, error: "pan must be a finite value from -100 through 100" };
+        }
         const script = buildToolScript(`
           var result = __findClip("${escapeForExtendScript(args.node_id)}");
           if (!result) return __error("Clip not found");
+          if (result.trackType !== "audio") return __error("Clip is not on an audio track");
 
           var clip = result.clip;
-          var set = false;
+          var panProperty = null;
           for (var i = 0; i < clip.components.numItems; i++) {
-            if (clip.components[i].displayName === "Panner") {
-              for (var p = 0; p < clip.components[i].properties.numItems; p++) {
-                if (clip.components[i].properties[p].displayName === "Balance" || clip.components[i].properties[p].displayName === "Pan") {
-                  clip.components[i].properties[p].setValue(${args.pan}, true);
-                  set = true;
-                  break;
-                }
+            var component = clip.components[i];
+            for (var p = 0; p < component.properties.numItems; p++) {
+              var property = component.properties[p];
+              if (property.displayName === "Balance" || property.displayName === "Pan") {
+                panProperty = property;
+                break;
               }
-              break;
             }
+            if (panProperty) break;
           }
-          if (!set) return __error("Could not set pan - is this an audio clip?");
-          return __result({ pan: ${args.pan}, clip: clip.name });
+          if (!panProperty) return __error("Audio clip does not expose a writable Balance or Pan property (checked Panner, Channel Volume, and other audio components).");
+          var writeResult = panProperty.setValue(${args.pan}, true);
+          var appliedPan = Number(panProperty.getValue());
+          if (isNaN(appliedPan) || Math.abs(appliedPan - ${args.pan}) > 0.0001) {
+            return __error("Premiere did not apply the requested pan: expected ${args.pan}, got " + appliedPan);
+          }
+          return __result({ pan: appliedPan, verified: true, writeResult: writeResult, clip: clip.name });
         `);
         return sendCommand(script, bridgeOptions);
       },
@@ -1014,7 +1022,7 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
           pattern: {
             type: "string",
             description:
-              "Name pattern. Use {n} for sequential number, {name} for original name (e.g., 'Scene_{n}', '{name}_v2')",
+              "Name pattern. Use {n} for a sequential number, ## for a zero-padded two-digit sequence number, and {name} for the original name (e.g., 'Scene_##', '{name}_v2')",
           },
           track_type: {
             type: "string",
@@ -1045,6 +1053,9 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
         start_number?: number;
       }) => {
         const startNum = args.start_number ?? 1;
+        if (!Number.isInteger(startNum) || startNum < 1 || startNum > 1_000_000) {
+          return { success: false, error: "start_number must be an integer from 1 through 1000000" };
+        }
         const script = buildToolScript(`
           app.enableQE();
           var seq = app.project.activeSequence;
@@ -1069,7 +1080,10 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
             var clip = track.clips[c];
             ${args.selected_only ? `if (!clip.isSelected()) continue;` : ""}
 
-            var newName = pattern.split("{n}").join("" + num).split("{name}").join(clip.name);
+            var sequenceNumber = "" + num;
+            var paddedSequenceNumber = sequenceNumber;
+            while (paddedSequenceNumber.length < 2) paddedSequenceNumber = "0" + paddedSequenceNumber;
+            var newName = pattern.split("{n}").join(sequenceNumber).split("##").join(paddedSequenceNumber).split("{name}").join(clip.name);
             try {
               var qeClip = qeTrack.getItemAt(c);
               qeClip.setName(newName);

--- a/tests/tools/tool-modules.test.ts
+++ b/tests/tools/tool-modules.test.ts
@@ -498,6 +498,30 @@ describe("Tool Handler Behavior", () => {
       expect(mockedSendCommand).not.toHaveBeenCalled();
     });
 
+    it("finds pan on Channel Volume layouts and verifies the readback", async () => {
+      const tools = getTrackTargetingTools(bridgeOptions);
+      await (tools.set_clip_pan.handler as any)({ node_id: "audio-clip-1", pan: -50 });
+      const script = mockedSendCommand.mock.calls[0][0];
+      expect(script).toContain('result.trackType !== "audio"');
+      expect(script).toContain("component.properties");
+      expect(script).toContain('property.displayName === "Balance"');
+      expect(script).toContain("panProperty.getValue()");
+      expect(script).toContain("Premiere did not apply the requested pan");
+
+      vi.clearAllMocks();
+      await expect((tools.set_clip_pan.handler as any)({ node_id: "audio-clip-1", pan: 101 })).resolves.toMatchObject({ success: false });
+      expect(mockedSendCommand).not.toHaveBeenCalled();
+    });
+
+    it("supports the documented ## zero-padded rename placeholder", async () => {
+      const tools = getTrackTargetingTools(bridgeOptions);
+      await (tools.batch_rename_clips.handler as any)({ pattern: "QA_Batch_##", track_type: "video", track_index: 0 });
+      const script = mockedSendCommand.mock.calls[0][0];
+      expect(script).toContain('.split("##").join(paddedSequenceNumber)');
+       expect(script).toContain('while (paddedSequenceNumber.length < 2)');
+       expect(script).toContain('"0" + paddedSequenceNumber');
+     });
+
     it("converts audio dB to amplitude and verifies the readback", async () => {
       const tools = getAudioTools(bridgeOptions);
       await (tools.adjust_audio_levels.handler as any)({ node_id: "clip-1", level_db: -6 });


### PR DESCRIPTION
## Summary
- locate Balance or Pan on all audio components, including Channel Volume, and require exact readback before reporting a pan change
- reject non-audio targets and invalid pan inputs with accurate diagnostics
- support the documented ## clip-rename placeholder as a two-digit zero-padded sequence number alongside {n}
- regenerate supported-actions documentation and add regression coverage

Fixes #251
Fixes #265

## Verification
- 
pm test -- --run tests/tools/tool-modules.test.ts (303 passed)
- 
px tsc --noEmit
- 
pm run check (83 files, 1,848 tests)
- git diff --check

## Host evidence boundary
The tests verify schema, generated ExtendScript, input validation, and readback guards. A licensed Premiere host is still required to prove the target host exposes and persists Channel Volume Balance/Pan.