### PR TITLE
fix: retain listed UXP transition match names

### DIFF
--- a/tests/uxp/commands.test.ts
+++ b/tests/uxp/commands.test.ts
@@ -117,6 +117,21 @@ describe("UXP command registry", () => {
     });
   });
 
+  it("accepts a transition match name returned by an earlier list when host enumeration changes", async () => {
+    const value = host();
+    value.ppro.TransitionFactory.getVideoTransitionMatchNames
+      .mockResolvedValueOnce(["ADBE Cross Dissolve New"])
+      .mockResolvedValueOnce(["ADBE Additive Dissolve"]);
+
+    await expect(value.registry.dispatch("transition.video.list", {})).resolves.toEqual({
+      matchNames: ["ADBE Cross Dissolve New"], count: 1,
+    });
+    await expect(value.registry.dispatch("transition.video.add", {
+      videoTrackIndex: 0, clipIndex: 0, matchName: "ADBE Cross Dissolve New", position: "start",
+    })).resolves.toMatchObject({ applied: true, matchName: "ADBE Cross Dissolve New" });
+    expect(value.ppro.TransitionFactory.createVideoTransition).toHaveBeenCalledWith("ADBE Cross Dissolve New");
+  });
+
   it("exports a PNG with a bare host filename and a one-extension returned path", async () => {
     const value = host();
     await expect(value.registry.dispatch("frame.export", {

--- a/uxp-plugin/commands.cjs
+++ b/uxp-plugin/commands.cjs
@@ -9,6 +9,7 @@
     const ppro = deps.ppro, Protocol = deps.Protocol, workspace = deps.workspace;
     const completedOperations = new Map();
     const inFlightOperations = new Map();
+    const listedVideoTransitionMatchNames = new Set();
     const definitions = {
       "capabilities.get": { readOnly: true, handler: capabilities },
       "state.get": { readOnly: true, handler: stateSnapshot },
@@ -391,14 +392,16 @@
       };
     }
     async function listTransitions() {
-      const matchNames = Array.from(await ppro.TransitionFactory.getVideoTransitionMatchNames() || []);
+      const matchNames = await currentVideoTransitionMatchNames();
       return { matchNames, count: matchNames.length };
     }
     async function addTransition(args) {
       const input = validateAddArgs(args), context = await activeContext(true);
       const target = await videoClipAt(context.sequence, input.videoTrackIndex, input.clipIndex);
-      const available = Array.from(await ppro.TransitionFactory.getVideoTransitionMatchNames() || []);
-      if (!available.includes(input.matchName)) throw commandError("UXP_TRANSITION_NOT_FOUND", "Unknown video transition matchName: " + input.matchName);
+      const available = await currentVideoTransitionMatchNames();
+      if (!available.includes(input.matchName) && !listedVideoTransitionMatchNames.has(input.matchName)) {
+        throw commandError("UXP_TRANSITION_NOT_FOUND", "Unknown video transition matchName: " + input.matchName);
+      }
       const transition = await ppro.TransitionFactory.createVideoTransition(input.matchName);
       if (!transition) throw commandError("UXP_TRANSITION_NOT_FOUND", "Premiere could not create video transition: " + input.matchName);
       const options = ppro.AddTransitionOptions();
@@ -415,6 +418,13 @@
       });
       assertTransactionCommitted(committed, "transition addition");
       return { applied: true, verified: "transaction", matchName: input.matchName, videoTrackIndex: input.videoTrackIndex, clipIndex: input.clipIndex, position: input.position };
+    }
+    async function currentVideoTransitionMatchNames() {
+      const matchNames = Array.from(await ppro.TransitionFactory.getVideoTransitionMatchNames() || []);
+      for (let i = 0; i < matchNames.length; i += 1) {
+        if (typeof matchNames[i] === "string" && matchNames[i]) listedVideoTransitionMatchNames.add(matchNames[i]);
+      }
+      return matchNames;
     }
     async function removeTransition(args) {
       const input = validateRemoveArgs(args), context = await activeContext(true);


### PR DESCRIPTION
## Summary
- retain exact transition match names returned by list_video_transitions_uxp for the lifetime of the connected panel
- accept a name listed earlier in the same MCP session even if Premiere's subsequent enumeration is inconsistent
- still require createVideoTransition to produce the transition, so a stale/uninstalled name returns an honest creation error

Fixes #261

## Verification
- 
pm test -- --run tests/uxp/commands.test.ts (18 passed)
- 
pm run lint
- 
pm run check (83 files, 1,847 tests)
- git diff --check

## Host evidence boundary
This reproduces unstable sequential enumeration with the UXP command mock. It does not claim a licensed-host timeline readback; the transaction result remains the existing verification boundary.