### PR TITLE
feat: bound large read tool results

### DIFF
--- a/docs/supported-actions.md
+++ b/docs/supported-actions.md
@@ -130,7 +130,7 @@ operation” when the tool has no enum-based mode.
 | `get_av_feature_support` | Default profile | Single operation | Report the documented automation boundary for advanced audio and modern color management, including actionable reasons for UI-only features. |
 | `get_bin_contents` | Default profile | Single operation | Get detailed contents of a specific bin (folder) including all nested items, media paths, offline status, color labels, and metadata. Searches by bin name or node ID. |
 | `get_bridge_telemetry` | Default profile | Single operation | Inspect privacy-preserving aggregate bridge health: pending command/response counts, busy operations, queue age, and CEP heartbeat state without returning project or personal data. |
-| `get_capabilities` | Default profile | Single operation | Report Windows/macOS support, Premiere Pro backend coverage, enabled authority, and whether live host verification is still required. |
+| `get_capabilities` | Default profile | Single operation | Report Windows/macOS support, Premiere Pro backend coverage, enabled authority, and whether live host verification is still required. Use tool_names or tool_offset/tool_limit to return a bounded tool catalog. |
 | `get_clip_adjustment_layer` | Default profile | Single operation | Check if a clip is an adjustment layer |
 | `get_clip_at_playhead` | Default profile | `track_type`: `video`, `audio`, `both` | Get all clips at the current playhead position across all tracks. |
 | `get_clip_at_position` | Default profile | `track_type`: `video`, `audio` | Get the clip at a specific time position on a track |
@@ -147,14 +147,14 @@ operation” when the tool has no enum-based mode.
 | `get_export_file_extension` | Default profile | Single operation | Get the file extension that would be used when exporting the active sequence with a given preset |
 | `get_footage_interpretation` | Default profile | Single operation | Get footage interpretation settings for a project item |
 | `get_full_clip_info` | Default profile | Single operation | Get exhaustive information about a specific clip: all effects with every property value, source media details, footage interpretation, metadata, markers, speed, enabled state, color label, linked clips, and proxy status. |
-| `get_full_project_overview` | Default profile | Single operation | Get a comprehensive overview of the entire project: all bins (recursive tree), all sequences, media stats, offline items, and project settings. This is the best first call to fully understand a project. |
+| `get_full_project_overview` | Default profile | Single operation | Get a comprehensive overview of the project. Use include_bin_tree false or sequence_offset/sequence_limit for a bounded response on large projects. |
 | `get_full_sequence_info` | Default profile | Single operation | Get exhaustive information about a sequence: settings, all tracks with lock/mute/target state, all clips with positions/effects/speed/enabled state, all markers, transitions, in/out points, and work area. |
 | `get_graphics_white_luminance` | Default profile | Single operation | Get the graphics white luminance value (HDR setting) for the project |
 | `get_insertion_bin` | Default profile | Single operation | Get the current target bin for new imports (the bin that is currently focused in the Project panel) |
 | `get_item_info` | Default profile | Single operation | Get detailed type info about a project item (is it a sequence, multicam, merged clip, etc.) |
 | `get_keyframes` | Default profile | Single operation | Get all keyframes for a specific effect property on a clip |
 | `get_linked_items` | Default profile | Single operation | Get all clips in the sequence that are linked to the same source as a given clip |
-| `get_metadata` | Default profile | Single operation | Get metadata for a project item |
+| `get_metadata` | Default profile | Single operation | Get metadata for a project item. Disable either XML payload when a bounded identity/path response is sufficient. |
 | `get_mogrt_component` | Default profile | Single operation | Get MOGRT (Motion Graphics Template) component parameters from a clip |
 | `get_next_edit_point` | Default profile | `direction`: `next`, `previous`; `track_type`: `video`, `audio`, `both` | Find the next or previous edit point (clip boundary) from the playhead position. |
 | `get_offline_media` | Default profile | Single operation | Find all offline/missing media in the project with their expected file paths. Essential for diagnosing broken links. |

--- a/src/tools/health.ts
+++ b/src/tools/health.ts
@@ -85,18 +85,74 @@ export function getHealthTools(
       },
     },
     get_capabilities: {
-      description: "Report Windows/macOS support, Premiere Pro backend coverage, enabled authority, and whether live host verification is still required.",
-      parameters: {},
-      handler: async () => ({
-        success: true,
-        data: buildPlatformCapabilityReport(
+      description: "Report Windows/macOS support, Premiere Pro backend coverage, enabled authority, and whether live host verification is still required. Use tool_names or tool_offset/tool_limit to return a bounded tool catalog.",
+      parameters: {
+        type: "object" as const,
+        additionalProperties: false,
+        properties: {
+          tool_names: {
+            type: "array",
+            items: { type: "string", minLength: 1, maxLength: 256 },
+            minItems: 1,
+            maxItems: 128,
+            uniqueItems: true,
+            description: "Optional exact tool-name allowlist. Returns only those catalog entries while retaining the overall capability summary.",
+          },
+          tool_offset: {
+            type: "integer",
+            minimum: 0,
+            description: "Zero-based offset into the filtered tool catalog. Pair with tool_limit for an explicitly sized page.",
+          },
+          tool_limit: {
+            type: "integer",
+            minimum: 1,
+            maximum: 128,
+            description: "Maximum tool catalog entries to return. Omit with tool_offset to preserve the complete legacy response.",
+          },
+        },
+      },
+      handler: async (args: { tool_names?: string[]; tool_offset?: number; tool_limit?: number } = {}) => {
+        const report = buildPlatformCapabilityReport(
           capabilities,
           process.platform,
           getTempDir(bridgeOptions),
           getToolCatalog(),
           buildToolPackReport(options.toolPacks ?? resolveToolPacks()),
-        ),
-      }),
+        );
+        const names = Array.isArray(args.tool_names) ? new Set(args.tool_names) : undefined;
+        const matchingTools = names
+          ? report.tools.tools.filter((tool) => names.has(tool.name))
+          : report.tools.tools;
+        const offset = Number.isInteger(args.tool_offset) && (args.tool_offset as number) >= 0 ? args.tool_offset as number : 0;
+        const hasExplicitPage = args.tool_limit !== undefined || args.tool_offset !== undefined;
+        const limit = Number.isInteger(args.tool_limit) && (args.tool_limit as number) > 0
+          ? Math.min(args.tool_limit as number, 128)
+          : matchingTools.length;
+        const page = hasExplicitPage ? matchingTools.slice(offset, offset + limit) : matchingTools;
+
+        return {
+          success: true,
+          data: {
+            ...report,
+            tools: {
+              ...report.tools,
+              tools: page,
+              ...(names || hasExplicitPage
+                ? {
+                    pagination: {
+                      offset,
+                      limit,
+                      returned: page.length,
+                      totalMatching: matchingTools.length,
+                      hasMore: offset + page.length < matchingTools.length,
+                      nextOffset: offset + page.length < matchingTools.length ? offset + page.length : null,
+                    },
+                  }
+                : {}),
+            },
+          },
+        };
+      },
     },
     ping: {
       description: "Health check — verify the CEP plugin is running and connected to Premiere Pro. Call this before other tools to confirm connectivity.",

--- a/src/tools/inspection.ts
+++ b/src/tools/inspection.ts
@@ -4,9 +4,24 @@ import { sendCommand, BridgeOptions } from "../bridge/file-bridge.js";
 export function getInspectionTools(bridgeOptions: BridgeOptions) {
   return {
     get_full_project_overview: {
-      description: "Get a comprehensive overview of the entire project: all bins (recursive tree), all sequences, media stats, offline items, and project settings. This is the best first call to fully understand a project.",
-      parameters: {},
-      handler: async () => {
+      description: "Get a comprehensive overview of the project. Use include_bin_tree false or sequence_offset/sequence_limit for a bounded response on large projects.",
+      parameters: {
+        type: "object" as const,
+        additionalProperties: false,
+        properties: {
+          include_bin_tree: { type: "boolean", description: "Include the recursive bin tree (default: true). Set false to return project statistics and sequences only." },
+          max_bin_depth: { type: "integer", minimum: 0, maximum: 10, description: "Maximum recursive bin-tree depth when include_bin_tree is true (default: 10)." },
+          sequence_offset: { type: "integer", minimum: 0, description: "Zero-based offset into project sequences." },
+          sequence_limit: { type: "integer", minimum: 1, maximum: 500, description: "Maximum sequences to include. Omit to preserve the complete legacy response." },
+        },
+      },
+      handler: async (args: { include_bin_tree?: boolean; max_bin_depth?: number; sequence_offset?: number; sequence_limit?: number } = {}) => {
+        const includeBinTree = args.include_bin_tree !== false;
+        const maxBinDepth = Number.isInteger(args.max_bin_depth) ? Math.min(Math.max(args.max_bin_depth as number, 0), 10) : 10;
+        const sequenceOffset = Number.isInteger(args.sequence_offset) && (args.sequence_offset as number) >= 0 ? args.sequence_offset as number : 0;
+        const sequenceLimit = Number.isInteger(args.sequence_limit) && (args.sequence_limit as number) > 0
+          ? Math.min(args.sequence_limit as number, 500)
+          : -1;
         const script = buildToolScript(`
           var project = app.project;
           if (!project) return __error("No project is open");
@@ -24,7 +39,7 @@ export function getInspectionTools(bridgeOptions: BridgeOptions) {
               try { entry.mediaPath = item.getMediaPath(); } catch(e) {}
               try { entry.offline = item.isOffline(); } catch(e) {}
               try { entry.colorLabel = item.getColorLabel(); } catch(e) {}
-              if (item.type === 2 && depth < 10) {
+              if (item.type === 2 && depth < ${maxBinDepth}) {
                 entry.children = walkBin(item, depth + 1);
                 entry.childCount = entry.children.length;
               }
@@ -33,10 +48,13 @@ export function getInspectionTools(bridgeOptions: BridgeOptions) {
             return items;
           }
 
-          var binTree = walkBin(project.rootItem, 0);
+          var binTree = ${includeBinTree ? "walkBin(project.rootItem, 0)" : "null"};
 
           var sequences = [];
-          for (var i = 0; i < project.sequences.numSequences; i++) {
+          var sequenceTotal = project.sequences.numSequences;
+          var sequenceOffset = ${sequenceOffset};
+          var sequenceLimit = ${sequenceLimit};
+          for (var i = sequenceOffset; i < sequenceTotal && (sequenceLimit < 0 || sequences.length < sequenceLimit); i++) {
             var seq = project.sequences[i];
             var clipCount = 0;
             for (var t = 0; t < seq.videoTracks.numTracks; t++) clipCount += seq.videoTracks[t].clips.numItems;
@@ -85,11 +103,19 @@ export function getInspectionTools(bridgeOptions: BridgeOptions) {
             projectPath: project.path,
             totalItems: totalItems,
             offlineItems: offlineCount,
-            sequenceCount: sequences.length,
+            sequenceCount: sequenceTotal,
             mediaFileTypes: mediaTypes,
             activeSequence: activeSeqInfo,
             sequences: sequences,
-            binTree: binTree
+            ${includeBinTree ? "binTree: binTree," : ""}
+            sequencePagination: {
+              offset: sequenceOffset,
+              limit: sequenceLimit < 0 ? null : sequenceLimit,
+              returned: sequences.length,
+              total: sequenceTotal,
+              hasMore: sequenceOffset + sequences.length < sequenceTotal,
+              nextOffset: sequenceOffset + sequences.length < sequenceTotal ? sequenceOffset + sequences.length : null
+            }
           });
         `);
         return sendCommand(script, bridgeOptions);
@@ -109,11 +135,31 @@ export function getInspectionTools(bridgeOptions: BridgeOptions) {
             type: "boolean",
             description: "Include items from sub-bins recursively (default: true)",
           },
+          offset: {
+            type: "integer",
+            minimum: 0,
+            description: "Zero-based offset into the bin's direct children. Pair with limit for a bounded page.",
+          },
+          limit: {
+            type: "integer",
+            minimum: 1,
+            maximum: 500,
+            description: "Maximum direct children to return. Pair with recursive false for the smallest bounded response.",
+          },
+          max_depth: {
+            type: "integer",
+            minimum: 0,
+            maximum: 10,
+            description: "Maximum nested-bin depth when recursive is true. Defaults to the legacy unlimited recursion.",
+          },
         },
         required: ["bin_id"],
       },
-      handler: async (args: { bin_id: string; recursive?: boolean }) => {
+      handler: async (args: { bin_id: string; recursive?: boolean; offset?: number; limit?: number; max_depth?: number }) => {
         const recursive = args.recursive !== false;
+        const offset = Number.isInteger(args.offset) && (args.offset as number) >= 0 ? args.offset as number : 0;
+        const limit = Number.isInteger(args.limit) && (args.limit as number) > 0 ? Math.min(args.limit as number, 500) : -1;
+        const maxDepth = Number.isInteger(args.max_depth) ? Math.min(Math.max(args.max_depth as number, 0), 10) : -1;
         const script = buildToolScript(`
           var root = app.project.rootItem;
           var target = null;
@@ -193,13 +239,13 @@ export function getInspectionTools(bridgeOptions: BridgeOptions) {
             return info;
           }
 
-          function walkItems(bin, recurse) {
+          function walkItems(bin, recurse, depth) {
             var items = [];
             for (var i = 0; i < bin.children.numItems; i++) {
               var item = bin.children[i];
               var info = getItemDetails(item);
-              if (item.type === 2 && recurse) {
-                info.children = walkItems(item, true);
+              if (item.type === 2 && recurse && (${maxDepth} < 0 || depth < ${maxDepth})) {
+                info.children = walkItems(item, true, depth + 1);
                 info.childCount = info.children.length;
               }
               items.push(info);
@@ -207,13 +253,25 @@ export function getInspectionTools(bridgeOptions: BridgeOptions) {
             return items;
           }
 
-          var contents = walkItems(target, ${recursive});
+          var allContents = walkItems(target, ${recursive}, 0);
+          var offset = ${offset};
+          var limit = ${limit};
+          var contents = limit < 0 ? allContents.slice(offset) : allContents.slice(offset, offset + limit);
           return __result({
             binName: target.name,
             binNodeId: target.nodeId,
             binPath: target.treePath,
             itemCount: contents.length,
-            items: contents
+            totalDirectItems: allContents.length,
+            items: contents,
+            pagination: {
+              offset: offset,
+              limit: limit < 0 ? null : limit,
+              returned: contents.length,
+              totalDirectItems: allContents.length,
+              hasMore: offset + contents.length < allContents.length,
+              nextOffset: offset + contents.length < allContents.length ? offset + contents.length : null
+            }
           });
         `);
         return sendCommand(script, bridgeOptions);

--- a/src/tools/metadata.ts
+++ b/src/tools/metadata.ts
@@ -4,7 +4,7 @@ import { sendCommand, BridgeOptions } from "../bridge/file-bridge.js";
 export function getMetadataTools(bridgeOptions: BridgeOptions) {
   return {
     get_metadata: {
-      description: "Get metadata for a project item",
+      description: "Get metadata for a project item. Disable either XML payload when a bounded identity/path response is sufficient.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -12,24 +12,34 @@ export function getMetadataTools(bridgeOptions: BridgeOptions) {
             type: "string",
             description: "Node ID or name of the project item",
           },
+          include_project_metadata: {
+            type: "boolean",
+            description: "Include the potentially large Project Metadata XML payload (default: true). Set false for a bounded identity/path response.",
+          },
+          include_xmp_metadata: {
+            type: "boolean",
+            description: "Include the potentially large XMP XML payload (default: true). Set false for a bounded identity/path response.",
+          },
         },
         required: ["item_id"],
       },
-      handler: async (args: { item_id: string }) => {
+      handler: async (args: { item_id: string; include_project_metadata?: boolean; include_xmp_metadata?: boolean }) => {
+        const includeProjectMetadata = args.include_project_metadata !== false;
+        const includeXmpMetadata = args.include_xmp_metadata !== false;
         const script = buildToolScript(`
           var item = __findProjectItem("${escapeForExtendScript(args.item_id)}");
           if (!item) return __error("Item not found");
           
           var metadata = {};
-          try {
+          ${includeProjectMetadata ? `try {
             var xmpBlob = item.getProjectMetadata();
             metadata.projectMetadata = xmpBlob;
-          } catch(e) {}
+          } catch(e) {}` : ""}
           
-          try {
+          ${includeXmpMetadata ? `try {
             var xmpBlob2 = item.getXMPMetadata();
             metadata.xmpMetadata = xmpBlob2;
-          } catch(e) {}
+          } catch(e) {}` : ""}
           
           metadata.name = item.name;
           metadata.nodeId = item.nodeId;

--- a/tests/tools/tool-modules.test.ts
+++ b/tests/tools/tool-modules.test.ts
@@ -405,6 +405,74 @@ describe("Tool Handler Behavior", () => {
     });
   });
 
+  describe("bounded read tools", () => {
+    it("returns a filtered, paged get_capabilities catalog without changing the capability summary", async () => {
+      const tools = getHealthTools(
+        bridgeOptions,
+        undefined,
+        () => ({
+          ping: { description: "Ping." },
+          get_capabilities: { description: "Capabilities." },
+          ripple_delete: { description: "Ripple delete. Uses QE DOM." },
+        }),
+      );
+      const result = await tools.get_capabilities.handler({ tool_names: ["ripple_delete", "missing"], tool_limit: 1 });
+
+      expect(result.success).toBe(true);
+      expect(result.data.tools.tools).toEqual([expect.objectContaining({ name: "ripple_delete" })]);
+      expect(result.data.tools.pagination).toEqual({
+        offset: 0,
+        limit: 1,
+        returned: 1,
+        totalMatching: 1,
+        hasMore: false,
+        nextOffset: null,
+      });
+      expect(result.data.backends.cep.status).toBe("production");
+    });
+
+    it("omits requested metadata XML payloads before invoking the CEP bridge", async () => {
+      const tools = getMetadataTools(bridgeOptions);
+      await tools.get_metadata.handler({
+        item_id: "source-1",
+        include_project_metadata: false,
+        include_xmp_metadata: false,
+      });
+
+      const script = mockedSendCommand.mock.calls[0][0];
+      expect(script).not.toContain("item.getProjectMetadata()");
+      expect(script).not.toContain("item.getXMPMetadata()");
+      expect(script).toContain("metadata.nodeId = item.nodeId");
+    });
+
+    it("generates bounded overview and bin read scripts", async () => {
+      const tools = getInspectionTools(bridgeOptions);
+      await tools.get_full_project_overview.handler({
+        include_bin_tree: false,
+        sequence_offset: 5,
+        sequence_limit: 10,
+      });
+      const overview = mockedSendCommand.mock.calls[0][0];
+      expect(overview).toContain("var binTree = null");
+      expect(overview).toContain("var sequenceOffset = 5");
+      expect(overview).toContain("var sequenceLimit = 10");
+      expect(overview).toContain("sequencePagination");
+
+      vi.clearAllMocks();
+      await tools.get_bin_contents.handler({
+        bin_id: "Footage",
+        recursive: false,
+        offset: 10,
+        limit: 25,
+        max_depth: 0,
+      });
+      const bin = mockedSendCommand.mock.calls[0][0];
+      expect(bin).toContain("var allContents = walkItems(target, false, 0)");
+      expect(bin).toContain("allContents.slice(offset, offset + limit)");
+      expect(bin).toContain("totalDirectItems");
+    });
+  });
+
   describe("workspace tools", () => {
     it("get_workspaces generates correct script", async () => {
       const tools = getWorkspaceTools(bridgeOptions);


### PR DESCRIPTION
Fixes #249.\n\nAdds opt-in bounded reads while preserving default response compatibility: filtered/paged capability catalogs, opt-out metadata XML payloads, paged/depth-limited bins, and section/sequence limits for project overviews. Includes contract coverage for each option.