### PR TITLE
fix: verify batch effect application

### DIFF
--- a/docs/supported-actions.md
+++ b/docs/supported-actions.md
@@ -60,7 +60,7 @@ operation” when the tool has no enum-based mode.
 | `attach_custom_property` | Default profile | Single operation | Attach a custom property (key/value pair) to the active sequence |
 | `auto_reframe_sequence` | Default profile | `motion_preset`: `slower`, `default`, `faster` | Auto-reframe a sequence for a different aspect ratio |
 | `batch_add_transitions` | Default profile | Single operation | Add the same transition to all cut points on a track |
-| `batch_apply_effect` | Default profile | `target`: `selected`, `track`, `all`; `track_type`: `video`, `audio` | Apply an effect to multiple clips at once. Can target selected clips, all clips on a track, or all clips in the sequence. |
+| `batch_apply_effect` | Default profile | `target`: `selected`, `track`, `all`; `track_type`: `video`, `audio` | Apply one audio or video effect to compatible selected clips, a compatible track, or all compatible clips. Every target is preflighted and then checked by component-count readback. |
 | `batch_enable_disable` | Default profile | `target`: `selected`, `track`, `all`; `track_type`: `video`, `audio` | Enable or disable multiple clips at once (selected, track, or all). |
 | `batch_rename_clips` | Default profile | `track_type`: `video`, `audio` | Rename multiple clips on the timeline using a pattern. Supports sequential numbering. |
 | `capture_frame` | Default profile | Single operation | Capture the current frame and return it as inline image data for the LLM to see. This lets the AI visually inspect the current state of the timeline. |
@@ -211,7 +211,7 @@ operation” when the tool has no enum-based mode.
 | `lift_selection` | Default profile | Single operation | Lift (remove without closing gap) the content between sequence in/out points or selected clips. |
 | `link_selection` | Default profile | Single operation | Link the currently selected video and audio clips in the active sequence |
 | `list_available_audio_effects` | Default profile | Single operation | List all available audio effects in Premiere Pro. Uses QE DOM. |
-| `list_available_audio_transitions` | Default profile | Single operation | List all available audio transitions. Uses QE DOM. |
+| `list_available_audio_transitions` | Default profile | Single operation | List all available audio transitions. Uses QE DOM and reports an unavailable or empty legacy catalog as an error rather than an assumed usable list. |
 | `list_available_effects` | Default profile | Single operation | List available video effects in Premiere Pro. Uses the full QE catalog when exposed; otherwise returns a verified, explicitly partial set of common effects resolved by exact name. |
 | `list_available_transitions` | Default profile | Single operation | List all available video transitions. Uses QE DOM. Returns a hint set on PPro 2026 where the transition registry list is empty even though by-name lookup works. |
 | `list_clip_effects` | Default profile | Single operation | List all effects/components on a clip with their properties and current values. Essential for debugging effect issues. |

--- a/src/tools/clipboard.ts
+++ b/src/tools/clipboard.ts
@@ -214,7 +214,7 @@ export function getClipboardTools(bridgeOptions: BridgeOptions) {
     },
 
     batch_apply_effect: {
-      description: "Apply an effect to multiple clips at once. Can target selected clips, all clips on a track, or all clips in the sequence.",
+      description: "Apply one audio or video effect to compatible selected clips, a compatible track, or all compatible clips. Every target is preflighted and then checked by component-count readback.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -236,70 +236,135 @@ export function getClipboardTools(bridgeOptions: BridgeOptions) {
             type: "number",
             description: "Track index (required when target is 'track')",
           },
-        },
-        required: ["effect_name", "target"],
+      },
+      required: ["effect_name", "target"],
       },
       handler: async (args: { effect_name: string; target: string; track_type?: string; track_index?: number }) => {
+        if (!args.effect_name.trim()) return { success: false, error: "effect_name must not be empty" };
+        if (args.target !== "selected" && args.target !== "track" && args.target !== "all") {
+          return { success: false, error: "target must be selected, track, or all" };
+        }
+        if (args.target === "track" && (args.track_type !== "video" && args.track_type !== "audio")) {
+          return { success: false, error: "track_type must be video or audio when target is track" };
+        }
+        if (args.target === "track" && (!Number.isInteger(args.track_index) || (args.track_index as number) < 0)) {
+          return { success: false, error: "track_index must be a non-negative integer when target is track" };
+        }
         const script = buildToolScript(`
           app.enableQE();
           var seq = app.project.activeSequence;
           if (!seq) return __error("No active sequence");
           var qeSeq = qe.project.getActiveSequence();
+          if (!qeSeq) return __error("No active sequence (QE)");
 
           var effectName = "${escapeForExtendScript(args.effect_name)}";
           var qeEffect = qe.project.getVideoEffectByName(effectName);
-          var isAudio = false;
+          var effectType = "video";
           if (!qeEffect) {
             qeEffect = qe.project.getAudioEffectByName(effectName);
-            isAudio = true;
+            effectType = "audio";
           }
           if (!qeEffect) return __error("Effect not found: " + effectName);
 
-          var applied = 0;
           var target = "${args.target}";
+          var targets = [];
+          var selectedIncompatible = 0;
 
-          function applyToClip(trackIdx, clipIdx, trackType) {
-            try {
-              var qeTrack = trackType === "video" ? qeSeq.getVideoTrackAt(trackIdx) : qeSeq.getAudioTrackAt(trackIdx);
-              var qeClip = qeTrack.getItemAt(clipIdx);
-              if (isAudio || trackType === "audio") {
-                qeClip.addAudioEffect(qeEffect);
-              } else {
-                qeClip.addVideoEffect(qeEffect);
+          function collectTracks(tracks, trackType, selectedOnly, onlyTrackIndex) {
+            for (var t = 0; t < tracks.numTracks; t++) {
+              if (onlyTrackIndex !== null && t !== onlyTrackIndex) continue;
+              for (var c = 0; c < tracks[t].clips.numItems; c++) {
+                var clip = tracks[t].clips[c];
+                if (selectedOnly && !clip.isSelected()) continue;
+                if (trackType !== effectType) {
+                  if (selectedOnly) selectedIncompatible++;
+                  continue;
+                }
+                targets.push({ clip: clip, trackIndex: t, trackType: trackType, qeClip: null, beforeCount: 0 });
               }
-              applied++;
-            } catch(e) {}
+            }
           }
 
           if (target === "selected") {
-            for (var t = 0; t < seq.videoTracks.numTracks; t++) {
-              for (var c = 0; c < seq.videoTracks[t].clips.numItems; c++) {
-                if (seq.videoTracks[t].clips[c].isSelected()) applyToClip(t, c, "video");
-              }
-            }
-            for (var t = 0; t < seq.audioTracks.numTracks; t++) {
-              for (var c = 0; c < seq.audioTracks[t].clips.numItems; c++) {
-                if (seq.audioTracks[t].clips[c].isSelected()) applyToClip(t, c, "audio");
-              }
-            }
+            collectTracks(seq.videoTracks, "video", true, null);
+            collectTracks(seq.audioTracks, "audio", true, null);
           } else if (target === "track") {
-            var tt = "${args.track_type || "video"}";
-            var ti = ${args.track_index ?? 0};
-            var tracks = tt === "video" ? seq.videoTracks : seq.audioTracks;
-            if (ti >= tracks.numTracks) return __error("Track index out of range");
-            for (var c = 0; c < tracks[ti].clips.numItems; c++) {
-              applyToClip(ti, c, tt);
+            var requestedTrackType = "${args.track_type || "video"}";
+            var requestedTrackIndex = ${args.track_index ?? 0};
+            if (requestedTrackType !== effectType) {
+              return __error("Effect " + effectName + " is a " + effectType + " effect and cannot be applied to an " + requestedTrackType + " track. No mutation was attempted.");
             }
+            var requestedTracks = requestedTrackType === "video" ? seq.videoTracks : seq.audioTracks;
+            if (requestedTrackIndex >= requestedTracks.numTracks) return __error("Track index out of range");
+            collectTracks(requestedTracks, requestedTrackType, false, requestedTrackIndex);
           } else {
-            for (var t = 0; t < seq.videoTracks.numTracks; t++) {
-              for (var c = 0; c < seq.videoTracks[t].clips.numItems; c++) applyToClip(t, c, "video");
-            }
-            for (var t = 0; t < seq.audioTracks.numTracks; t++) {
-              for (var c = 0; c < seq.audioTracks[t].clips.numItems; c++) applyToClip(t, c, "audio");
-            }
+            collectTracks(effectType === "video" ? seq.videoTracks : seq.audioTracks, effectType, false, null);
           }
 
-          return __result({ applied: applied, effect: effectName, target: target });
+          if (targets.length === 0) {
+            return __error("No compatible " + effectType + " clips matched target " + target + ". No mutation was attempted.");
+          }
+
+          function findQeClip(target) {
+            var qeTrack = target.trackType === "video"
+              ? qeSeq.getVideoTrackAt(target.trackIndex)
+              : qeSeq.getAudioTrackAt(target.trackIndex);
+            if (!qeTrack) return null;
+            var expectedStart = parseFloat(target.clip.start.ticks);
+            for (var qi = 0; qi < qeTrack.numItems; qi++) {
+              var candidate = qeTrack.getItemAt(qi);
+              if (!candidate || String(candidate.type) !== "Clip") continue;
+              try {
+                if (Math.abs(parseFloat(candidate.start.ticks) - expectedStart) < 1) return candidate;
+              } catch (lookupError) {}
+            }
+            return null;
+          }
+
+          function countEffectComponents(clip) {
+            var count = 0;
+            for (var ci = 0; ci < clip.components.numItems; ci++) {
+              var component = clip.components[ci];
+              if (component.displayName === effectName || component.matchName === effectName) count++;
+            }
+            return count;
+          }
+
+          // Resolve every QE clip before changing anything. QE item indexes include
+          // gaps, so a DOM clip index cannot safely be used as a QE item index.
+          for (var preflightIndex = 0; preflightIndex < targets.length; preflightIndex++) {
+            var preflightTarget = targets[preflightIndex];
+            preflightTarget.qeClip = findQeClip(preflightTarget);
+            if (!preflightTarget.qeClip) {
+              return __error("Could not match a selected " + effectType + " clip to its QE item. No effects were applied.");
+            }
+            preflightTarget.beforeCount = countEffectComponents(preflightTarget.clip);
+          }
+
+          var applied = 0;
+          var failures = [];
+          for (var targetIndex = 0; targetIndex < targets.length; targetIndex++) {
+            var current = targets[targetIndex];
+            try {
+              if (effectType === "audio") current.qeClip.addAudioEffect(qeEffect);
+              else current.qeClip.addVideoEffect(qeEffect);
+            } catch (applyError) {
+              failures.push("track " + current.trackIndex + ": " + applyError.toString());
+              continue;
+            }
+            var afterCount = countEffectComponents(current.clip);
+            if (afterCount <= current.beforeCount) {
+              failures.push("track " + current.trackIndex + ": component count did not increase");
+              continue;
+            }
+            applied++;
+          }
+
+          if (failures.length > 0) {
+            return __error("Batch effect application was only partially verified (" + applied + "/" + targets.length + "). Do not retry blindly; inspect Effect Controls. Failures: " + failures.join("; "));
+          }
+
+          return __result({ applied: applied, verified: true, effect: effectName, effectType: effectType, target: target, selectedIncompatible: selectedIncompatible });
         `);
         return sendCommand(script, bridgeOptions);
       },

--- a/src/tools/transitions.ts
+++ b/src/tools/transitions.ts
@@ -305,17 +305,26 @@ export function getTransitionsTools(bridgeOptions: BridgeOptions) {
     },
 
     list_available_audio_transitions: {
-      description: "List all available audio transitions. Uses QE DOM.",
+      description: "List all available audio transitions. Uses QE DOM and reports an unavailable or empty legacy catalog as an error rather than an assumed usable list.",
       parameters: {},
       handler: async () => {
         const script = buildToolScript(`
           app.enableQE();
-          var transitions = qe.project.getAudioTransitionList();
+          var transitions = null;
+          try { transitions = qe.project.getAudioTransitionList(); } catch (catalogError) {
+            return __error("Premiere did not expose an audio-transition catalog through QE: " + catalogError.toString());
+          }
+          if (!transitions || typeof transitions.numItems !== "number") {
+            return __error("Premiere did not expose an enumerable audio-transition catalog through QE.");
+          }
           var list = [];
           for (var i = 0; i < transitions.numItems; i++) {
             list.push({ name: transitions[i].name, index: i });
           }
-          return __result(list);
+          if (list.length === 0) {
+            return __error("QE reported an empty audio-transition catalog. No supported by-name fallback is available, so no transition availability is claimed.");
+          }
+          return __result({ transitions: list, verified: true, source: "qe.catalog" });
         `);
         return sendCommand(script, bridgeOptions);
       },

--- a/tests/tools/tool-modules.test.ts
+++ b/tests/tools/tool-modules.test.ts
@@ -606,6 +606,31 @@ describe("Tool Handler Behavior", () => {
       expect(mockedSendCommand).not.toHaveBeenCalled();
     });
 
+    it("preflights and verifies every batch effect target instead of swallowing failures", async () => {
+      const tools = getClipboardTools(bridgeOptions);
+      await (tools.batch_apply_effect.handler as any)({ effect_name: "Gaussian Blur", target: "selected" });
+      const script = mockedSendCommand.mock.calls[0][0];
+      expect(script).toContain("function findQeClip(target)");
+      expect(script).toContain("function countEffectComponents(clip)");
+      expect(script).toContain("component count did not increase");
+      expect(script).toContain("Batch effect application was only partially verified");
+      expect(script).toContain("selectedIncompatible");
+
+      vi.clearAllMocks();
+      await expect((tools.batch_apply_effect.handler as any)({ effect_name: "Gaussian Blur", target: "track" }))
+        .resolves.toMatchObject({ success: false, error: expect.stringContaining("track_type") });
+      expect(mockedSendCommand).not.toHaveBeenCalled();
+    });
+
+    it("does not report an empty QE audio-transition catalog as an available list", async () => {
+      const tools = getTransitionsTools(bridgeOptions);
+      await (tools.list_available_audio_transitions.handler as any)({});
+      const script = mockedSendCommand.mock.calls[0][0];
+      expect(script).toContain("QE reported an empty audio-transition catalog");
+      expect(script).toContain("no transition availability is claimed");
+      expect(script).toContain('source: "qe.catalog"');
+    });
+
     it("uses Time objects and verifies audio keyframe values", async () => {
       const tools = getAudioTools(bridgeOptions);
       await (tools.add_audio_keyframes.handler as any)({


### PR DESCRIPTION
Fixes #275.\n\nBatch application now validates target inputs, selects only compatible media types, maps DOM clips to QE items by start time, preflights every target, and checks component-count readback rather than swallowing errors. Empty/unavailable QE audio-transition catalogs are explicit errors rather than false availability. Existing export-path documentation and exclusive selection behavior cover the other report items.