### PR TITLE
fix: report playback requests as unverified

### DIFF
--- a/docs/supported-actions.md
+++ b/docs/supported-actions.md
@@ -238,8 +238,8 @@ operation” when the tool has no enum-based mode.
 | `overwrite_from_source` | Default profile | Single operation | Overwrite the clip from the Source Monitor at the playhead position (overwrite edit — replaces existing clips). |
 | `ping` | Default profile | Single operation | Health check — verify the CEP plugin is running and connected to Premiere Pro. Call this before other tools to confirm connectivity. |
 | `plan_silence_review_markers` | Default profile | Single operation | Create a bounded, non-mutating review plan that maps FFmpeg-detected source-media silences onto one known 1x timeline placement. It clips candidates to the supplied source in/out span, redacts the source path, and never adds markers, cuts clips, or changes Premiere. |
-| `play_source_monitor` | Default profile | Single operation | Start playback of the clip in the Source Monitor |
-| `play_timeline` | Default profile | Single operation | Start playback of the active sequence timeline. Uses QE DOM. |
+| `play_source_monitor` | Default profile | Single operation | Request playback of the clip in the Source Monitor. The legacy API does not provide a same-call position readback, so movement is not reported as verified. |
+| `play_timeline` | Default profile | Single operation | Request playback of the active sequence timeline through QE. The legacy API does not provide a same-call playhead readback, so movement is not reported as verified. |
 | `preview_brand_spot` | Default profile | `motion_style`: `none`, `push_in`, `pull_out`, `alternate` | Preview a brand-spot assembly from existing project items with an optional workspace-contained MOGRT overlay. Preview is local-only; it does not read or import the MOGRT file. |
 | `preview_edit_plan` | Default profile | Single operation | Validate and preview a compound timeline edit without changing Premiere. Returns a confirmation token required by apply_edit_plan. |
 | `preview_editorial_plan` | Default profile | Single operation | Revalidate an exact server-issued editorial plan against the saved project-context revisions and return an opaque confirmation token. This tool is read-only and cannot apply the plan. |
@@ -340,7 +340,7 @@ operation” when the tool has no enum-based mode.
 | `split_clip` | Default profile | `track_type`: `video`, `audio` | Split every clip on one track that spans a timeline time, then verify both resulting boundaries. Requires QE DOM; effect-keyframe redistribution remains unverified. |
 | `stabilize_clip` | Default profile | `method`: `Subspace Warp`, `Position`, `Position, Scale, Rotation` | Apply the Warp Stabilizer effect to a clip for video stabilization. Uses QE DOM. |
 | `start_batch_encode` | Default profile | Single operation | Start encoding all items in the Adobe Media Encoder render queue |
-| `stop_playback` | Default profile | Single operation | Stop playback of the active sequence timeline. Uses QE DOM. |
+| `stop_playback` | Default profile | Single operation | Request that active-sequence timeline playback stop through QE. The legacy API does not provide a same-call playhead readback, so stopped state is not reported as verified. |
 | `toggle_track_visibility` | Default profile | Single operation | Toggle a video track's visibility (eye icon) |
 | `trim_clip` | Default profile | `keyframe_policy`: `reject`, `preserve` | Trim exactly one source in/out point and verify the corresponding visible timeline edge. Refuses retimed clips and, by default, trims that would leave effect keyframes outside the visible clip. |
 | `undo` | Default profile | Single operation | Undo the last action in Premiere Pro |

--- a/src/tools/playback.ts
+++ b/src/tools/playback.ts
@@ -4,33 +4,41 @@ import { sendCommand, BridgeOptions } from "../bridge/file-bridge.js";
 export function getPlaybackTools(bridgeOptions: BridgeOptions) {
   return {
     play_timeline: {
-      description: "Start playback of the active sequence timeline. Uses QE DOM.",
+      description: "Request playback of the active sequence timeline through QE. The legacy API does not provide a same-call playhead readback, so movement is not reported as verified.",
       parameters: {},
       handler: async () => {
         const script = buildToolScript(`
           app.enableQE();
           qe.startPlayback();
-          return __result({ playing: true });
+          return __result({
+            playbackRequested: true,
+            playbackVerified: false,
+            verificationScope: "QE accepted the playback request only; poll get_playhead_position before treating timeline movement as confirmed."
+          });
         `);
         return sendCommand(script, bridgeOptions);
       },
     },
 
     stop_playback: {
-      description: "Stop playback of the active sequence timeline. Uses QE DOM.",
+      description: "Request that active-sequence timeline playback stop through QE. The legacy API does not provide a same-call playhead readback, so stopped state is not reported as verified.",
       parameters: {},
       handler: async () => {
         const script = buildToolScript(`
           app.enableQE();
           qe.stopPlayback();
-          return __result({ stopped: true });
+          return __result({
+            stopRequested: true,
+            playbackVerified: false,
+            verificationScope: "QE accepted the stop request only; poll get_playhead_position across time before treating playback as stopped."
+          });
         `);
         return sendCommand(script, bridgeOptions);
       },
     },
 
     play_source_monitor: {
-      description: "Start playback of the clip in the Source Monitor",
+      description: "Request playback of the clip in the Source Monitor. The legacy API does not provide a same-call position readback, so movement is not reported as verified.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -44,7 +52,12 @@ export function getPlaybackTools(bridgeOptions: BridgeOptions) {
         const speed = args.speed ?? 1.0;
         const script = buildToolScript(`
           app.sourceMonitor.play(${speed});
-          return __result({ playing: true, speed: ${speed} });
+          return __result({
+            playbackRequested: true,
+            playbackVerified: false,
+            speed: ${speed},
+            verificationScope: "Premiere accepted the source-monitor playback request only; poll get_source_monitor_position before treating movement as confirmed."
+          });
         `);
         return sendCommand(script, bridgeOptions);
       },

--- a/tests/tools/tool-modules.test.ts
+++ b/tests/tools/tool-modules.test.ts
@@ -501,11 +501,28 @@ describe("Tool Handler Behavior", () => {
       const script = mockedSendCommand.mock.calls[0][0];
       expect(script).toContain("app.enableQE()");
       expect(script).toContain("qe.startPlayback()");
+      expect(script).toContain("playbackRequested: true");
+      expect(script).toContain("playbackVerified: false");
+      expect(script).toContain("poll get_playhead_position");
     });
 
     it("play_timeline has no speed parameter (QE startPlayback ignores it)", async () => {
       const tools = getPlaybackTools(bridgeOptions);
       expect(tools.play_timeline.parameters).toEqual({});
+    });
+
+    it("does not claim legacy source-monitor or stop-playback requests are verified", async () => {
+      const tools = getPlaybackTools(bridgeOptions);
+      await (tools.stop_playback.handler as any)({});
+      let script = mockedSendCommand.mock.calls[0][0];
+      expect(script).toContain("stopRequested: true");
+      expect(script).toContain("playbackVerified: false");
+
+      vi.clearAllMocks();
+      await (tools.play_source_monitor.handler as any)({ speed: 1 });
+      script = mockedSendCommand.mock.calls[0][0];
+      expect(script).toContain("playbackRequested: true");
+      expect(script).toContain("poll get_source_monitor_position");
     });
 
     it("stop_playback uses QE DOM", async () => {


### PR DESCRIPTION
Fixes #250.\n\nLegacy QE and Source Monitor calls now report a request, not asserted playback state. Each response explains the specific position poll required to verify movement or stopping. Includes regression coverage and regenerated supported-action documentation.