### PR TITLE
fix: probe effects when QE catalogs are empty

### DIFF
--- a/docs/supported-actions.md
+++ b/docs/supported-actions.md
@@ -52,9 +52,9 @@ operation” when the tool has no enum-based mode.
 | `analyze_loudness` | Default profile | Single operation | Measure integrated loudness (LUFS), loudness range (LU), and true peak (dBFS) from a local media file using FFmpeg's EBU R128 filter. Analysis only: it does not normalize audio or change Premiere. |
 | `analyze_video_interlacing` | Default profile | Single operation | Classify decoded video frames as progressive, top-field-first, bottom-field-first, mixed, or undetermined using FFmpeg idet. Read-only delivery preflight. |
 | `analyze_video_qc` | Default profile | Single operation | Analyze a local video delivery for sustained black and frozen sections with FFmpeg. Read-only: it does not contact Premiere or modify the file. |
-| `apply_audio_effect` | Default profile | Single operation | Apply an audio effect to a clip |
+| `apply_audio_effect` | Default profile | Single operation | Apply an audio effect to a clip. Uses QE catalog lookup, with an exact-name QE probe when enumeration is empty. |
 | `apply_edit_plan` | Default profile | Single operation | Apply a previously previewed compound edit after revalidating every target. Requires the edit capability and exact preview confirmation token. |
-| `apply_effect` | Default profile | Single operation | Apply a video effect to a clip. Uses QE DOM for effect lookup. |
+| `apply_effect` | Default profile | Single operation | Apply a video effect to a clip. Uses QE DOM catalog lookup, with an exact-name QE probe when Premiere's catalog enumeration is empty. |
 | `apply_lut` | Default profile | Single operation | Apply a LUT file to a clip via Lumetri Color |
 | `apply_spot_workflow_plan` | Default profile | Single operation | Apply one exact previewed motion-demo, product-spot, or brand-spot plan. Requires edit authority, requires filesystem authority for a MOGRT, and only targets empty explicitly named tracks. Host readback is not playback or render verification. |
 | `attach_custom_property` | Default profile | Single operation | Attach a custom property (key/value pair) to the active sequence |
@@ -212,7 +212,7 @@ operation” when the tool has no enum-based mode.
 | `link_selection` | Default profile | Single operation | Link the currently selected video and audio clips in the active sequence |
 | `list_available_audio_effects` | Default profile | Single operation | List all available audio effects in Premiere Pro. Uses QE DOM. |
 | `list_available_audio_transitions` | Default profile | Single operation | List all available audio transitions. Uses QE DOM. |
-| `list_available_effects` | Default profile | Single operation | List all available video effects in Premiere Pro. Uses QE DOM. |
+| `list_available_effects` | Default profile | Single operation | List available video effects in Premiere Pro. Uses the full QE catalog when exposed; otherwise returns a verified, explicitly partial set of common effects resolved by exact name. |
 | `list_available_transitions` | Default profile | Single operation | List all available video transitions. Uses QE DOM. Returns a hint set on PPro 2026 where the transition registry list is empty even though by-name lookup works. |
 | `list_clip_effects` | Default profile | Single operation | List all effects/components on a clip with their properties and current values. Essential for debugging effect issues. |
 | `list_markers` | Default profile | Single operation | List all markers on the active sequence or a specific clip |

--- a/src/tools/effects.ts
+++ b/src/tools/effects.ts
@@ -4,7 +4,7 @@ import { sendCommand, BridgeOptions } from "../bridge/file-bridge.js";
 export function getEffectsTools(bridgeOptions: BridgeOptions) {
   return {
     apply_effect: {
-      description: "Apply a video effect to a clip. Uses QE DOM for effect lookup.",
+      description: "Apply a video effect to a clip. Uses QE DOM catalog lookup, with an exact-name QE probe when Premiere's catalog enumeration is empty.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -39,28 +39,33 @@ export function getEffectsTools(bridgeOptions: BridgeOptions) {
           var qeClip = qeTrack.getItemAt(result.clipIndex);
           if (!qeClip) return __error("QE clip not found");
           
-          // Search for the effect
-          var effectCatalog = __getQeEffectCatalog("video");
-          if (!effectCatalog.ok) return __error(effectCatalog.error);
-          var effects = effectCatalog.effects;
-          var found = false;
-          for (var i = 0; i < effects.numItems; i++) {
-            if (effects[i].name === effectName) {
-              qeClip.addVideoEffect(effects[i]);
-              found = true;
-              break;
+          // Premiere 26 can expose direct by-name lookup while returning an
+          // empty QE catalog. Probe the requested name before consulting the
+          // catalog so a known installed effect remains usable.
+          var qeEffect = null;
+          try { qeEffect = qe.project.getVideoEffectByName(effectName); } catch (byNameError) {}
+          var lookupSource = qeEffect ? "qe.byName" : "qe.catalog";
+          if (!qeEffect) {
+            var effectCatalog = __getQeEffectCatalog("video");
+            if (!effectCatalog.ok) return __error(effectCatalog.error + " Direct QE lookup for \"" + effectName + "\" also did not resolve an effect.");
+            var effects = effectCatalog.effects;
+            for (var i = 0; i < effects.numItems; i++) {
+              if (effects[i].name === effectName) {
+                qeEffect = effects[i];
+                break;
+              }
             }
           }
-          
-          if (!found) return __error("Effect not found: " + effectName);
-          return __result({ applied: true, effect: effectName, clipName: result.clip.name });
+          if (!qeEffect) return __error("Effect not found: " + effectName);
+          qeClip.addVideoEffect(qeEffect);
+          return __result({ applied: true, effect: effectName, lookupSource: lookupSource, clipName: result.clip.name });
         `);
         return sendCommand(script, bridgeOptions);
       },
     },
 
     apply_audio_effect: {
-      description: "Apply an audio effect to a clip",
+      description: "Apply an audio effect to a clip. Uses QE catalog lookup, with an exact-name QE probe when enumeration is empty.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -91,20 +96,23 @@ export function getEffectsTools(bridgeOptions: BridgeOptions) {
           var qeClip = qeTrack.getItemAt(result.clipIndex);
           if (!qeClip) return __error("QE clip not found");
           
-          var effectCatalog = __getQeEffectCatalog("audio");
-          if (!effectCatalog.ok) return __error(effectCatalog.error);
-          var effects = effectCatalog.effects;
-          var found = false;
-          for (var i = 0; i < effects.numItems; i++) {
-            if (effects[i].name === effectName) {
-              qeClip.addAudioEffect(effects[i]);
-              found = true;
-              break;
+          var qeEffect = null;
+          try { qeEffect = qe.project.getAudioEffectByName(effectName); } catch (byNameError) {}
+          var lookupSource = qeEffect ? "qe.byName" : "qe.catalog";
+          if (!qeEffect) {
+            var effectCatalog = __getQeEffectCatalog("audio");
+            if (!effectCatalog.ok) return __error(effectCatalog.error + " Direct QE lookup for \"" + effectName + "\" also did not resolve an effect.");
+            var effects = effectCatalog.effects;
+            for (var i = 0; i < effects.numItems; i++) {
+              if (effects[i].name === effectName) {
+                qeEffect = effects[i];
+                break;
+              }
             }
           }
-          
-          if (!found) return __error("Audio effect not found: " + effectName);
-          return __result({ applied: true, effect: effectName });
+          if (!qeEffect) return __error("Audio effect not found: " + effectName);
+          qeClip.addAudioEffect(qeEffect);
+          return __result({ applied: true, effect: effectName, lookupSource: lookupSource });
         `);
         return sendCommand(script, bridgeOptions);
       },
@@ -185,18 +193,31 @@ export function getEffectsTools(bridgeOptions: BridgeOptions) {
     },
 
     list_available_effects: {
-      description: "List all available video effects in Premiere Pro. Uses QE DOM.",
+      description: "List available video effects in Premiere Pro. Uses the full QE catalog when exposed; otherwise returns a verified, explicitly partial set of common effects resolved by exact name.",
       parameters: {},
       handler: async () => {
         const script = buildToolScript(`
           app.enableQE();
-          var effectCatalog = __getQeEffectCatalog("video");
-          if (!effectCatalog.ok) return __error(effectCatalog.error);
-          var effects = effectCatalog.effects;
           var list = [];
-          for (var i = 0; i < effects.numItems; i++) {
-            list.push({ name: effects[i].name, index: i });
+          var effectCatalog = __getQeEffectCatalog("video");
+          if (effectCatalog.ok) {
+            var effects = effectCatalog.effects;
+            for (var i = 0; i < effects.numItems; i++) {
+              list.push({ name: effects[i].name, index: i, source: "qe.catalog" });
+            }
+            return __result(list);
           }
+
+          // Keep this bounded and label every result as partial. It is a
+          // usability fallback, not a claim that these are all installed
+          // effects or that their localized display names are exhaustive.
+          var commonNames = ["Transform", "Gaussian Blur", "Lumetri Color", "Crop", "Warp Stabilizer", "Tint", "Brightness & Contrast", "Ultra Key"];
+          for (var probeIndex = 0; probeIndex < commonNames.length; probeIndex++) {
+            var candidate = null;
+            try { candidate = qe.project.getVideoEffectByName(commonNames[probeIndex]); } catch (probeError) {}
+            if (candidate) list.push({ name: commonNames[probeIndex], index: null, source: "qe.byName.partial" });
+          }
+          if (list.length === 0) return __error(effectCatalog.error + " Direct lookup did not resolve any bounded fallback effects.");
           return __result(list);
         `);
         return sendCommand(script, bridgeOptions);

--- a/tests/tools/regressions.test.ts
+++ b/tests/tools/regressions.test.ts
@@ -380,14 +380,21 @@ describe("issue #194 — string-backed MOGRT effect properties", () => {
 describe("issue #196 — empty Premiere 26.x QE effect catalogs", () => {
   const effects = getEffectsTools(bridgeOptions);
 
-  it("routes an empty legacy QE catalog to the documented UXP effect workflow, not an effect-name miss", async () => {
+  it("probes an exact QE effect name before treating an empty catalog as unavailable", async () => {
     const script = await scriptFor(effects.apply_effect, {
       node_id: "clip-1",
       effect_name: "Transform",
     });
 
+    expect(script).toContain("qe.project.getVideoEffectByName(effectName)");
     expect(script).toContain('var effectCatalog = __getQeEffectCatalog("video")');
-    expect(script).toContain("if (!effectCatalog.ok) return __error(effectCatalog.error)");
+    expect(script).toContain("Direct QE lookup for");
+    expect(script).toContain('lookupSource: lookupSource');
+
+    const listScript = await scriptFor(effects.list_available_effects, {});
+    expect(listScript).toContain("var commonNames = [");
+    expect(listScript).toContain("qe.byName.partial");
+    expect(listScript).toContain("Direct lookup did not resolve any bounded fallback effects.");
 
     const helpers = getHelpersSource();
     expect(helpers).toContain("function __getQeEffectCatalog(kind)");


### PR DESCRIPTION
Fixes #196.\n\nWhen Premiere 26 exposes direct QE lookup but returns an empty effect catalog, apply_effect and apply_audio_effect now probe the exact requested name first. list_available_effects returns a bounded, explicitly partial by-name fallback only for effects actually resolved by QE, otherwise preserves the diagnostic error. Includes regression coverage.