### PR TITLE
Fix macOS CEP bridge discovery when TMPDIR is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ Add to your VS Code MCP server configuration:
 4. Ask your AI assistant to run `get_capabilities`, then `ping`, with Premiere open.
 5. For a safe first request, ask: *"What is my current Premiere Pro project and active sequence? Do not make changes."*
 
-The default bridge directory is derived from the operating system on both sides, so most local setups should not set `PREMIERE_TEMP_DIR`. If you override it, use the same absolute path in the MCP server and CEP panel; Windows and macOS paths are not interchangeable.
+The default bridge directory is derived from the operating system on both sides, so most local setups should not set `PREMIERE_TEMP_DIR`. On macOS, the server resolves the per-user system temporary directory even when a GUI-launched client strips `TMPDIR`, keeping it aligned with Premiere's CEP panel. If you override it, use the same absolute path in the MCP server and CEP panel; Windows and macOS paths are not interchangeable.
 
 ### Codex plugin
 
@@ -930,7 +930,7 @@ user/device authorization are implemented.
 
 | Variable | Description | Default |
 | :------- | :---------- | :------ |
-| `PREMIERE_TEMP_DIR` | Shared temp directory for MCP ↔ CEP communication | OS temp dir + `/premiere-mcp-bridge` |
+| `PREMIERE_TEMP_DIR` | Shared temp directory for MCP ↔ CEP communication | OS user temp dir + `/premiere-mcp-bridge` (macOS fallback is independent of `TMPDIR`) |
 | `PREMIERE_TIMEOUT_MS` | Command timeout in milliseconds | `30000` |
 | `PREMIERE_DEFAULT_SEQUENCE_PRESET` | Override the auto-discovered `.sqpreset` used by `create_sequence` | auto-discovered |
 | `PREMIERE_MCP_CAPABILITIES` | Comma-separated authority profile; add `unsafe-script` only when raw scripting is required | `inspect,edit,export,filesystem` |

--- a/cep-plugin/main.js
+++ b/cep-plugin/main.js
@@ -95,7 +95,17 @@ var fs = nodeRequire("fs");
 var path = nodeRequire("path");
 var os = nodeRequire("os");
 var https = nodeRequire("https");
-tempDir = path.join(os.tmpdir(), "premiere-mcp-bridge");
+function defaultBridgeDirectory() {
+  try {
+    var nodeProcess = nodeRequire("process");
+    var configured = nodeProcess && nodeProcess.env && nodeProcess.env.PREMIERE_TEMP_DIR;
+    if (typeof configured === "string" && configured.trim()) return configured.trim();
+  } catch (e) {
+    // The panel still has a safe OS temporary-directory fallback.
+  }
+  return path.join(os.tmpdir(), "premiere-mcp-bridge");
+}
+tempDir = defaultBridgeDirectory();
 var latestUpdate = null;
 
 function ensureDir(dir) {

--- a/src/bridge/file-bridge.ts
+++ b/src/bridge/file-bridge.ts
@@ -1,10 +1,41 @@
 import { mkdirSync, writeFileSync, readFileSync, unlinkSync, existsSync, readdirSync, renameSync, statSync, chmodSync, watch, FSWatcher } from "node:fs";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, isAbsolute, join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
+import { execFileSync } from "node:child_process";
 import { getHelpersSource, helpersFileName, buildBootstrap } from "./script-builder.js";
 
-const DEFAULT_TEMP_DIR = join(tmpdir(), "premiere-mcp-bridge");
+export function getDarwinUserTempDirectory(): string | null {
+  try {
+    // GUI-launched MCP clients can omit TMPDIR. On macOS, getconf still returns
+    // the same per-user temporary root inherited by Premiere's CEP process.
+    const value = execFileSync("/usr/bin/getconf", ["DARWIN_USER_TEMP_DIR"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return value && isAbsolute(value) ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function getDefaultBridgeTempDir(
+  platform: NodeJS.Platform = process.platform,
+  fallbackTempDirectory = tmpdir(),
+  readDarwinUserTempDirectory: () => string | null = getDarwinUserTempDirectory,
+  environment: NodeJS.ProcessEnv = process.env,
+): string {
+  const hasConfiguredNodeTempDirectory = Boolean(
+    environment.TMPDIR || environment.TMP || environment.TEMP,
+  );
+  const temporaryRoot =
+    platform === "darwin" && !hasConfiguredNodeTempDirectory
+      ? readDarwinUserTempDirectory() ?? fallbackTempDirectory
+      : fallbackTempDirectory;
+  return join(temporaryRoot, "premiere-mcp-bridge");
+}
+
+const DEFAULT_TEMP_DIR = getDefaultBridgeTempDir();
 const POLL_FALLBACK_MS = 250;
 const DEFAULT_TIMEOUT_MS = 30000;
 export const BRIDGE_HEARTBEAT_FILE = "bridge-heartbeat.json";

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -237,7 +237,7 @@ export function buildFirstRunReport(
         },
       ],
       nextStep: "Reconnect the Premiere Connector, then run this safe check again.",
-      repair: "If the Connector still does not respond, run premiere-pro-mcp --diagnose-cep and follow its repair guidance.",
+      repair: "If the Connector still does not respond, run get_capabilities to compare the selected bridge directory with the CEP panel, then run premiere-pro-mcp --diagnose-cep and follow its repair guidance.",
     };
   }
 

--- a/src/tools/recovery.ts
+++ b/src/tools/recovery.ts
@@ -177,6 +177,7 @@ export function collectBridgeTelemetry(
     heartbeat,
     healthy:
       directoryAccessible &&
+      heartbeat.state === "running" &&
       counts.busyOperations === 0 &&
       (oldestPendingAgeMs === null || oldestPendingAgeMs < 30_000),
     privacy:

--- a/tests/bridge/file-bridge.test.ts
+++ b/tests/bridge/file-bridge.test.ts
@@ -13,8 +13,11 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
+import { execFileSync } from "node:child_process";
 import {
+  getDarwinUserTempDirectory,
   getTempDir,
+  getDefaultBridgeTempDir,
   getBridgeLiveness,
   sendCommand,
   sendRawCommand,
@@ -37,6 +40,10 @@ vi.mock("node:fs", () => ({
   }),
 }));
 
+vi.mock("node:child_process", () => ({
+  execFileSync: vi.fn(),
+}));
+
 const mockedExistsSync = vi.mocked(existsSync);
 const mockedMkdirSync = vi.mocked(mkdirSync);
 const mockedWriteFileSync = vi.mocked(writeFileSync);
@@ -47,6 +54,7 @@ const mockedRenameSync = vi.mocked(renameSync);
 const mockedStatSync = vi.mocked(statSync);
 const mockedChmodSync = vi.mocked(chmodSync);
 const mockedWatch = vi.mocked(watch);
+const mockedExecFileSync = vi.mocked(execFileSync);
 
 // ensureDir on an existing dir stat-checks ownership; default to a dir owned by us
 // with safe perms so the existing tests exercise the happy path.
@@ -84,9 +92,56 @@ describe("getTempDir", () => {
     expect(result).toBe(join(tmpdir(), "premiere-mcp-bridge"));
   });
 
+  it("uses the Darwin per-user temporary root when a GUI client omits TMPDIR", () => {
+    expect(getDefaultBridgeTempDir(
+      "darwin",
+      "/tmp",
+      () => "/var/folders/example/T",
+      {},
+    ).replaceAll("\\", "/")).toBe("/var/folders/example/T/premiere-mcp-bridge");
+  });
+
+  it("falls back safely when the Darwin temporary-root lookup is unavailable", () => {
+    expect(getDefaultBridgeTempDir("darwin", "/tmp", () => null, {}).replaceAll("\\", "/"))
+      .toBe("/tmp/premiere-mcp-bridge");
+  });
+
+  it("preserves a configured Darwin temporary root", () => {
+    expect(getDefaultBridgeTempDir(
+      "darwin",
+      "/configured/T",
+      () => "/var/folders/example/T",
+      { TMPDIR: "/configured/T" },
+    ).replaceAll("\\", "/")).toBe("/configured/T/premiere-mcp-bridge");
+  });
+
   it("prefers options.tempDir over env var", () => {
     process.env.PREMIERE_TEMP_DIR = "/env/dir";
     expect(getTempDir({ tempDir: "/custom/dir" })).toBe("/custom/dir");
+  });
+});
+
+describe("getDarwinUserTempDirectory", () => {
+  it("uses the per-user macOS temporary root reported by getconf", () => {
+    mockedExecFileSync.mockReturnValue("/var/folders/example/T/\n" as never);
+
+    expect(getDarwinUserTempDirectory()).toBe("/var/folders/example/T/");
+    expect(mockedExecFileSync).toHaveBeenCalledWith("/usr/bin/getconf", ["DARWIN_USER_TEMP_DIR"], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  });
+
+  it("rejects a non-absolute getconf result", () => {
+    mockedExecFileSync.mockReturnValue("relative-temp\n" as never);
+
+    expect(getDarwinUserTempDirectory()).toBeNull();
+  });
+
+  it("falls back when the getconf lookup fails", () => {
+    mockedExecFileSync.mockImplementation(() => { throw new Error("unavailable"); });
+
+    expect(getDarwinUserTempDirectory()).toBeNull();
   });
 });
 

--- a/tests/cep-install.test.ts
+++ b/tests/cep-install.test.ts
@@ -62,6 +62,8 @@ describe("CEP installation metadata", () => {
     expect(panelLogic).toContain('"bridge-heartbeat.json"');
     expect(panelLogic).toContain("protocolVersion: 1");
     expect(panelLogic).toContain("startBridgeHeartbeat()");
+    expect(panelLogic).toContain("PREMIERE_TEMP_DIR");
+    expect(panelLogic).toContain('nodeRequire("process")');
   });
 
   it("copies the macOS plugin for npm installs and supports diagnostics", () => {

--- a/tests/tools/recovery.test.ts
+++ b/tests/tools/recovery.test.ts
@@ -71,6 +71,15 @@ describe("recovery candidate discovery", () => {
 });
 
 describe("privacy-preserving bridge telemetry", () => {
+  it("does not report a quiet directory as healthy when no CEP heartbeat is present", () => {
+    const directory = temporaryDirectory();
+    expect(collectBridgeTelemetry({ tempDir: directory })).toMatchObject({
+      directoryAccessible: true,
+      heartbeat: { state: "unknown" },
+      healthy: false,
+    });
+  });
+
   it("returns aggregate state without paths, filenames, or contents", () => {
     const directory = temporaryDirectory();
     writeFileSync(join(directory, "cmd_secret.jsx"), "private project script");


### PR DESCRIPTION
Fixes #294.\n\nThe stdio server now preserves explicit temp-directory configuration and, only when macOS GUI launchers omit all Node temp variables, resolves the per-user Darwin temporary root used by Premiere's CEP process. The CEP panel also honors PREMIERE_TEMP_DIR. Bridge telemetry requires a running heartbeat before reporting healthy, and the read-only connection repair guidance directs operators to compare the selected directory.\n\nTests: npm run check (85 files, 1,875 tests).