### PR TITLE
fix(uxp): probe complete environment API chain

### DIFF
--- a/tests/uxp/stable-workflows.test.ts
+++ b/tests/uxp/stable-workflows.test.ts
@@ -779,7 +779,7 @@ describe("stable Premiere UXP workflow expansion", () => {
     expect(withoutColorApi.commands["environment.inspect"]).toMatchObject({ supported: false });
 
     const noActiveProject = stableHost();
-    noActiveProject.ppro.Project.getActiveProject.mockResolvedValueOnce(null);
+    noActiveProject.ppro.Project.getActiveProject.mockResolvedValue(null);
     const withoutProject = await noActiveProject.registry.capabilities();
     expect(withoutProject.commands["environment.inspect"]).toMatchObject({ supported: true });
   });

--- a/tests/uxp/stable-workflows.test.ts
+++ b/tests/uxp/stable-workflows.test.ts
@@ -772,6 +772,16 @@ describe("stable Premiere UXP workflow expansion", () => {
     Reflect.deleteProperty(value.ppro.Utils, "isAEInstalled");
     const capabilities = await value.registry.capabilities();
     expect(capabilities.commands["environment.inspect"]).toMatchObject({ supported: false });
+
+    const missingColorApi = stableHost();
+    missingColorApi.project.getColorSettings.mockResolvedValueOnce({});
+    const withoutColorApi = await missingColorApi.registry.capabilities();
+    expect(withoutColorApi.commands["environment.inspect"]).toMatchObject({ supported: false });
+
+    const noActiveProject = stableHost();
+    noActiveProject.ppro.Project.getActiveProject.mockResolvedValueOnce(null);
+    const withoutProject = await noActiveProject.registry.capabilities();
+    expect(withoutProject.commands["environment.inspect"]).toMatchObject({ supported: true });
   });
 
   it("rejects metadata whose combined serialized UTF-8 result exceeds the frame budget", async () => {

--- a/uxp-plugin/workflows.cjs
+++ b/uxp-plugin/workflows.cjs
@@ -1165,8 +1165,16 @@
     function canUseIngest() { return canInspectProject() && !!(ppro.ProjectSettings && typeof ppro.ProjectSettings.getIngestSettings === "function" && typeof ppro.ProjectSettings.createSetIngestSettingsAction === "function"); }
     function canUseMetadata() { return canUseClipItems() && !!(ppro.Metadata && typeof ppro.Metadata.getProjectMetadata === "function" && typeof ppro.Metadata.getXMPMetadata === "function" && typeof ppro.Metadata.createSetProjectMetadataAction === "function" && typeof ppro.Metadata.createSetXMPMetadataAction === "function"); }
     function canInspectColor() { return canUseClipItems(); }
-    function canInspectEnvironment() {
-      return canInspectProject() && !!(ppro.Utils && typeof ppro.Utils.isAEInstalled === "function");
+    async function canInspectEnvironment() {
+      if (!canInspectProject() || !ppro.Utils || typeof ppro.Utils.isAEInstalled !== "function") return false;
+      try {
+        const project = await ppro.Project.getActiveProject();
+        if (!project) return true;
+        if (typeof project.getColorSettings !== "function") return false;
+        const settings = await project.getColorSettings();
+        return !!settings && typeof settings.getGraphicsWhiteLuminance === "function" &&
+          typeof settings.getSupportedGraphicsWhiteLuminances === "function";
+      } catch (_) { return false; }
     }
     function canConformFootage() { return canUseClipItems(); }
     function canInspectSourceMonitor() {


### PR DESCRIPTION
## Summary
- probe every API required by environment.inspect before advertising it
- treat a missing active project as inconclusive while failing closed on incomplete color settings
- cover missing settings APIs and the no-project capability case

## Verification
- npm run check (86 files, 1,890 tests)
- git diff --check

Follow-up to late review feedback on #302.