### PR TITLE
docs(api): inventory Adobe UXP JavaScript surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,9 +562,10 @@ validation boundary.
 The [Premiere surface registry](docs/premiere-surface-registry.md) separately
 tracks the Premiere DOM, general UXP JavaScript, HTML/CSS, Spectrum, plugin
 guides, UXP Hybrid C++, the standalone Premiere C++ PrSDK, CEP/ExtendScript,
-the CEP platform, QE, and pinned competitor sources. This
-keeps complete DOM declaration inventory distinct from incomplete platform and
-runtime coverage.
+the CEP platform, QE, and pinned competitor sources. The exhaustive
+[general UXP JavaScript inventory](docs/uxp-js-api-inventory.md) is generated
+from Adobe's pinned declarations. This keeps declaration inventory distinct
+from implementation and licensed-host coverage.
 
 The stable workflow expansion adds native component-chain effects, deterministic
 timeline selection, compound selection batches, scene-edit detection, proxy/ingest control, guarded offline

--- a/docs/uxp-js-api-inventory.md
+++ b/docs/uxp-js-api-inventory.md
@@ -1,0 +1,9 @@
+# Adobe UXP JavaScript API inventory
+
+The generated `src/resources/uxp-js-api-inventory.json` accounts for every named API declaration in Adobe's pinned `@adobe/cc-ext-uxp-types@7.3.1` package. This is the general UXP runtime surface used by Premiere panels; it is separate from the Premiere DOM inventory.
+
+Run `npm run uxp:js-api-inventory` after deliberately updating the pinned Adobe package or the exact panel mappings. CI runs `npm run uxp:js-api-inventory:check` and fails when the declaration version, normalized declaration hash, symbol set, or classifications drift.
+
+`mapped` means an exact declared symbol is referenced by `src/resources/uxp-js-coverage.json`. It is static source evidence only. `unmapped` is a review queue, because many DOM, storage, XMP, web, and platform APIs do not warrant standalone editing tools. Neither state proves availability in a licensed Premiere host.
+
+The npm package includes the generated inventory, and package verification resolves every non-null inventory path recorded in the Premiere surface registry.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "premiere-pro-mcp": "dist/index.js"
       },
       "devDependencies": {
+        "@adobe/cc-ext-uxp-types": "7.3.1",
         "@adobe/eslint-plugin-premierepro": "26.3.0",
         "@adobe/premierepro": "26.3.0",
         "@modelcontextprotocol/client": "^2.0.0",
@@ -34,6 +35,12 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/@adobe/cc-ext-uxp-types": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@adobe/cc-ext-uxp-types/-/cc-ext-uxp-types-7.3.1.tgz",
+      "integrity": "sha512-HLWYoqvDXOmVr9d7l4/hY7h+Ae6IJC1Rm8uIqUK28E8nlT36A23YUsAfnamh24LZC/Xkq5jsYNORW7wX44QEKg==",
+      "dev": true
     },
     "node_modules/@adobe/eslint-plugin-premierepro": {
       "version": "26.3.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "dist/**/*.d.ts",
     "dist/resources/adobe-uxp-coverage.json",
     "dist/resources/adobe-api-inventory.json",
+    "dist/resources/uxp-js-api-inventory.json",
     "dist/resources/premiere-surface-registry.json",
     "cep-plugin",
     "artifacts/MCPBridgeCEP.zxp",
@@ -21,6 +22,7 @@
     "benchmarks/uxp-hybrid",
     "docs/supported-actions.md",
     "docs/adobe-api-inventory.md",
+    "docs/uxp-js-api-inventory.md",
     "docs/premiere-surface-registry.md",
     "docs/project-context-engine.md",
     "docs/mcp-2026-07-28-capabilities.md",
@@ -37,10 +39,10 @@
     "CHANGELOG.md"
   ],
   "scripts": {
-    "build": "node scripts/generate-adobe-api-inventory.mjs --check && tsc && node scripts/copy-adobe-uxp-coverage.mjs",
+    "build": "node scripts/generate-adobe-api-inventory.mjs --check && node scripts/generate-uxp-js-api-inventory.mjs --check && tsc && node scripts/copy-adobe-uxp-coverage.mjs",
     "build:claude": "npm run build && node scripts/build-claude-desktop.mjs",
     "build:connector:windows": "powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-connector-installer.ps1",
-    "check": "npm run lint && npm run adobe:api-inventory:check && npm run build && npm run validate:marketplace-branding && npm run validate:mcp-registry-metadata && npm run docs:supported-actions:check && npm run docs:quickstart:check && npm test",
+    "check": "npm run lint && npm run adobe:api-inventory:check && npm run uxp:js-api-inventory:check && npm run build && npm run validate:marketplace-branding && npm run validate:mcp-registry-metadata && npm run docs:supported-actions:check && npm run docs:quickstart:check && npm test",
     "check:release-metadata": "vitest run tests/release-metadata.test.ts",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
@@ -59,6 +61,8 @@
     "docs:quickstart:check": "node scripts/check-quickstart-locales.mjs",
     "adobe:api-inventory": "node scripts/generate-adobe-api-inventory.mjs",
     "adobe:api-inventory:check": "node scripts/generate-adobe-api-inventory.mjs --check",
+    "uxp:js-api-inventory": "node scripts/generate-uxp-js-api-inventory.mjs",
+    "uxp:js-api-inventory:check": "node scripts/generate-uxp-js-api-inventory.mjs --check",
     "install-cep": "node dist/index.js --install-cep",
     "uninstall-cep": "node dist/index.js --uninstall-cep",
     "check-update:source": "node scripts/update-source.mjs --check",
@@ -119,6 +123,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@adobe/cc-ext-uxp-types": "7.3.1",
     "@adobe/eslint-plugin-premierepro": "26.3.0",
     "@adobe/premierepro": "26.3.0",
     "@modelcontextprotocol/client": "^2.0.0",

--- a/scripts/copy-adobe-uxp-coverage.mjs
+++ b/scripts/copy-adobe-uxp-coverage.mjs
@@ -3,7 +3,13 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
-const resources = ["adobe-uxp-coverage.json", "adobe-api-inventory.json", "premiere-surface-registry.json"];
+const resources = [
+  "adobe-uxp-coverage.json",
+  "adobe-api-inventory.json",
+  "uxp-js-coverage.json",
+  "uxp-js-api-inventory.json",
+  "premiere-surface-registry.json",
+];
 const targetDirectory = resolve(scriptDirectory, "../dist/resources");
 
 await mkdir(targetDirectory, { recursive: true });

--- a/scripts/generate-uxp-js-api-inventory.mjs
+++ b/scripts/generate-uxp-js-api-inventory.mjs
@@ -1,0 +1,168 @@
+import { createHash } from "node:crypto";
+import { readFile, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const packagePath = resolve(root, "node_modules/@adobe/cc-ext-uxp-types/package.json");
+const declarationsPath = process.env.UXP_JS_DECLARATIONS_PATH
+  ? resolve(process.env.UXP_JS_DECLARATIONS_PATH)
+  : resolve(root, "node_modules/@adobe/cc-ext-uxp-types/uxp/index.d.ts");
+const coveragePath = resolve(root, "src/resources/uxp-js-coverage.json");
+const outputPath = resolve(root, "src/resources/uxp-js-api-inventory.json");
+const check = process.argv.includes("--check");
+const validateOnly = process.argv.includes("--validate-only");
+
+const [packageText, declarationsText, coverageText] = await Promise.all([
+  readFile(packagePath, "utf8"),
+  readFile(declarationsPath, "utf8"),
+  readFile(coveragePath, "utf8"),
+]);
+const packageMetadata = JSON.parse(packageText);
+const coverage = JSON.parse(coverageText);
+const mappedSymbols = new Set(coverage.entries.flatMap((entry) => entry.uxpApi));
+const source = ts.createSourceFile(declarationsPath, declarationsText, ts.ScriptTarget.Latest, true);
+if (source.parseDiagnostics.length > 0) {
+  const details = source.parseDiagnostics
+    .map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, " "))
+    .join("; ");
+  throw new Error(`TypeScript declaration parse failed: ${details}`);
+}
+
+const normalizedDeclarations = declarationsText.replaceAll("\r\n", "\n");
+const declarationsSha256 = createHash("sha256").update(normalizedDeclarations).digest("hex");
+const symbols = [];
+const compareText = (left, right) => left < right ? -1 : left > right ? 1 : 0;
+const cleanName = (node) => node.getText(source).replaceAll('"', "").replaceAll("'", "");
+const joinName = (owner, name) => owner ? `${owner}.${name}` : name;
+
+function add(symbol, kind) {
+  symbols.push({ symbol, kind });
+}
+
+function memberName(member) {
+  if (ts.isConstructorDeclaration(member) || ts.isConstructSignatureDeclaration(member)) return "[[construct]]";
+  if (ts.isCallSignatureDeclaration(member)) return "[[call]]";
+  if (ts.isIndexSignatureDeclaration(member)) return "[[index]]";
+  if (!member.name) throw new Error(`Unsupported anonymous UXP member: ${ts.SyntaxKind[member.kind]}`);
+  return cleanName(member.name);
+}
+
+function memberKind(member) {
+  if (ts.isConstructorDeclaration(member) || ts.isConstructSignatureDeclaration(member)) return "constructor";
+  if (ts.isMethodDeclaration(member) || ts.isMethodSignature(member)) return "method";
+  if (ts.isPropertyDeclaration(member) || ts.isPropertySignature(member)) return "property";
+  if (ts.isGetAccessorDeclaration(member)) return "getter";
+  if (ts.isSetAccessorDeclaration(member)) return "setter";
+  if (ts.isCallSignatureDeclaration(member)) return "call";
+  if (ts.isIndexSignatureDeclaration(member)) return "index";
+  throw new Error(`Unsupported UXP type member: ${ts.SyntaxKind[member.kind]}`);
+}
+
+function collectMembers(owner, members) {
+  for (const member of members) add(joinName(owner, memberName(member)), memberKind(member));
+}
+
+function collectTypeNode(owner, node) {
+  if (ts.isTypeLiteralNode(node)) {
+    collectMembers(owner, node.members);
+  } else if (ts.isIntersectionTypeNode(node) || ts.isUnionTypeNode(node)) {
+    for (const type of node.types) collectTypeNode(owner, type);
+  } else if (ts.isParenthesizedTypeNode(node)) {
+    collectTypeNode(owner, node.type);
+  }
+}
+
+function collectStatements(statements, owner = "globalThis") {
+  for (const statement of statements) {
+    if (ts.isModuleDeclaration(statement)) {
+      const moduleOwner = joinName(owner === "globalThis" ? "" : owner, cleanName(statement.name));
+      add(moduleOwner, "module");
+      collectModuleBody(statement.body, moduleOwner);
+    } else if (ts.isClassDeclaration(statement) || ts.isInterfaceDeclaration(statement)) {
+      if (!statement.name) throw new Error(`Anonymous UXP declaration: ${ts.SyntaxKind[statement.kind]}`);
+      const symbol = joinName(owner, statement.name.text);
+      add(symbol, ts.isClassDeclaration(statement) ? "class" : "interface");
+      collectMembers(symbol, statement.members);
+    } else if (ts.isTypeAliasDeclaration(statement)) {
+      const symbol = joinName(owner, statement.name.text);
+      add(symbol, "type");
+      collectTypeNode(symbol, statement.type);
+    } else if (ts.isEnumDeclaration(statement)) {
+      const symbol = joinName(owner, statement.name.text);
+      add(symbol, "enum");
+      for (const member of statement.members) add(joinName(symbol, cleanName(member.name)), "enumMember");
+    } else if (ts.isFunctionDeclaration(statement)) {
+      if (!statement.name) throw new Error("Anonymous UXP function declaration");
+      add(joinName(owner, statement.name.text), "function");
+    } else if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        if (!ts.isIdentifier(declaration.name)) throw new Error("Unsupported destructured UXP variable declaration");
+        add(joinName(owner, declaration.name.text), "variable");
+      }
+    } else if (ts.isExportAssignment(statement) || ts.isExportDeclaration(statement) || ts.isImportDeclaration(statement)) {
+      // Module wiring does not add a callable or inspectable API symbol.
+    } else {
+      throw new Error(`Unsupported top-level UXP declaration: ${ts.SyntaxKind[statement.kind]}`);
+    }
+  }
+}
+
+function collectModuleBody(body, owner) {
+  if (!body) throw new Error(`UXP module ${owner} has no body`);
+  if (ts.isModuleDeclaration(body)) {
+    const nestedOwner = joinName(owner, cleanName(body.name));
+    add(nestedOwner, "module");
+    collectModuleBody(body.body, nestedOwner);
+  } else if (ts.isModuleBlock(body)) {
+    collectStatements(body.statements, owner);
+  } else {
+    throw new Error(`Unsupported UXP module body: ${ts.SyntaxKind[body.kind]}`);
+  }
+}
+
+collectStatements(source.statements);
+const uniqueSymbols = [...new Map(symbols.map((entry) => [entry.symbol, entry])).values()]
+  .sort((left, right) => compareText(left.symbol, right.symbol));
+const declaredSymbols = new Set(uniqueSymbols.map((entry) => entry.symbol));
+const entries = uniqueSymbols.map((entry) => ({
+  ...entry,
+  coverage: mappedSymbols.has(entry.symbol) ? "mapped" : "unmapped",
+}));
+const mapped = entries.filter((entry) => entry.coverage === "mapped").length;
+const manifestOnly = [...mappedSymbols].filter((symbol) => !declaredSymbols.has(symbol)).sort(compareText);
+const inventory = {
+  schemaVersion: 1,
+  source: {
+    package: "@adobe/cc-ext-uxp-types",
+    version: packageMetadata.version,
+    declarations: "node_modules/@adobe/cc-ext-uxp-types/uxp/index.d.ts",
+    declarationsSha256,
+    coverageManifest: "src/resources/uxp-js-coverage.json",
+  },
+  semantics: {
+    mapped: "The exact declaration symbol is referenced by panel coverage; this alone is not licensed-host verification.",
+    unmapped: "No panel coverage entry references the exact declaration symbol; this is a review queue, not a requirement for a standalone MCP tool.",
+  },
+  stats: { total: entries.length, mapped, unmapped: entries.length - mapped, manifestOnly: manifestOnly.length },
+  manifestOnly,
+  entries,
+};
+const rendered = `${JSON.stringify(inventory, null, 2)}\n`;
+
+if (validateOnly) {
+  console.log(`Validated ${entries.length} UXP JavaScript API symbols from ${packageMetadata.version}.`);
+} else if (check) {
+  let current = "";
+  try { current = await readFile(outputPath, "utf8"); } catch {}
+  if (current.replaceAll("\r\n", "\n") !== rendered) {
+    console.error("UXP JavaScript API inventory is stale. Run npm run uxp:js-api-inventory.");
+    process.exitCode = 1;
+  } else {
+    console.log(`UXP JavaScript API inventory is current: ${entries.length} symbols from ${packageMetadata.version}.`);
+  }
+} else {
+  await writeFile(outputPath, rendered);
+  console.log(`Wrote ${entries.length} UXP JavaScript API symbols (${mapped} mapped, ${entries.length - mapped} unmapped).`);
+}

--- a/scripts/verify-npm-package.mjs
+++ b/scripts/verify-npm-package.mjs
@@ -20,7 +20,9 @@ const requiredFiles = [
   "package/uxp-plugin/manifest.json",
   "package/docs/supported-actions.md",
   "package/docs/premiere-surface-registry.md",
+  "package/docs/uxp-js-api-inventory.md",
   "package/dist/resources/premiere-surface-registry.json",
+  "package/dist/resources/uxp-js-api-inventory.json",
   "package/scripts/install-cep.ps1",
   "package/scripts/install-cep.sh",
 ];

--- a/src/resources/premiere-surface-registry.json
+++ b/src/resources/premiere-surface-registry.json
@@ -17,11 +17,11 @@
       "id": "uxp-javascript",
       "kind": "api",
       "authorityUrls": ["https://developer.adobe.com/premiere-pro/uxp/uxp-api/reference-js/"],
-      "versionSource": "Premiere-bundled UXP runtime",
-      "inventoryArtifact": null,
-      "inventoryState": "not_started",
+      "versionSource": "@adobe/cc-ext-uxp-types@7.3.1",
+      "inventoryArtifact": "dist/resources/uxp-js-api-inventory.json",
+      "inventoryState": "complete",
       "implementationState": "partial",
-      "notes": "Filesystem, networking, shell, core runtime, and module APIs require a separate inventory from the Premiere DOM."
+      "notes": "All declarations in Adobe's UXP 7.3 type package are inventoried and classified separately from the Premiere DOM; mapped remains static panel evidence, not licensed-host proof."
     },
     {
       "id": "uxp-html",

--- a/src/resources/uxp-js-api-inventory.json
+++ b/src/resources/uxp-js-api-inventory.json
@@ -1,0 +1,17053 @@
+{
+  "schemaVersion": 1,
+  "source": {
+    "package": "@adobe/cc-ext-uxp-types",
+    "version": "7.3.1",
+    "declarations": "node_modules/@adobe/cc-ext-uxp-types/uxp/index.d.ts",
+    "declarationsSha256": "6188a6c24309c016fcddf9cde296afd500eadaf1500e85c86f3bf620bdf16282",
+    "coverageManifest": "src/resources/uxp-js-coverage.json"
+  },
+  "semantics": {
+    "mapped": "The exact declaration symbol is referenced by panel coverage; this alone is not licensed-host verification.",
+    "unmapped": "No panel coverage entry references the exact declaration symbol; this is a review queue, not a requirement for a standalone MCP tool."
+  },
+  "stats": {
+    "total": 3406,
+    "mapped": 12,
+    "unmapped": 3394,
+    "manifestOnly": 0
+  },
+  "manifestOnly": [],
+  "entries": [
+    {
+      "symbol": "fs",
+      "kind": "module",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "fs._fs",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "fs.fs",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "fs.fs.close",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "fs.fs.copyFile",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "fs.fs.lstat",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "fs.fs.lstatSync",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "fs.fs.mkdir",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "fs.fs.open",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "fs.fs.read",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "fs.fs.readFile",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "fs.fs.readFileSync",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "fs.fs.readdir",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "fs.fs.readdirSync",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "fs.fs.rename",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "fs.fs.rmdir",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "fs.fs.unlink",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "fs.fs.write",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "fs.fs.writeFile",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "fs.fs.writeFileSync",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "global",
+      "kind": "module",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "global.FormData",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "global.FormData.append",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "global.FormData.delete",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "global.FormData.entries",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "global.FormData.get",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "global.FormData.getAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "global.FormData.has",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "global.FormData.keys",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "global.FormData.set",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "global.FormData.values",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.AbortController",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.AbortController.abort",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.AbortController.signal",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.AbortSignal",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.AbortSignal.abort",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.AbortSignal.aborted",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.AbortSignal.reason",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.AbortSignal.throwIfAborted",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.localName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.name",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.nodeValue",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.ownerElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.specified",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Attr.value",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.AudioTrackList",
+      "kind": "type",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.altKey",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.bubbles",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.button",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.buttons",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.cancelable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.clientX",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.clientY",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.composed",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.composedPath",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.ctrlKey",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.currentTarget",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.defaultPrevented",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.detail",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.eventPhase",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.height",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.initEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.isPrimary",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.isTrusted",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.metaKey",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.movementX",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.movementY",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.offsetX",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.offsetY",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.pageX",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.pageY",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.pointerId",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.pointerType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.pressure",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.preventDefault",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.returnValue",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.screenX",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.screenY",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.shiftKey",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.stopImmediatePropagation",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.stopPropagation",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.tangentialPressure",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.target",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.tiltX",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.tiltY",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.twist",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.type",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.which",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.BaseUIEvent.width",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Blob",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Blob.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Blob.arrayBuffer",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Blob.size",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Blob.slice",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Blob.stream",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Blob.text",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Blob.type",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasGradient",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasGradient.addColorStop",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasRenderingContext2D",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasRenderingContext2D.arc",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasRenderingContext2D.arcTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasRenderingContext2D.beginPath",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasRenderingContext2D.bezierCurveTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasRenderingContext2D.clearRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasRenderingContext2D.closePath",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasRenderingContext2D.createLinearGradient",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasRenderingContext2D.createRadialGradient",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasRenderingContext2D.fill",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasRenderingContext2D.fillRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasRenderingContext2D.fillStyle",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasRenderingContext2D.globalAlpha",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasRenderingContext2D.lineCap",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasRenderingContext2D.lineJoin",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasRenderingContext2D.lineTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasRenderingContext2D.lineWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasRenderingContext2D.moveTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasRenderingContext2D.quadraticCurveTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasRenderingContext2D.rect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasRenderingContext2D.stroke",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasRenderingContext2D.strokeRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CanvasRenderingContext2D.strokeStyle",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.appendData",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.data",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.deleteData",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.insertData",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.length",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.nodeValue",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.replaceData",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.substringData",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CharacterData.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ClassList",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ClassList.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ClassList.add",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ClassList.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ClassList.item",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ClassList.length",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ClassList.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ClassList.replace",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ClassList.supports",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ClassList.toggle",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ClassList.value",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Clipboard",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Clipboard.clearContent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Clipboard.getContent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Clipboard.read",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Clipboard.readText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Clipboard.setContent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Clipboard.write",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Clipboard.writeText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CloseEvent",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CloseEvent.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CloseEvent.bubbles",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CloseEvent.cancelable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CloseEvent.code",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CloseEvent.composed",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CloseEvent.composedPath",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CloseEvent.currentTarget",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CloseEvent.defaultPrevented",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CloseEvent.eventPhase",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CloseEvent.initEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CloseEvent.isTrusted",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CloseEvent.preventDefault",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CloseEvent.reason",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CloseEvent.returnValue",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CloseEvent.stopImmediatePropagation",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CloseEvent.stopPropagation",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CloseEvent.target",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CloseEvent.type",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CloseEvent.wasClean",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.appendData",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.data",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.deleteData",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.insertData",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.length",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.nodeValue",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.replaceData",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.substringData",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Comment.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CountQueuingStrategy",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CountQueuingStrategy.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CountQueuingStrategy.highWaterMark",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CountQueuingStrategy.size",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Crypto",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Crypto.getRandomValues",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Crypto.randomUUID",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CustomElement",
+      "kind": "type",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CustomElementRegistry",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CustomElementRegistry.define",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CustomElementRegistry.get",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CustomElementRegistry.upgrade",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.CustomElementRegistry.whenDefined",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.DOMTokenList",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.DOMTokenList.add",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.DOMTokenList.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.DOMTokenList.item",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.DOMTokenList.length",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.DOMTokenList.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.DOMTokenList.replace",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.DOMTokenList.supports",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.DOMTokenList.toggle",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.DOMTokenList.value",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.activeElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.adoptNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.body",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.clipboard",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.createAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.createComment",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.createDocumentFragment",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.createElement",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.createElementNS",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.createEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.createTextNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.createTreeWalker",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.documentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.getElementById",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.getElementsByClassName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.getElementsByTagName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.head",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.importNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.onLine",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.styleSheets",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Document.uxpContainer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.DocumentFragment",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.DocumentFragment.append",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.DocumentFragment.childElementCount",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.DocumentFragment.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.DocumentFragment.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.DragEvent",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.DragEvent.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.DragEvent.dataTransfer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.assignedSlot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.attachShadow",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.autofocus",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.blur",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.className",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.click",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.clientHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.clientLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.clientTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.clientWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.closest",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.disabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.focus",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.getAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.getAttributeNames",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.getAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.getBoundingClientRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.getElementsByClassName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.getElementsByTagName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.hasAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.hasAttributes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.hasPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.innerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.insertAdjacentElement",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.insertAdjacentHTML",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.insertAdjacentText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.localName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.matches",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.namespaceURI",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.offsetHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.offsetLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.offsetParent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.offsetTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.offsetWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.outerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.releasePointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.removeAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.removeAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.scrollHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.scrollIntoView",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.scrollIntoViewIfNeeded",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.scrollLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.scrollTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.scrollTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.scrollWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.setAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.setAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.setPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.shadowRoot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.slot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.style",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.tabIndex",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.tagName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Element.uxpContainer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Entry",
+      "kind": "type",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.EntryPointsError",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ErrorEvent",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ErrorEvent.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ErrorEvent.bubbles",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ErrorEvent.cancelable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ErrorEvent.colno",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ErrorEvent.composed",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ErrorEvent.composedPath",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ErrorEvent.currentTarget",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ErrorEvent.defaultPrevented",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ErrorEvent.error",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ErrorEvent.eventPhase",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ErrorEvent.filename",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ErrorEvent.initEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ErrorEvent.isTrusted",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ErrorEvent.lineno",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ErrorEvent.message",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ErrorEvent.preventDefault",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ErrorEvent.returnValue",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ErrorEvent.stopImmediatePropagation",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ErrorEvent.stopPropagation",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ErrorEvent.target",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ErrorEvent.type",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Event",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Event.AT_TARGET",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Event.BUBBLING_PHASE",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Event.CAPTURING_PHASE",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Event.NONE",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Event.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Event.bubbles",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Event.cancelable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Event.composed",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Event.composedPath",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Event.currentTarget",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Event.defaultPrevented",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Event.eventPhase",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Event.initEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Event.isTrusted",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Event.preventDefault",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Event.returnValue",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Event.stopImmediatePropagation",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Event.stopPropagation",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Event.target",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Event.type",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.EventTarget",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.EventTarget.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.EventTarget.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.EventTarget.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ExecutionContext",
+      "kind": "type",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.File",
+      "kind": "type",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.altKey",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.bubbles",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.button",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.buttons",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.cancelable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.clientX",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.clientY",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.composed",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.composedPath",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.ctrlKey",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.currentTarget",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.defaultPrevented",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.detail",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.eventPhase",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.expansion",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.height",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.initEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.isPrimary",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.isTrusted",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.metaKey",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.movementX",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.movementY",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.offsetX",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.offsetY",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.pageX",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.pageY",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.pointerId",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.pointerType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.pressure",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.preventDefault",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.returnValue",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.rotation",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.scale",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.screenX",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.screenY",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.shiftKey",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.stopImmediatePropagation",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.stopPropagation",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.tangentialPressure",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.target",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.tiltX",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.tiltY",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.translationX",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.translationY",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.twist",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.type",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.velocityAngular",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.velocityExpansion",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.velocityX",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.velocityY",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.which",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.GestureEvent.width",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.assignedSlot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.attachShadow",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.autofocus",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.blur",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.className",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.click",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.clientHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.clientLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.clientTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.clientWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.closest",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.dataset",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.dir",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.disabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.focus",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.getAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.getAttributeNames",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.getAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.getBoundingClientRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.getElementsByClassName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.getElementsByTagName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.hasAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.hasAttributes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.hasPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.hidden",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.href",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.innerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.innerText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.insertAdjacentElement",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.insertAdjacentHTML",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.insertAdjacentText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.lang",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.localName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.matches",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.namespaceURI",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.offsetHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.offsetLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.offsetParent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.offsetTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.offsetWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.outerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.pathname",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.protocol",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.releasePointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.removeAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.removeAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.scrollHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.scrollIntoView",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.scrollIntoViewIfNeeded",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.scrollLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.scrollTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.scrollTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.scrollWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.setAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.setAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.setPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.shadowRoot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.slot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.style",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.tabIndex",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.tagName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLAnchorElement.uxpContainer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.assignedSlot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.attachShadow",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.autofocus",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.blur",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.className",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.click",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.clientHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.clientLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.clientTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.clientWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.closest",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.dataset",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.dir",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.disabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.focus",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.getAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.getAttributeNames",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.getAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.getBoundingClientRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.getElementsByClassName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.getElementsByTagName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.hasAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.hasAttributes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.hasPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.hidden",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.innerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.innerText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.insertAdjacentElement",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.insertAdjacentHTML",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.insertAdjacentText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.lang",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.localName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.matches",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.namespaceURI",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.offsetHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.offsetLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.offsetParent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.offsetTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.offsetWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.outerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.releasePointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.removeAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.removeAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.scrollHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.scrollIntoView",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.scrollIntoViewIfNeeded",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.scrollLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.scrollTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.scrollTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.scrollWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.setAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.setAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.setPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.shadowRoot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.slot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.style",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.tabIndex",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.tagName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLBodyElement.uxpContainer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.assignedSlot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.attachShadow",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.autofocus",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.blur",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.className",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.click",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.clientHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.clientLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.clientTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.clientWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.closest",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.dataset",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.dir",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.disabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.focus",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.getAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.getAttributeNames",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.getAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.getBoundingClientRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.getElementsByClassName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.getElementsByTagName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.hasAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.hasAttributes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.hasPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.hidden",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.innerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.innerText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.insertAdjacentElement",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.insertAdjacentHTML",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.insertAdjacentText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.lang",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.localName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.matches",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.namespaceURI",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.offsetHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.offsetLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.offsetParent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.offsetTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.offsetWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.outerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.releasePointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.removeAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.removeAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.scrollHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.scrollIntoView",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.scrollIntoViewIfNeeded",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.scrollLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.scrollTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.scrollTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.scrollWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.setAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.setAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.setPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.shadowRoot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.slot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.style",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.tabIndex",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.tagName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLButtonElement.uxpContainer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLCanvasElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLCanvasElement.getContext",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLCanvasElement.height",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLCanvasElement.width",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLCollection",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLCollection.entries",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLCollection.forEach",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLCollection.item",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLCollection.keys",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLCollection.length",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLCollection.values",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.REJECTION_REASON_DETACHED",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.REJECTION_REASON_NOT_ALLOWED",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.assignedSlot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.attachShadow",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.autofocus",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.blur",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.className",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.click",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.clientHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.clientLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.clientTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.clientWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.close",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.closest",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.dataset",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.dir",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.disabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.focus",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.getAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.getAttributeNames",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.getAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.getBoundingClientRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.getElementsByClassName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.getElementsByTagName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.hasAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.hasAttributes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.hasPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.hidden",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.innerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.innerText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.insertAdjacentElement",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.insertAdjacentHTML",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.insertAdjacentText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.isMinimized",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.lang",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.localName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.matches",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.namespaceURI",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.offsetHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.offsetLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.offsetParent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.offsetTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.offsetWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.open",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.outerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.releasePointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.removeAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.removeAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.returnValue",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.scrollHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.scrollIntoView",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.scrollIntoViewIfNeeded",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.scrollLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.scrollTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.scrollTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.scrollWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.setAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.setAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.setPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.shadowRoot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.show",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.showModal",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.slot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.style",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.tabIndex",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.tagName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLDialogElement.uxpContainer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.assignedSlot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.attachShadow",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.autofocus",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.blur",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.className",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.click",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.clientHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.clientLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.clientTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.clientWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.closest",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.dataset",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.dir",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.disabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.focus",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.getAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.getAttributeNames",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.getAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.getBoundingClientRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.getElementsByClassName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.getElementsByTagName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.hasAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.hasAttributes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.hasPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.hidden",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.innerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.innerText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.insertAdjacentElement",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.insertAdjacentHTML",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.insertAdjacentText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.lang",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.localName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.matches",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.namespaceURI",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.offsetHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.offsetLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.offsetParent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.offsetTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.offsetWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.outerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.releasePointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.removeAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.removeAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.scrollHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.scrollIntoView",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.scrollIntoViewIfNeeded",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.scrollLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.scrollTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.scrollTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.scrollWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.setAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.setAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.setPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.shadowRoot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.slot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.style",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.tabIndex",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.tagName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLElement.uxpContainer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.assignedSlot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.attachShadow",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.autofocus",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.blur",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.className",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.click",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.clientHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.clientLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.clientTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.clientWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.closest",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.dataset",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.dir",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.disabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.focus",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.getAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.getAttributeNames",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.getAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.getBoundingClientRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.getElementsByClassName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.getElementsByTagName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.hasAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.hasAttributes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.hasPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.hidden",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.innerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.innerText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.insertAdjacentElement",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.insertAdjacentHTML",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.insertAdjacentText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.lang",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.localName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.matches",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.namespaceURI",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.offsetHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.offsetLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.offsetParent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.offsetTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.offsetWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.outerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.releasePointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.removeAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.removeAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.scrollHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.scrollIntoView",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.scrollIntoViewIfNeeded",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.scrollLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.scrollTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.scrollTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.scrollWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.setAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.setAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.setPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.shadowRoot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.slot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.style",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.tabIndex",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.tagName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHeadElement.uxpContainer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.assignedSlot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.attachShadow",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.autofocus",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.blur",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.className",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.click",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.clientHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.clientLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.clientTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.clientWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.closest",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.dataset",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.dir",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.disabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.focus",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.getAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.getAttributeNames",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.getAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.getBoundingClientRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.getElementsByClassName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.getElementsByTagName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.hasAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.hasAttributes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.hasPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.hidden",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.innerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.innerText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.insertAdjacentElement",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.insertAdjacentHTML",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.insertAdjacentText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.lang",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.localName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.matches",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.namespaceURI",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.offsetHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.offsetLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.offsetParent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.offsetTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.offsetWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.outerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.releasePointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.removeAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.removeAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.scrollHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.scrollIntoView",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.scrollIntoViewIfNeeded",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.scrollLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.scrollTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.scrollTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.scrollWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.setAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.setAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.setPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.shadowRoot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.slot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.style",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.tabIndex",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.tagName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLHtmlElement.uxpContainer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.assignedSlot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.attachShadow",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.autofocus",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.blur",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.className",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.click",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.clientHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.clientLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.clientTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.clientWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.closest",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.dataset",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.dir",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.disabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.focus",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.getAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.getAttributeNames",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.getAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.getBoundingClientRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.getElementsByClassName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.getElementsByTagName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.hasAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.hasAttributes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.hasPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.hidden",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.innerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.innerText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.insertAdjacentElement",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.insertAdjacentHTML",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.insertAdjacentText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.lang",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.localName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.matches",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.namespaceURI",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.offsetHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.offsetLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.offsetParent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.offsetTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.offsetWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.outerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.releasePointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.removeAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.removeAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.scrollHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.scrollIntoView",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.scrollIntoViewIfNeeded",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.scrollLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.scrollTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.scrollTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.scrollWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.setAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.setAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.setPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.shadowRoot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.slot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.src",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.style",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.tabIndex",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.tagName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLImageElement.uxpContainer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.assignedSlot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.attachShadow",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.autofocus",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.blur",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.checked",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.className",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.click",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.clientHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.clientLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.clientTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.clientWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.closest",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.dataset",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.defaultValue",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.dir",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.disabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.focus",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.getAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.getAttributeNames",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.getAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.getBoundingClientRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.getElementsByClassName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.getElementsByTagName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.hasAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.hasAttributes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.hasPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.hidden",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.indeterminate",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.innerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.innerText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.insertAdjacentElement",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.insertAdjacentHTML",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.insertAdjacentText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.lang",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.localName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.matches",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.max",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.min",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.name",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.namespaceURI",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.offsetHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.offsetLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.offsetParent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.offsetTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.offsetWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.outerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.placeholder",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.readOnly",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.releasePointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.removeAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.removeAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.scrollHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.scrollIntoView",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.scrollIntoViewIfNeeded",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.scrollLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.scrollTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.scrollTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.scrollWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.selectionEnd",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.selectionStart",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.setAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.setAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.setPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.shadowRoot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.slot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.step",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.style",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.tabIndex",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.tagName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.type",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.uxpContainer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.uxpQuiet",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.uxpVariant",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLInputElement.value",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.assignedSlot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.attachShadow",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.autofocus",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.blur",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.className",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.click",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.clientHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.clientLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.clientTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.clientWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.closest",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.control",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.dataset",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.dir",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.disabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.focus",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.getAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.getAttributeNames",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.getAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.getBoundingClientRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.getElementsByClassName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.getElementsByTagName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.hasAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.hasAttributes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.hasPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.hidden",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.innerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.innerText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.insertAdjacentElement",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.insertAdjacentHTML",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.insertAdjacentText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.lang",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.localName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.matches",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.namespaceURI",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.offsetHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.offsetLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.offsetParent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.offsetTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.offsetWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.outerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.releasePointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.removeAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.removeAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.scrollHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.scrollIntoView",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.scrollIntoViewIfNeeded",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.scrollLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.scrollTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.scrollTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.scrollWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.setAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.setAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.setPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.shadowRoot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.slot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.style",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.tabIndex",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.tagName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLabelElement.uxpContainer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.assignedSlot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.attachShadow",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.autofocus",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.blur",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.className",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.click",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.clientHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.clientLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.clientTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.clientWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.closest",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.dataset",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.dir",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.disabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.focus",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.getAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.getAttributeNames",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.getAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.getBoundingClientRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.getElementsByClassName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.getElementsByTagName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.hasAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.hasAttributes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.hasPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.hidden",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.innerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.innerText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.insertAdjacentElement",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.insertAdjacentHTML",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.insertAdjacentText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.lang",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.localName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.matches",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.namespaceURI",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.offsetHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.offsetLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.offsetParent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.offsetTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.offsetWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.outerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.releasePointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.removeAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.removeAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.scrollHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.scrollIntoView",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.scrollIntoViewIfNeeded",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.scrollLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.scrollTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.scrollTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.scrollWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.setAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.setAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.setPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.shadowRoot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.slot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.style",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.tabIndex",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.tagName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLLinkElement.uxpContainer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.assignedSlot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.attachShadow",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.autofocus",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.blur",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.className",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.click",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.clientHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.clientLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.clientTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.clientWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.closest",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.dataset",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.dir",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.disabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.focus",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.getAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.getAttributeNames",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.getAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.getBoundingClientRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.getElementsByClassName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.getElementsByTagName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.hasAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.hasAttributes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.hasPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.hidden",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.innerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.innerText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.insertAdjacentElement",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.insertAdjacentHTML",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.insertAdjacentText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.lang",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.localName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.matches",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.namespaceURI",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.offsetHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.offsetLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.offsetParent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.offsetTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.offsetWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.outerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.popupAt",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.releasePointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.removeAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.removeAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.scrollHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.scrollIntoView",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.scrollIntoViewIfNeeded",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.scrollLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.scrollTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.scrollTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.scrollWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.setAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.setAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.setPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.shadowRoot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.slot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.style",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.tabIndex",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.tagName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuElement.uxpContainer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.assignedSlot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.attachShadow",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.autofocus",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.blur",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.checked",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.className",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.click",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.clientHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.clientLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.clientTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.clientWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.closest",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.dataset",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.dir",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.disabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.focus",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.getAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.getAttributeNames",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.getAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.getBoundingClientRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.getElementsByClassName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.getElementsByTagName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.hasAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.hasAttributes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.hasPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.hidden",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.innerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.innerText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.insertAdjacentElement",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.insertAdjacentHTML",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.insertAdjacentText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.lang",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.localName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.matches",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.namespaceURI",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.offsetHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.offsetLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.offsetParent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.offsetTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.offsetWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.outerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.releasePointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.removeAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.removeAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.scrollHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.scrollIntoView",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.scrollIntoViewIfNeeded",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.scrollLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.scrollTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.scrollTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.scrollWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.setAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.setAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.setPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.shadowRoot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.slot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.style",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.tabIndex",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.tagName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLMenuItemElement.uxpContainer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.assignedSlot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.attachShadow",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.autofocus",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.blur",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.className",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.click",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.clientHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.clientLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.clientTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.clientWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.closest",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.dataset",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.dir",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.disabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.focus",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.getAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.getAttributeNames",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.getAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.getBoundingClientRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.getElementsByClassName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.getElementsByTagName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.hasAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.hasAttributes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.hasPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.hidden",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.innerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.innerText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.insertAdjacentElement",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.insertAdjacentHTML",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.insertAdjacentText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.lang",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.localName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.matches",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.namespaceURI",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.offsetHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.offsetLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.offsetParent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.offsetTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.offsetWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.outerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.releasePointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.removeAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.removeAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.scrollHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.scrollIntoView",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.scrollIntoViewIfNeeded",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.scrollLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.scrollTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.scrollTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.scrollWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.setAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.setAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.setPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.shadowRoot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.slot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.style",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.tabIndex",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.tagName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.uxpContainer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLOptionElement.value",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.assignedSlot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.attachShadow",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.autofocus",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.blur",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.className",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.click",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.clientHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.clientLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.clientTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.clientWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.closest",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.dataset",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.dir",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.disabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.focus",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.getAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.getAttributeNames",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.getAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.getBoundingClientRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.getElementsByClassName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.getElementsByTagName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.hasAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.hasAttributes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.hasPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.hidden",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.innerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.innerText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.insertAdjacentElement",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.insertAdjacentHTML",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.insertAdjacentText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.lang",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.localName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.matches",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.max",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.namespaceURI",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.offsetHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.offsetLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.offsetParent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.offsetTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.offsetWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.outerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.position",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.releasePointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.removeAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.removeAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.scrollHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.scrollIntoView",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.scrollIntoViewIfNeeded",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.scrollLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.scrollTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.scrollTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.scrollWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.setAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.setAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.setPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.shadowRoot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.slot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.style",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.tabIndex",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.tagName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.uxpContainer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLProgressElement.value",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.assignedSlot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.attachShadow",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.autofocus",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.blur",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.charset",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.className",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.click",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.clientHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.clientLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.clientTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.clientWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.closest",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.dataset",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.dir",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.disabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.focus",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.getAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.getAttributeNames",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.getAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.getBoundingClientRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.getElementsByClassName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.getElementsByTagName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.hasAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.hasAttributes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.hasPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.hidden",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.innerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.innerText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.insertAdjacentElement",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.insertAdjacentHTML",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.insertAdjacentText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.lang",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.localName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.matches",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.namespaceURI",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.offsetHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.offsetLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.offsetParent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.offsetTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.offsetWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.outerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.releasePointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.removeAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.removeAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.scrollHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.scrollIntoView",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.scrollIntoViewIfNeeded",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.scrollLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.scrollTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.scrollTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.scrollWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.setAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.setAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.setPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.shadowRoot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.slot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.src",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.style",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.tabIndex",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.tagName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.text",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.type",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLScriptElement.uxpContainer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.assignedSlot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.attachShadow",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.autofocus",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.blur",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.className",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.click",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.clientHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.clientLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.clientTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.clientWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.closest",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.dataset",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.dir",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.disabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.focus",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.getAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.getAttributeNames",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.getAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.getBoundingClientRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.getElementsByClassName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.getElementsByTagName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.hasAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.hasAttributes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.hasPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.hidden",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.innerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.innerText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.insertAdjacentElement",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.insertAdjacentHTML",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.insertAdjacentText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.lang",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.localName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.matches",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.namespaceURI",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.offsetHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.offsetLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.offsetParent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.offsetTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.offsetWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.options",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.outerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.releasePointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.removeAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.removeAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.scrollHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.scrollIntoView",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.scrollIntoViewIfNeeded",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.scrollLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.scrollTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.scrollTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.scrollWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.selectedIndex",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.selectedOptions",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.setAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.setAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.setPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.shadowRoot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.slot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.style",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.tabIndex",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.tagName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.uxpContainer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.uxpQuiet",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.uxpVariant",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSelectElement.value",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSlotElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSlotElement.assignedElements",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSlotElement.assignedNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLSlotElement.name",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.assignedSlot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.attachShadow",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.autofocus",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.blur",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.className",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.click",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.clientHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.clientLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.clientTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.clientWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.closest",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.dataset",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.dir",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.disabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.focus",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.getAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.getAttributeNames",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.getAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.getBoundingClientRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.getElementsByClassName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.getElementsByTagName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.hasAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.hasAttributes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.hasPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.hidden",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.innerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.innerText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.insertAdjacentElement",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.insertAdjacentHTML",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.insertAdjacentText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.lang",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.localName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.matches",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.namespaceURI",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.offsetHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.offsetLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.offsetParent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.offsetTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.offsetWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.outerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.releasePointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.removeAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.removeAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.scrollHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.scrollIntoView",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.scrollIntoViewIfNeeded",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.scrollLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.scrollTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.scrollTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.scrollWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.setAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.setAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.setPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.shadowRoot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.slot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.style",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.tabIndex",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.tagName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLStyleElement.uxpContainer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.assignedSlot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.attachShadow",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.autofocus",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.blur",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.className",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.click",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.clientHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.clientLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.clientTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.clientWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.closest",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.content",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.dataset",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.dir",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.disabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.focus",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.getAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.getAttributeNames",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.getAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.getBoundingClientRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.getElementsByClassName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.getElementsByTagName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.hasAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.hasAttributes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.hasPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.hidden",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.innerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.innerText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.insertAdjacentElement",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.insertAdjacentHTML",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.insertAdjacentText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.lang",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.localName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.matches",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.namespaceURI",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.offsetHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.offsetLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.offsetParent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.offsetTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.offsetWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.outerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.releasePointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.removeAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.removeAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.scrollHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.scrollIntoView",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.scrollIntoViewIfNeeded",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.scrollLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.scrollTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.scrollTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.scrollWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.setAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.setAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.setPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.shadowRoot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.slot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.style",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.tabIndex",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.tagName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTemplateElement.uxpContainer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.assignedSlot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.attachShadow",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.autofocus",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.blur",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.className",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.click",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.clientHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.clientLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.clientTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.clientWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.closest",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.dataset",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.defaultValue",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.dir",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.disabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.focus",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.getAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.getAttributeNames",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.getAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.getBoundingClientRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.getElementsByClassName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.getElementsByTagName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.hasAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.hasAttributes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.hasPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.hidden",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.innerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.innerText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.insertAdjacentElement",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.insertAdjacentHTML",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.insertAdjacentText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.lang",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.localName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.matches",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.namespaceURI",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.offsetHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.offsetLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.offsetParent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.offsetTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.offsetWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.outerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.placeholder",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.readOnly",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.releasePointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.removeAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.removeAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.scrollHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.scrollIntoView",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.scrollIntoViewIfNeeded",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.scrollLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.scrollTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.scrollTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.scrollWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.selectionEnd",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.selectionStart",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.setAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.setAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.setPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.shadowRoot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.slot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.style",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.tabIndex",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.tagName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.uxpContainer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLTextAreaElement.value",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.assignedSlot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.attachShadow",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.audioTracks",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.autofocus",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.autoplay",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.blur",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.canPlayType",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.className",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.click",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.clientHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.clientLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.clientTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.clientWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.closest",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.currentTime",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.dataset",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.dir",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.disabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.duration",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.ended",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.error",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.focus",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.getAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.getAttributeNames",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.getAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.getBoundingClientRect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.getElementsByClassName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.getElementsByTagName",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.hasAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.hasAttributes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.hasPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.hidden",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.innerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.innerText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.insertAdjacentElement",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.insertAdjacentHTML",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.insertAdjacentText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.lang",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.load",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.localName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.loop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.matches",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.muted",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.namespaceURI",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.offsetHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.offsetLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.offsetParent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.offsetTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.offsetWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.outerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.pause",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.paused",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.play",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.playbackRate",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.played",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.preload",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.querySelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.querySelectorAll",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.releasePointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.removeAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.removeAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.scrollHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.scrollIntoView",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.scrollIntoViewIfNeeded",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.scrollLeft",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.scrollTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.scrollTop",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.scrollWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.setAttribute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.setAttributeNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.setPointerCapture",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.shadowRoot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.slot",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.src",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.stop",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.style",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.tabIndex",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.tagName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.textTracks",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.uxpContainer",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.videoHeight",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.videoTracks",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.videoWidth",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLVideoElement.volume",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLWebViewElement",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLWebViewElement.height",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLWebViewElement.postMessage",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLWebViewElement.src",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLWebViewElement.uxpallowinspector",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HTMLWebViewElement.width",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Headers",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Headers.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Headers.append",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Headers.delete",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Headers.entries",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Headers.forEach",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Headers.get",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Headers.has",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Headers.keys",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Headers.set",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Headers.values",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.HostDefinition",
+      "kind": "type",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ImageBlob",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ImageBlob.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ImageBlob.arrayBuffer",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ImageBlob.size",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ImageBlob.slice",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ImageBlob.stream",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ImageBlob.text",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ImageBlob.type",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.IntegerArray",
+      "kind": "type",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.altKey",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.bubbles",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.cancelable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.code",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.composed",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.composedPath",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.ctrlKey",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.currentTarget",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.defaultPrevented",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.eventPhase",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.getModifierState",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.initEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.isTrusted",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.key",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.keyCode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.location",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.metaKey",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.preventDefault",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.repeat",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.returnValue",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.shiftKey",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.stopImmediatePropagation",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.stopPropagation",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.target",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.KeyboardEvent.type",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.LocalStorage",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.LocalStorage.clear",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.LocalStorage.getItem",
+      "kind": "method",
+      "coverage": "mapped"
+    },
+    {
+      "symbol": "globalThis.LocalStorage.key",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.LocalStorage.length",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.LocalStorage.removeItem",
+      "kind": "method",
+      "coverage": "mapped"
+    },
+    {
+      "symbol": "globalThis.LocalStorage.setItem",
+      "kind": "method",
+      "coverage": "mapped"
+    },
+    {
+      "symbol": "globalThis.MediaError",
+      "kind": "type",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.MessageEvent",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.MessageEvent.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.MessageEvent.bubbles",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.MessageEvent.cancelable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.MessageEvent.composed",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.MessageEvent.composedPath",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.MessageEvent.currentTarget",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.MessageEvent.data",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.MessageEvent.defaultPrevented",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.MessageEvent.eventPhase",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.MessageEvent.initEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.MessageEvent.isTrusted",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.MessageEvent.origin",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.MessageEvent.preventDefault",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.MessageEvent.returnValue",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.MessageEvent.source",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.MessageEvent.stopImmediatePropagation",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.MessageEvent.stopPropagation",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.MessageEvent.target",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.MessageEvent.type",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.MouseEvent",
+      "kind": "type",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.NamedNodeMap",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.NamedNodeMap.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.NamedNodeMap.getNamedItem",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.NamedNodeMap.item",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.NamedNodeMap.length",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.NamedNodeMap.removeNamedItem",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.NamedNodeMap.setNamedItem",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.ATTRIBUTE_NODE",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.COMMENT_NODE",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.DOCUMENT_FRAGMENT_NODE",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.DOCUMENT_NODE",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.ELEMENT_NODE",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.TEXT_NODE",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Node.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.NodeFilter",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.NodeList",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.NodeList.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.NodeList.entries",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.NodeList.forEach",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.NodeList.item",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.NodeList.keys",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.NodeList.length",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.NodeList.values",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path.basename",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path.delimiter",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path.dirname",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path.extname",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path.format",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path.isAbsolute",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path.join",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path.normalize",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path.parse",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path.posix",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path.relative",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path.resolve",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path.sep",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path.win32",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path2D",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path2D.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path2D.addPath",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path2D.arc",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path2D.arcTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path2D.bezierCurveTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path2D.closePath",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path2D.lineTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path2D.moveTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path2D.quadraticCurveTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Path2D.rect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Plugin",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Plugin.enabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Plugin.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Plugin.invokeCommand",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Plugin.manifest",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Plugin.name",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Plugin.showPanel",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Plugin.version",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.altKey",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.bubbles",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.button",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.buttons",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.cancelable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.clientX",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.clientY",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.composed",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.composedPath",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.ctrlKey",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.currentTarget",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.defaultPrevented",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.detail",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.eventPhase",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.height",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.initEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.isPrimary",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.isTrusted",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.metaKey",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.movementX",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.movementY",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.offsetX",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.offsetY",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.pageX",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.pageY",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.pointerId",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.pointerType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.pressure",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.preventDefault",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.returnValue",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.screenX",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.screenY",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.shiftKey",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.stopImmediatePropagation",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.stopPropagation",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.tangentialPressure",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.target",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.tiltX",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.tiltY",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.twist",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.type",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.which",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.PointerEvent.width",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ProgressEvent",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ProgressEvent.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ProgressEvent.bubbles",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ProgressEvent.cancelable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ProgressEvent.composed",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ProgressEvent.composedPath",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ProgressEvent.currentTarget",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ProgressEvent.defaultPrevented",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ProgressEvent.eventPhase",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ProgressEvent.initEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ProgressEvent.isTrusted",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ProgressEvent.lengthComputable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ProgressEvent.loaded",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ProgressEvent.preventDefault",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ProgressEvent.returnValue",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ProgressEvent.stopImmediatePropagation",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ProgressEvent.stopPropagation",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ProgressEvent.target",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ProgressEvent.total",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ProgressEvent.type",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ReadableStream",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ReadableStream.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ReadableStream.cancel",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ReadableStream.getReader",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ReadableStream.locked",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ReadableStream.pipeThrough",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ReadableStream.pipeTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ReadableStream.tee",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ReadableStreamDefaultController",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ReadableStreamDefaultController.close",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ReadableStreamDefaultController.desiredSize",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ReadableStreamDefaultController.enqueue",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ReadableStreamDefaultController.error",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ReadableStreamDefaultReader",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ReadableStreamDefaultReader.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ReadableStreamDefaultReader.cancel",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ReadableStreamDefaultReader.closed",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ReadableStreamDefaultReader.read",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ReadableStreamDefaultReader.releaseLock",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Request",
+      "kind": "type",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Response",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Response.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Response.arrayBuffer",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Response.blob",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Response.body",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Response.bodyUsed",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Response.clone",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Response.error",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Response.formData",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Response.headers",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Response.json",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Response.ok",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Response.redirect",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Response.status",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Response.statusText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Response.text",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Response.url",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.SessionStorage",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ShadowRoot",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ShadowRoot.activeElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ShadowRoot.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ShadowRoot.host",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ShadowRoot.innerHTML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.ShadowRoot.mode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Style",
+      "kind": "type",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.StyleSheetList",
+      "kind": "type",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.addEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.after",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.appendChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.appendData",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.attributes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.before",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.childNodes",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.children",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.cloneNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.contains",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.contentEditable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.data",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.deleteData",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.dispatchEvent",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.firstChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.firstElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.getRootNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.hasChildNodes",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.insertBefore",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.insertData",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.isConnected",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.lastChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.lastElementChild",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.length",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.nextElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.nextSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.nodeName",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.nodeType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.nodeValue",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.ownerDocument",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.parentElement",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.parentNode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.previousElementSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.previousSibling",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.removeChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.removeEventListener",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.replaceChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.replaceData",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.replaceWith",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.substringData",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.Text.textContent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.TextTrackList",
+      "kind": "type",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.TimeRanges",
+      "kind": "type",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.TransformStream",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.TransformStream.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.TransformStream.readable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.TransformStream.writable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.TransformStreamDefaultController",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.TransformStreamDefaultController.desiredSize",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.TransformStreamDefaultController.enqueue",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.TransformStreamDefaultController.error",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.TransformStreamDefaultController.terminate",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.TreeWalker",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.TreeWalker.filter",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.TreeWalker.firstChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.TreeWalker.lastChild",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.TreeWalker.nextNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.TreeWalker.nextSibling",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.TreeWalker.parentNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.TreeWalker.previousNode",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.TreeWalker.previousSibling",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.TreeWalker.root",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.TreeWalker.whatToShow",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.TypedArray",
+      "kind": "type",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UXPContainer",
+      "kind": "type",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpCommandInfo",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpCommandInfo.commandOptions",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpCommandInfo.description",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpCommandInfo.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpCommandInfo.isManifestCommand",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpCommandInfo.label",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpCommandInfo.shortcut",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpMenuItem",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpMenuItem.checked",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpMenuItem.enabled",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpMenuItem.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpMenuItem.label",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpMenuItem.parent",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpMenuItem.remove",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpMenuItem.submenu",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpMenuItems",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpMenuItems.getItem",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpMenuItems.getItemAt",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpMenuItems.insertAt",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpMenuItems.removeAt",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpMenuItems.size",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpPanelInfo",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpPanelInfo.description",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpPanelInfo.icons",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpPanelInfo.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpPanelInfo.label",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpPanelInfo.maximumSize",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpPanelInfo.menuItems",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpPanelInfo.minimumSize",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpPanelInfo.preferredDockedSize",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpPanelInfo.preferredFloatingSize",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpPanelInfo.shortcut",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpPanelInfo.title",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpPluginInfo",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpPluginInfo.id",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpPluginInfo.isFirstParty",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpPluginInfo.manifest",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpPluginInfo.name",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.UxpPluginInfo.version",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.VideoTrackList",
+      "kind": "type",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WebSocket",
+      "kind": "class",
+      "coverage": "mapped"
+    },
+    {
+      "symbol": "globalThis.WebSocket.CLOSED",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WebSocket.CLOSING",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WebSocket.CONNECTING",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WebSocket.OPEN",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WebSocket.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WebSocket.binaryType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WebSocket.bufferedAmount",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WebSocket.close",
+      "kind": "method",
+      "coverage": "mapped"
+    },
+    {
+      "symbol": "globalThis.WebSocket.protocol",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WebSocket.readyState",
+      "kind": "property",
+      "coverage": "mapped"
+    },
+    {
+      "symbol": "globalThis.WebSocket.send",
+      "kind": "method",
+      "coverage": "mapped"
+    },
+    {
+      "symbol": "globalThis.WebSocket.url",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WritableAndReadable",
+      "kind": "type",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WritableStream",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WritableStream.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WritableStream.abort",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WritableStream.close",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WritableStream.getWriter",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WritableStream.locked",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WritableStreamDefaultController",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WritableStreamDefaultController.error",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WritableStreamDefaultController.signal",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WritableStreamDefaultWriter",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WritableStreamDefaultWriter.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WritableStreamDefaultWriter.abort",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WritableStreamDefaultWriter.close",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WritableStreamDefaultWriter.closed",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WritableStreamDefaultWriter.desiredSize",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WritableStreamDefaultWriter.ready",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WritableStreamDefaultWriter.releaseLock",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.WritableStreamDefaultWriter.write",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest.DONE",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest.HEADERS_RECEIVED",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest.LOADING",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest.OPENED",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest.UNSENT",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest.abort",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest.getAllResponseHeaders",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest.getResponseHeader",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest.open",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest.overrideMimeType",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest.readyState",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest.response",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest.responseText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest.responseType",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest.responseURL",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest.responseXML",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest.send",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest.setRequestHeader",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest.status",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest.statusText",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest.timeout",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest.upload",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequest.withCredentials",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMLHttpRequestEventUpload",
+      "kind": "type",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPDateTime",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPDateTime.compareTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPDateTime.convertToLocalTime",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPDateTime.convertToUTCTime",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPDateTime.day",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPDateTime.getDate",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPDateTime.hasDate",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPDateTime.hasTime",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPDateTime.hasTimeZone",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPDateTime.hour",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPDateTime.minute",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPDateTime.month",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPDateTime.nanosecond",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPDateTime.second",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPDateTime.setLocalTimeZone",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPDateTime.toString",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPDateTime.tzHour",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPDateTime.tzMinute",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPDateTime.tzSign",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPDateTime.year",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPFile",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPFile.canPutXMP",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPFile.closeFile",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPFile.getFileInfo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPFile.getFormatInfo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPFile.getPacketInfo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPFile.getXMP",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPFile.putXMP",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPFileInfo",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPFileInfo.filePath",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPFileInfo.format",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPFileInfo.handlerFlags",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPFileInfo.openFlags",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPIterator",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPIterator.next",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPIterator.skipSiblings",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPIterator.skipSubtree",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPPacketInfo",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPPacketInfo.charForm",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPPacketInfo.length",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPPacketInfo.offset",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPPacketInfo.packet",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPPacketInfo.padSize",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPPacketInfo.writeable",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPProperty",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPProperty.locale",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPProperty.namespace",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPProperty.options",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPProperty.path",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPProperty.toString",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.XMPProperty.value",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.alert",
+      "kind": "function",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.confirm",
+      "kind": "function",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.crypto",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.document",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.fetch",
+      "kind": "function",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.get",
+      "kind": "function",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.guard",
+      "kind": "function",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.iterator",
+      "kind": "type",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.localStorage",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.path",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.prompt",
+      "kind": "function",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "globalThis.sessionStorage",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "os",
+      "kind": "module",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "os.OS",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "os.OS.arch",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "os.OS.cpus",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "os.OS.freemem",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "os.OS.homedir",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "os.OS.platform",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "os.OS.release",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "os.OS.totalmem",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "os._os",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp",
+      "kind": "module",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.EntryPoints",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.EntryPoints.getCommand",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.EntryPoints.getPanel",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.EntryPoints.setup",
+      "kind": "method",
+      "coverage": "mapped"
+    },
+    {
+      "symbol": "uxp.Host",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.Host.name",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.Host.uiLocale",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.Host.version",
+      "kind": "property",
+      "coverage": "mapped"
+    },
+    {
+      "symbol": "uxp.PluginManager",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.PluginManager.plugins",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.Script",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.Script.args",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.Script.executionContext",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.Script.setResult",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.SecureStorage",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.SecureStorage.clear",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.SecureStorage.getItem",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.SecureStorage.key",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.SecureStorage.length",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.SecureStorage.removeItem",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.SecureStorage.setItem",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.Shell",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.Shell.openExternal",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.Shell.openPath",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.UserInfo",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.UserInfo.userId",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.Versions",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.Versions.plugin",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.Versions.uxp",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPConst",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPDateTime",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPDateTime.compareTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPDateTime.convertToLocalTime",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPDateTime.convertToUTCTime",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPDateTime.day",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPDateTime.getDate",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPDateTime.hasDate",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPDateTime.hasTime",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPDateTime.hasTimeZone",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPDateTime.hour",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPDateTime.minute",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPDateTime.month",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPDateTime.nanosecond",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPDateTime.second",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPDateTime.setLocalTimeZone",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPDateTime.toString",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPDateTime.tzHour",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPDateTime.tzMinute",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPDateTime.tzSign",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPDateTime.year",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPFile",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPFile.canPutXMP",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPFile.closeFile",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPFile.getFileInfo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPFile.getFormatInfo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPFile.getPacketInfo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPFile.getXMP",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPFile.putXMP",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.[[construct]]",
+      "kind": "constructor",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.appendArrayItem",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.countArrayItems",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.deleteArrayItem",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.deleteNamespace",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.deleteProperty",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.deleteQualifier",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.deleteStructField",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.doesArrayItemExist",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.doesPropertyExist",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.doesQualifierExist",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.doesStructFieldExist",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.dumpNamespaces",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.dumpObject",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.getArrayItem",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.getLocalizedText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.getNamespacePrefix",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.getNamespaceURI",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.getProperty",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.getQualifier",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.getStructField",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.insertArrayItem",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.iterator",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.registerNamespace",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.serialize",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.serializeToArray",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.setArrayItem",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.setLocalizedText",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.setProperty",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.setQualifier",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.setStructField",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPMeta.sort",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPUtils",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPUtils.appendProperties",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPUtils.catenateArrayItems",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPUtils.composeArrayItemPath",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPUtils.composeFieldSelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPUtils.composeLangSelector",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPUtils.composeQualifierPath",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPUtils.composeStructFieldPath",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPUtils.duplicateSubtree",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPUtils.removeProperties",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.XMPUtils.separateArrayItems",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.entrypoints",
+      "kind": "variable",
+      "coverage": "mapped"
+    },
+    {
+      "symbol": "uxp.host",
+      "kind": "variable",
+      "coverage": "mapped"
+    },
+    {
+      "symbol": "uxp.pluginManager",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.script",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.secureStorage",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.shell",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage",
+      "kind": "module",
+      "coverage": "mapped"
+    },
+    {
+      "symbol": "uxp.storage.Entry",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.Entry.copyTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.Entry.delete",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.Entry.getMetadata",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.Entry.isEntry",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.Entry.isFile",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.Entry.isFolder",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.Entry.moveTo",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.Entry.name",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.Entry.nativePath",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.Entry.provider",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.Entry.toString",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.Entry.url",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.EntryMetadata",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.EntryMetadata.dateCreated",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.EntryMetadata.dateModified",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.EntryMetadata.isFile",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.EntryMetadata.isFolder",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.EntryMetadata.name",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.EntryMetadata.size",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.File",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.File.isFile",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.File.mode",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.File.read",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.File.write",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.FileSystemProvider",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.FileSystemProvider.createEntryWithUrl",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.FileSystemProvider.createPersistentToken",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.FileSystemProvider.createSessionToken",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.FileSystemProvider.getDataFolder",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.FileSystemProvider.getEntryForPersistentToken",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.FileSystemProvider.getEntryForSessionToken",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.FileSystemProvider.getEntryWithUrl",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.FileSystemProvider.getFileForOpening",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.FileSystemProvider.getFileForSaving",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.FileSystemProvider.getFolder",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.FileSystemProvider.getFsUrl",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.FileSystemProvider.getNativePath",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.FileSystemProvider.getPluginFolder",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.FileSystemProvider.getTemporaryFolder",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.FileSystemProvider.isFileSystemProvider",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.FileSystemProvider.supportedDomains",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.Folder",
+      "kind": "class",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.Folder.createEntry",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.Folder.createFile",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.Folder.createFolder",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.Folder.getEntries",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.Folder.getEntry",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.Folder.isFolder",
+      "kind": "property",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.Folder.renameEntry",
+      "kind": "method",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.domains",
+      "kind": "module",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.domains.appLocalCache",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.domains.appLocalData",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.domains.appLocalLibrary",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.domains.appLocalShared",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.domains.appLocalTemporary",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.domains.appRoamingData",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.domains.appRoamingLibrary",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.domains.userDesktop",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.domains.userDocuments",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.domains.userMusic",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.domains.userPictures",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.domains.userVideos",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.fileTypes",
+      "kind": "module",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.fileTypes.all",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.fileTypes.images",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.fileTypes.text",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.formats",
+      "kind": "module",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.formats.binary",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.formats.utf8",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.modes",
+      "kind": "module",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.modes.readOnly",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.modes.readWrite",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.types",
+      "kind": "module",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.types.file",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.storage.types.folder",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.userInfo",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.versions",
+      "kind": "variable",
+      "coverage": "unmapped"
+    },
+    {
+      "symbol": "uxp.xmp",
+      "kind": "variable",
+      "coverage": "unmapped"
+    }
+  ]
+}

--- a/src/resources/uxp-js-coverage.json
+++ b/src/resources/uxp-js-coverage.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": 1,
+  "entries": [
+    {
+      "implementation": "uxp-plugin/index.cjs",
+      "uxpApi": [
+        "uxp.entrypoints",
+        "uxp.EntryPoints.setup",
+        "uxp.host",
+        "uxp.Host.version",
+        "uxp.storage",
+        "globalThis.LocalStorage.getItem",
+        "globalThis.LocalStorage.removeItem",
+        "globalThis.LocalStorage.setItem",
+        "globalThis.WebSocket",
+        "globalThis.WebSocket.close",
+        "globalThis.WebSocket.readyState",
+        "globalThis.WebSocket.send"
+      ],
+      "evidence": "Static panel source mapping only; runtime availability remains host- and manifest-dependent."
+    }
+  ]
+}

--- a/tests/premiere-surface-registry.test.ts
+++ b/tests/premiere-surface-registry.test.ts
@@ -76,13 +76,20 @@ describe("Premiere API and competitor surface registry", () => {
     }
     expect(registry.integrationSurfaces.find((surface) => surface.id === "premiere-dom"))
       .toMatchObject({ inventoryState: "complete", implementationState: "partial" });
+    expect(registry.integrationSurfaces.find((surface) => surface.id === "uxp-javascript"))
+      .toMatchObject({
+        versionSource: "@adobe/cc-ext-uxp-types@7.3.1",
+        inventoryArtifact: "dist/resources/uxp-js-api-inventory.json",
+        inventoryState: "complete",
+        implementationState: "partial",
+      });
     expect(registry.integrationSurfaces.find((surface) => surface.id === "cep-extendscript"))
       .toMatchObject({
         authorityUrls: ["https://github.com/Adobe-CEP/Samples/tree/master/PProPanel"],
         communityReferenceUrls: ["https://ppro-scripting.docsforadobe.dev/"],
       });
     expect(registry.integrationSurfaces.filter((surface) => surface.inventoryState === "complete"))
-      .toHaveLength(1);
+      .toHaveLength(2);
   });
 
   it("pins reviewed competitor sources and explicit safe-adoption boundaries", () => {

--- a/tests/uxp-js-api-inventory.test.ts
+++ b/tests/uxp-js-api-inventory.test.ts
@@ -1,0 +1,56 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+
+const inventory = JSON.parse(readFileSync("src/resources/uxp-js-api-inventory.json", "utf8"));
+const coverage = JSON.parse(readFileSync("src/resources/uxp-js-coverage.json", "utf8"));
+
+describe("Adobe UXP JavaScript declaration inventory", () => {
+  it("accounts for every generated declaration symbol and exact panel mapping", () => {
+    expect(inventory.source).toMatchObject({
+      package: "@adobe/cc-ext-uxp-types",
+      version: "7.3.1",
+    });
+    expect(inventory.source.declarationsSha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(inventory.stats.total).toBe(inventory.entries.length);
+    expect(inventory.stats.mapped + inventory.stats.unmapped).toBe(inventory.stats.total);
+    expect(inventory.manifestOnly).toEqual([]);
+    expect(inventory.entries).toEqual(expect.arrayContaining([
+      expect.objectContaining({ symbol: "uxp.EntryPoints.setup", kind: "method", coverage: "mapped" }),
+      expect.objectContaining({ symbol: "uxp.Host.version", kind: "property", coverage: "mapped" }),
+      expect.objectContaining({ symbol: "uxp.storage.FileSystemProvider.getTemporaryFolder", kind: "method" }),
+      expect.objectContaining({ symbol: "globalThis.WebSocket.send", kind: "method", coverage: "mapped" }),
+      expect.objectContaining({ symbol: "fs.fs.readFile", kind: "method" }),
+      expect.objectContaining({ symbol: "os.OS.platform", kind: "method" }),
+    ]));
+  });
+
+  it("derives manifest-only drift from exact declaration identities", () => {
+    const declared = new Set(inventory.entries.map((entry: { symbol: string }) => entry.symbol));
+    const mapped = new Set(coverage.entries.flatMap((entry: { uxpApi: string[] }) => entry.uxpApi));
+    expect(inventory.manifestOnly).toEqual([...mapped].filter((symbol) => !declared.has(symbol)).sort());
+  });
+
+  it.each([
+    ["top-level", ";", "Unsupported top-level UXP declaration"],
+    ["member", "declare class Unsupported { ; }", "Unsupported anonymous UXP member"],
+    ["variable", "declare const { value }: any;", "Unsupported destructured UXP variable declaration"],
+    ["syntax", "declare class Unsupported {", "TypeScript declaration parse failed"],
+  ])("fails closed for unsupported %s syntax", (_label, declarations, expectedError) => {
+    const directory = mkdtempSync(join(tmpdir(), "uxp-js-api-inventory-"));
+    const fixture = join(directory, "index.d.ts");
+    writeFileSync(fixture, declarations);
+    try {
+      const result = spawnSync(process.execPath, ["scripts/generate-uxp-js-api-inventory.mjs", "--validate-only"], {
+        encoding: "utf8",
+        env: { ...process.env, UXP_JS_DECLARATIONS_PATH: fixture },
+      });
+      expect(result.status).not.toBe(0);
+      expect(result.stderr).toContain(expectedError);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- pin Adobe's current @adobe/cc-ext-uxp-types 7.3.1 declarations
- generate a fail-closed, hashed inventory of all 3,406 general UXP JavaScript symbols
- classify exact panel mappings separately from implementation and licensed-host evidence
- package the inventory and enforce registry artifact resolution during npm pack verification

## Validation
- npm run check (88 files, 1,898 tests)
- npm run pack:check
- git diff --check