### PR TITLE
Verify sequence, spot, and scene-edit mutations

### DIFF
--- a/docs/supported-actions.md
+++ b/docs/supported-actions.md
@@ -268,7 +268,7 @@ operation” when the tool has no enum-based mode.
 | `rename_project_item` | Default profile | Single operation | Rename a project item in the project panel. |
 | `rename_track` | Default profile | `track_type`: `video`, `audio` | Rename a video or audio track. |
 | `replace_clip` | Default profile | Single operation | Replace a clip on the timeline with a different project item, preserving position and duration |
-| `replace_clip_media` | Default profile | Single operation | Replace the source media of a clip on the timeline with a different project item, keeping the clip's position and duration. |
+| `replace_clip_media` | Default profile | Single operation | Unavailable by design: the legacy ExtendScript overwrite route cannot prove that replacing media preserves the original clip's trim, position, linked audio, or adjacent clips, so this tool performs no mutation. |
 | `reverse_clip` | Default profile | Single operation | Unavailable: Premiere does not expose a supported scripting API for reversing a timeline clip's playback direction. |
 | `ripple_delete` | Default profile | Single operation | Ripple delete a clip (removes clip and closes the gap). Uses QE DOM. |
 | `roll_edit` | Default profile | Single operation | Perform a verified roll edit at the outgoing cut of a clip using the public timeline DOM. |

--- a/docs/uxp-stable-workflows.md
+++ b/docs/uxp-stable-workflows.md
@@ -24,7 +24,7 @@ Premiere build.
 | Native effects pipeline | `manage_clip_effects_uxp` | `effects.catalog`, `effects.chain.get`, `effects.chain.add`, `effects.chain.remove` | Effect catalog allowlist; component-chain count and component readback after an action transaction |
 | Selection compound batch | `batch_selected_clips_uxp` | `selection.inspect`, `effects.selection.add`, `effects.selection.remove` | Preflight all selected items, then commit one action group and read every chain count back |
 | Deterministic timeline selection | `manage_timeline_selection_uxp` | `selection.fingerprints.inspect`, `selection.targets.inspect`, `selection.update` | Current or coordinate-resolved clips return active-sequence GUID and project-item/time fingerprints; mutations check them before one native selection update and exact readback |
-| Scene-edit detection | `detect_scene_edits_uxp` | `sceneEdit.detect` | Adobe host return plus selected-item count; no Undo or detection-count claim |
+| Scene-edit detection | `detect_scene_edits_uxp` | `sceneEdit.detect` | `createMarkers` requires selected project-item marker-GUID growth; cut/subclip modes return only Adobe's host result and selected-item count |
 | Proxy and ingest controller | `manage_proxy_ingest_uxp` | `proxy.inspect`, `proxy.attach`, `ingest.get`, `ingest.configure` | Proxy path/attachment readback; ingest state readback after transaction |
 | Offline relink repair | `relink_offline_media_uxp` | `media.relink` | Expected old path, offline default, capability check, then media-path and online-state readback |
 | Transactional metadata | `manage_metadata_uxp` | `metadata.get`, `metadata.update` | Project metadata and XMP are committed together and read back; each payload is size bounded |
@@ -67,9 +67,11 @@ documented as non-undoable. Their MCP workflows require
 Setting `override_compatibility_check` remains opt-in.
 
 `SequenceUtils.performSceneEditDetectionOnSelection()` is also kept outside the
-action-transaction claim. The workflow returns `committed_unverified` after Adobe's
-positive host result because the API does not return the number or identities of
-created cuts, markers, or subclips.
+action-transaction claim. For `createMarkers`, the workflow snapshots each selected
+item's project-item marker GUIDs and returns `verified` only when at least one GUID
+is added. Cut and subclip modes return `committed_unverified` after Adobe's positive
+host result because the API does not return the number or identities of created cuts
+or subclips.
 
 ## Filesystem authority
 

--- a/src/tools/clipboard.ts
+++ b/src/tools/clipboard.ts
@@ -173,6 +173,16 @@ export function getClipboardTools(bridgeOptions: BridgeOptions) {
 
     replace_clip_media: {
       description: "Unavailable by design: the legacy ExtendScript overwrite route cannot prove that replacing media preserves the original clip's trim, position, linked audio, or adjacent clips, so this tool performs no mutation.",
+      operationalCapability: {
+        backend: "local" as const,
+        backends: ["local" as const],
+        status: "unsupported" as const,
+        minimumPremiereVersion: null,
+        authority: "edit" as const,
+        verificationBoundary: "static_metadata_only" as const,
+        hostVerificationRequired: false,
+        notes: ["Unavailable by design; this tool returns a local negative result and never contacts Premiere."],
+      },
       parameters: {
         type: "object" as const,
         properties: {

--- a/src/tools/clipboard.ts
+++ b/src/tools/clipboard.ts
@@ -172,7 +172,7 @@ export function getClipboardTools(bridgeOptions: BridgeOptions) {
     },
 
     replace_clip_media: {
-      description: "Replace the source media of a clip on the timeline with a different project item, keeping the clip's position and duration.",
+      description: "Unavailable by design: the legacy ExtendScript overwrite route cannot prove that replacing media preserves the original clip's trim, position, linked audio, or adjacent clips, so this tool performs no mutation.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -187,30 +187,10 @@ export function getClipboardTools(bridgeOptions: BridgeOptions) {
         },
         required: ["clip_node_id", "new_item_id"],
       },
-      handler: async (args: { clip_node_id: string; new_item_id: string }) => {
-        const script = buildToolScript(`
-          var clipResult = __findClip("${escapeForExtendScript(args.clip_node_id)}");
-          if (!clipResult) return __error("Clip not found");
-          var newItem = __findProjectItem("${escapeForExtendScript(args.new_item_id)}");
-          if (!newItem) return __error("New project item not found: ${escapeForExtendScript(args.new_item_id)}");
-
-          var clip = clipResult.clip;
-          var seq = app.project.activeSequence;
-          var startTicks = clip.start.ticks;
-          var trackType = clipResult.trackType;
-          var trackIndex = clipResult.trackIndex;
-
-          // Overwrite at the same position with new media
-          if (trackType === "video") {
-            seq.overwriteClip(newItem, startTicks, trackIndex, -1);
-          } else {
-            seq.overwriteClip(newItem, startTicks, -1, trackIndex);
-          }
-
-          return __result({ replaced: true, clipName: clip.name, newSource: newItem.name });
-        `);
-        return sendCommand(script, bridgeOptions);
-      },
+      handler: async () => ({
+        success: false,
+        error: "replace_clip_media is unavailable because the legacy overwrite route cannot preserve and verify clip duration, placement, linked audio, and neighboring clips. No mutation was attempted.",
+      }),
     },
 
     batch_apply_effect: {

--- a/src/tools/sequence.ts
+++ b/src/tools/sequence.ts
@@ -107,7 +107,12 @@ export function getSequenceTools(bridgeOptions: BridgeOptions) {
           if (!seq || seq.name !== "${escapeForExtendScript(args.name)}") {
             return __error("Failed to create sequence from preset: ${escapeForExtendScript(presetPath)}");
           }
-          return __result({ created: true, name: seq.name, id: seq.sequenceID, presetUsed: "${escapeForExtendScript(presetPath)}" });
+          var sequenceId = String(seq.sequenceID);
+          var created = __findSequence(sequenceId);
+          if (!created || String(created.sequenceID) !== sequenceId) {
+            return __error("Premiere did not add the new sequence to the project collection; no creation success is reported.");
+          }
+          return __result({ created: true, verified: true, name: created.name, id: sequenceId, presetUsed: "${escapeForExtendScript(presetPath)}" });
         `);
         return sendCommand(script, bridgeOptions);
       },

--- a/src/tools/sequence.ts
+++ b/src/tools/sequence.ts
@@ -101,6 +101,10 @@ export function getSequenceTools(bridgeOptions: BridgeOptions) {
         }
 
         const script = buildToolScript(`
+          var beforeSequenceIds = {};
+          for (var i = 0; i < app.project.sequences.numSequences; i++) {
+            beforeSequenceIds[String(app.project.sequences[i].sequenceID)] = true;
+          }
           app.enableQE();
           qe.project.newSequence("${escapeForExtendScript(args.name)}", "${escapeForExtendScript(presetPath)}");
           var seq = app.project.activeSequence;
@@ -108,6 +112,9 @@ export function getSequenceTools(bridgeOptions: BridgeOptions) {
             return __error("Failed to create sequence from preset: ${escapeForExtendScript(presetPath)}");
           }
           var sequenceId = String(seq.sequenceID);
+          if (beforeSequenceIds[sequenceId]) {
+            return __error("Premiere did not create a new sequence; the active sequence already existed before the preset request.");
+          }
           var created = __findSequence(sequenceId);
           if (!created || String(created.sequenceID) !== sequenceId) {
             return __error("Premiere did not add the new sequence to the project collection; no creation success is reported.");

--- a/src/tools/spot-workflows.ts
+++ b/src/tools/spot-workflows.ts
@@ -359,12 +359,17 @@ function buildApplyScript(plan: SpotWorkflowPlan): string {
     for (var placementIndex = 0; placementIndex < requestedItems.length; placementIndex++) {
       var targetStart = placementIndex * ${plan.clip_duration_seconds};
       var targetEnd = targetStart + ${plan.clip_duration_seconds};
+      var audioCountBefore = audioTrack.clips.numItems;
       seq.insertClip(requestedItems[placementIndex], __secondsToTicks(targetStart).toString(), ${plan.video_track_index}, ${plan.audio_track_index});
       var placedClip = findPlacedClip(videoTrack, requestedItemIds[placementIndex], targetStart);
       if (!placedClip) return __error("Premiere did not add the requested video item at the planned frame; the assembly is not reported as verified");
       if (!trimPlacedClip(placedClip, targetEnd)) return __error("Premiere did not trim the placed video item to the previewed duration; the assembly is not reported as verified");
-      var placedAudio = findPlacedClip(audioTrack, requestedItemIds[placementIndex], targetStart);
-      if (placedAudio && !trimPlacedClip(placedAudio, targetEnd)) return __error("Premiere did not trim the placed audio item to the previewed duration; the assembly is not reported as verified");
+      var audioCountAfter = audioTrack.clips.numItems;
+      if (audioCountAfter > audioCountBefore) {
+        if (audioCountAfter !== audioCountBefore + 1) return __error("Premiere added an unexpected number of audio items; the assembly is not reported as verified");
+        var placedAudio = findPlacedClip(audioTrack, requestedItemIds[placementIndex], targetStart);
+        if (!placedAudio || !trimPlacedClip(placedAudio, targetEnd)) return __error("Premiere did not identify and trim the placed audio item to the previewed duration; the assembly is not reported as verified");
+      }
       usedNodeIds[String(placedClip.nodeId)] = true;
       placed.push({
         nodeId: String(placedClip.nodeId),

--- a/src/tools/spot-workflows.ts
+++ b/src/tools/spot-workflows.ts
@@ -343,25 +343,35 @@ function buildApplyScript(plan: SpotWorkflowPlan): string {
     var frameTolerance = __ticksToSeconds(frameTicks) + 0.000001;
     var placed = [];
     var usedNodeIds = {};
-    function findPlacedVideo(itemId, expectedStart) {
-      for (var clipIndex = 0; clipIndex < videoTrack.clips.numItems; clipIndex++) {
-        var candidate = videoTrack.clips[clipIndex];
+    function findPlacedClip(track, itemId, expectedStart) {
+      for (var clipIndex = 0; clipIndex < track.clips.numItems; clipIndex++) {
+        var candidate = track.clips[clipIndex];
         if (!candidate.projectItem || String(candidate.projectItem.nodeId) !== String(itemId) || usedNodeIds[String(candidate.nodeId)]) continue;
         if (Math.abs(__ticksToSeconds(candidate.start.ticks) - expectedStart) <= frameTolerance) return candidate;
       }
       return null;
     }
+    function trimPlacedClip(clip, targetEnd) {
+      var requestedEnd = new Time(); requestedEnd.ticks = __secondsToTicks(targetEnd).toString();
+      clip.end = requestedEnd;
+      return Math.abs(__ticksToSeconds(clip.end.ticks) - targetEnd) <= frameTolerance;
+    }
     for (var placementIndex = 0; placementIndex < requestedItems.length; placementIndex++) {
       var targetStart = placementIndex * ${plan.clip_duration_seconds};
+      var targetEnd = targetStart + ${plan.clip_duration_seconds};
       seq.insertClip(requestedItems[placementIndex], __secondsToTicks(targetStart).toString(), ${plan.video_track_index}, ${plan.audio_track_index});
-      var placedClip = findPlacedVideo(requestedItemIds[placementIndex], targetStart);
+      var placedClip = findPlacedClip(videoTrack, requestedItemIds[placementIndex], targetStart);
       if (!placedClip) return __error("Premiere did not add the requested video item at the planned frame; the assembly is not reported as verified");
+      if (!trimPlacedClip(placedClip, targetEnd)) return __error("Premiere did not trim the placed video item to the previewed duration; the assembly is not reported as verified");
+      var placedAudio = findPlacedClip(audioTrack, requestedItemIds[placementIndex], targetStart);
+      if (placedAudio && !trimPlacedClip(placedAudio, targetEnd)) return __error("Premiere did not trim the placed audio item to the previewed duration; the assembly is not reported as verified");
       usedNodeIds[String(placedClip.nodeId)] = true;
       placed.push({
         nodeId: String(placedClip.nodeId),
         projectItemId: requestedItemIds[placementIndex],
         startSeconds: __ticksToSeconds(placedClip.start.ticks),
         endSeconds: __ticksToSeconds(placedClip.end.ticks),
+        requestedDurationSeconds: ${plan.clip_duration_seconds},
         verified: true
       });
     }

--- a/tests/spot-workflows.test.ts
+++ b/tests/spot-workflows.test.ts
@@ -98,6 +98,10 @@ describe("spot workflow plans", () => {
     expect(script).toContain("Target sequence must be active before applying a spot workflow plan");
     expect(script).toContain("Target video and audio tracks must be empty");
     expect(script).toContain("Project item ID was not found exactly");
+    expect(script).toContain("function findPlacedClip(track, itemId, expectedStart)");
+    expect(script).toContain("function trimPlacedClip(clip, targetEnd)");
+    expect(script).toContain("clip.end = requestedEnd");
+    expect(script).toContain("requestedDurationSeconds");
     expect(script).toContain("scaleProperty.getValueAtKey");
     expect(script).toContain("__findClip(placed[cutIndex + 1].nodeId)");
     expect(script).toContain("__findQeClipByDomClip(qeTrack, placedInfo.clip)");

--- a/tests/spot-workflows.test.ts
+++ b/tests/spot-workflows.test.ts
@@ -100,6 +100,9 @@ describe("spot workflow plans", () => {
     expect(script).toContain("Project item ID was not found exactly");
     expect(script).toContain("function findPlacedClip(track, itemId, expectedStart)");
     expect(script).toContain("function trimPlacedClip(clip, targetEnd)");
+    expect(script).toContain("var audioCountBefore = audioTrack.clips.numItems");
+    expect(script).toContain("if (audioCountAfter > audioCountBefore)");
+    expect(script).toContain("did not identify and trim the placed audio item");
     expect(script).toContain("clip.end = requestedEnd");
     expect(script).toContain("requestedDurationSeconds");
     expect(script).toContain("scaleProperty.getValueAtKey");

--- a/tests/tools/regressions.test.ts
+++ b/tests/tools/regressions.test.ts
@@ -737,7 +737,10 @@ describe("issue #326 — sequence creation requires project-collection readback"
     const script = await scriptFor(sequence.create_sequence, {
       name: "Verified Sequence", preset_path: "/tmp/sequence.sqpreset",
     });
+    expect(script).toContain("var beforeSequenceIds = {}");
     expect(script).toContain("var sequenceId = String(seq.sequenceID)");
+    expect(script).toContain("if (beforeSequenceIds[sequenceId])");
+    expect(script).toContain("did not create a new sequence");
     expect(script).toContain("var created = __findSequence(sequenceId)");
     expect(script).toContain("no creation success is reported");
     expect(script).toContain("verified: true");

--- a/tests/tools/regressions.test.ts
+++ b/tests/tools/regressions.test.ts
@@ -728,3 +728,29 @@ describe("issue #324 — duplicate media requires distinct project-item node IDs
     expect(script).not.toContain("pathMap[path].length > 1");
   });
 });
+
+// https://github.com/leancoderkavy/premiere-pro-mcp/issues/326
+describe("issue #326 — sequence creation requires project-collection readback", () => {
+  const sequence = getSequenceTools(bridgeOptions);
+
+  it("does not report a QE-active sequence as created unless it is discoverable", async () => {
+    const script = await scriptFor(sequence.create_sequence, {
+      name: "Verified Sequence", preset_path: "/tmp/sequence.sqpreset",
+    });
+    expect(script).toContain("var sequenceId = String(seq.sequenceID)");
+    expect(script).toContain("var created = __findSequence(sequenceId)");
+    expect(script).toContain("no creation success is reported");
+    expect(script).toContain("verified: true");
+  });
+});
+
+// https://github.com/leancoderkavy/premiere-pro-mcp/issues/327
+describe("issue #327 — legacy media replacement is fail-closed", () => {
+  const clipboard = getClipboardTools(bridgeOptions);
+
+  it("never uses overwriteClip when duration and adjacent-track preservation cannot be verified", async () => {
+    const result = await clipboard.replace_clip_media.handler({ clip_node_id: "clip-1", new_item_id: "item-2" } as never);
+    expect(result).toMatchObject({ success: false, error: expect.stringContaining("No mutation was attempted") });
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+  });
+});

--- a/tests/tools/regressions.test.ts
+++ b/tests/tools/regressions.test.ts
@@ -749,6 +749,9 @@ describe("issue #327 — legacy media replacement is fail-closed", () => {
   const clipboard = getClipboardTools(bridgeOptions);
 
   it("never uses overwriteClip when duration and adjacent-track preservation cannot be verified", async () => {
+    expect(clipboard.replace_clip_media.operationalCapability).toMatchObject({
+      backend: "local", backends: ["local"], status: "unsupported", hostVerificationRequired: false,
+    });
     const result = await clipboard.replace_clip_media.handler({ clip_node_id: "clip-1", new_item_id: "item-2" } as never);
     expect(result).toMatchObject({ success: false, error: expect.stringContaining("No mutation was attempted") });
     expect(mockedSendCommand).not.toHaveBeenCalled();

--- a/tests/uxp/stable-workflows.test.ts
+++ b/tests/uxp/stable-workflows.test.ts
@@ -233,6 +233,9 @@ describe("stable Premiere UXP workflow expansion", () => {
     expect(capabilities.commands["effects.selection.add"]).toMatchObject({
       supported: true, documented: true, destructive: true, undoable: true,
     });
+    expect(capabilities.commands["sceneEdit.detect"]).toMatchObject({
+      supported: true, minHostVersion: "26.3.0",
+    });
     expect(capabilities.commands["selection.update"]).toMatchObject({
       supported: true, documented: true, readOnly: false, destructive: false,
       undoable: false, idempotent: true, minHostVersion: "25.6.0",

--- a/tests/uxp/stable-workflows.test.ts
+++ b/tests/uxp/stable-workflows.test.ts
@@ -728,6 +728,9 @@ describe("stable Premiere UXP workflow expansion", () => {
       });
       expect(value.ppro.SequenceUtils.performSceneEditDetectionOnSelection)
         .toHaveBeenLastCalledWith(hostOperation, expect.any(Object));
+      if (mode === "createMarkers") {
+        expect(value.ppro.Markers.getMarkers).toHaveBeenCalledWith(value.sourceClip);
+      }
     }
   });
 

--- a/tests/uxp/stable-workflows.test.ts
+++ b/tests/uxp/stable-workflows.test.ts
@@ -119,6 +119,8 @@ function stableHost() {
     getAudioTrackCount: vi.fn(async () => 1),
     getAudioTrack: vi.fn(async () => audioTrack),
   };
+  const markerValues: Array<{ guid: string }> = [];
+  const markers = { getMarkers: vi.fn(async () => markerValues) };
   const root = { isFolder: true, getItems: vi.fn(async () => [sourceClip]) };
   let projectMetadata = "project-before", xmpMetadata = "xmp-before", ingestEnabled = false;
   const ingestSettings = {
@@ -174,8 +176,12 @@ function stableHost() {
       SEQUENCE_OPERATION_APPLYCUT: "ApplyCuts",
       SEQUENCE_OPERATION_CREATEMARKER: "CreateMarkers",
       SEQUENCE_OPERATION_CREATESUBCLIP: "CreateSubclips",
-      performSceneEditDetectionOnSelection: vi.fn(async () => true),
+      performSceneEditDetectionOnSelection: vi.fn(async (operation: string) => {
+        if (operation === "CreateMarkers") markerValues.push({ guid: `marker-${markerValues.length + 1}` });
+        return true;
+      }),
     },
+    Markers: { getMarkers: vi.fn(async () => markers) },
     ProjectSettings: {
       getIngestSettings: vi.fn(async () => ingestSettings),
       createSetIngestSettingsAction: vi.fn(() => ({ apply: () => undefined })),
@@ -717,12 +723,19 @@ describe("stable Premiere UXP workflow expansion", () => {
       ["createSubclips", "CreateSubclips"],
     ]) {
       await expect(value.registry.dispatch("sceneEdit.detect", { mode })).resolves.toMatchObject({
-        detected: true, mode, selectedItemCount: 1, outcome: "committed_unverified",
+        detected: true, mode, selectedItemCount: 1, outcome: mode === "createMarkers" ? "verified" : "committed_unverified",
         operation: { mutatesProject: true, undo: { supported: false } },
       });
       expect(value.ppro.SequenceUtils.performSceneEditDetectionOnSelection)
         .toHaveBeenLastCalledWith(hostOperation, expect.any(Object));
     }
+  });
+
+  it("refuses to report scene-marker detection when marker readback is unchanged", async () => {
+    const value = stableHost();
+    value.ppro.SequenceUtils.performSceneEditDetectionOnSelection.mockImplementationOnce(async () => true);
+    await expect(value.registry.dispatch("sceneEdit.detect", { mode: "createMarkers" }))
+      .rejects.toMatchObject({ code: "UXP_VERIFICATION_FAILED" });
   });
 
   it("guards non-undoable proxy/relink calls and verifies host readback", async () => {

--- a/uxp-plugin/workflows.cjs
+++ b/uxp-plugin/workflows.cjs
@@ -37,7 +37,7 @@
       "selection.update": { idempotent: true, minHostVersion: "25.6.0", probe: canManageSelection, handler: updateSelection },
       "effects.selection.add": { destructive: true, undoable: true, targetCapabilityProbe: true, minHostVersion: "25.6.0", probe: canUseEffectsSelection, handler: addEffectToSelection },
       "effects.selection.remove": { destructive: true, undoable: true, targetCapabilityProbe: true, minHostVersion: "25.6.0", probe: canUseEffectsSelection, handler: removeEffectFromSelection },
-      "sceneEdit.detect": { destructive: true, undoable: false, minHostVersion: "25.6.0", probe: canDetectScenes, handler: detectScenes },
+      "sceneEdit.detect": { destructive: true, undoable: false, minHostVersion: "26.3.0", probe: canDetectScenes, handler: detectScenes },
       "proxy.inspect": { readOnly: true, targetCapabilityProbe: true, minHostVersion: "25.6.0", probe: canUseClipItems, handler: inspectProxy },
       "proxy.attach": { destructive: true, undoable: false, idempotent: true, targetCapabilityProbe: true, requiresWorkspace: true, minHostVersion: "25.6.0", probe: canAttachProxy, handler: attachProxy },
       "ingest.get": { readOnly: true, minHostVersion: "25.6.0", probe: canUseIngest, handler: getIngest },

--- a/uxp-plugin/workflows.cjs
+++ b/uxp-plugin/workflows.cjs
@@ -694,6 +694,13 @@
       assertObject(args); assertOnlyKeys(args, ["mode", "operationId"]);
       const mode = enumValue(args.mode, "mode", ["applyCuts", "createMarkers", "createSubclips"]);
       const context = await activeContext(false), selected = await selectedTrackItems(context.sequence);
+      let markersBefore = null;
+      if (mode === "createMarkers") {
+        if (!ppro.Markers || typeof ppro.Markers.getMarkers !== "function") throw commandError("UXP_COMMAND_UNAVAILABLE", "Premiere marker readback is required before scene-marker detection can run");
+        const collection = await ppro.Markers.getMarkers(context.sequence);
+        if (!collection || typeof collection.getMarkers !== "function") throw commandError("UXP_COMMAND_UNAVAILABLE", "Premiere did not expose a marker collection for scene-marker readback");
+        markersBefore = Array.from(await collection.getMarkers() || []).length;
+      }
       const utils = ppro.SequenceUtils, names = {
         applyCuts: "SEQUENCE_OPERATION_APPLYCUT",
         createMarkers: "SEQUENCE_OPERATION_CREATEMARKER",
@@ -703,6 +710,21 @@
       if (typeof operation !== "string" || !operation) throw commandError("UXP_COMMAND_UNAVAILABLE", "Premiere scene-edit operation constants are unavailable");
       const detected = await utils.performSceneEditDetectionOnSelection(operation, selected.selection);
       if (!detected) throw commandError("UXP_VERIFICATION_FAILED", "Premiere did not confirm scene-edit detection");
+      if (mode === "createMarkers") {
+        const collection = await ppro.Markers.getMarkers(context.sequence);
+        if (!collection || typeof collection.getMarkers !== "function") throw commandError("UXP_VERIFICATION_FAILED", "Premiere could not read scene markers after detection");
+        const markersAfter = Array.from(await collection.getMarkers() || []).length;
+        if (markersAfter <= markersBefore) throw commandError("UXP_VERIFICATION_FAILED", "Premiere reported scene-marker detection but did not add observable markers");
+        return {
+          detected: true, verified: true, mode, selectedItemCount: selected.items.length,
+          markerCountBefore: markersBefore, markerCountAfter: markersAfter, addedMarkerCount: markersAfter - markersBefore,
+          outcome: "verified", verificationBoundary: "marker_collection_count_readback",
+          operation: operationSemantics({
+            mutatesProject: true, verificationStatus: "verified", verificationBoundary: "marker_collection_count_readback",
+            verificationEvidence: [{ type: "marker_count_delta", before: markersBefore, after: markersAfter }], undoSupported: false, cancellationSupported: true
+          })
+        };
+      }
       return {
         detected: true, outcome: "committed_unverified", mode, selectedItemCount: selected.items.length,
         verificationBoundary: "sequence_utils_host_return",

--- a/uxp-plugin/workflows.cjs
+++ b/uxp-plugin/workflows.cjs
@@ -694,12 +694,27 @@
       assertObject(args); assertOnlyKeys(args, ["mode", "operationId"]);
       const mode = enumValue(args.mode, "mode", ["applyCuts", "createMarkers", "createSubclips"]);
       const context = await activeContext(false), selected = await selectedTrackItems(context.sequence);
+      const markerSnapshot = async () => {
+        if (!ppro.Markers || typeof ppro.Markers.getMarkers !== "function") throw commandError("UXP_COMMAND_UNAVAILABLE", "Premiere marker readback is required before scene-marker detection can run");
+        const ownerIds = new Set(), markerIds = new Set();
+        for (const trackItem of selected.items) {
+          if (!trackItem || typeof trackItem.getProjectItem !== "function") throw commandError("UXP_COMMAND_UNAVAILABLE", "Selected timeline items must expose project-item marker owners for scene-marker readback");
+          const owner = await trackItem.getProjectItem(), ownerId = await projectItemIdentifier(owner);
+          if (!ownerId || ownerIds.has(ownerId)) continue;
+          ownerIds.add(ownerId);
+          const collection = await ppro.Markers.getMarkers(castProjectItem(owner));
+          if (!collection || typeof collection.getMarkers !== "function") throw commandError("UXP_COMMAND_UNAVAILABLE", "Premiere did not expose a marker collection for a selected scene-edit item");
+          for (const marker of Array.from(await collection.getMarkers() || [])) {
+            let markerId = "";
+            try { markerId = marker && marker.guid != null ? String(marker.guid) : ""; } catch (_) {}
+            if (markerId) markerIds.add(ownerId + ":" + markerId);
+          }
+        }
+        return { ownerIds: Array.from(ownerIds), markerIds: Array.from(markerIds) };
+      };
       let markersBefore = null;
       if (mode === "createMarkers") {
-        if (!ppro.Markers || typeof ppro.Markers.getMarkers !== "function") throw commandError("UXP_COMMAND_UNAVAILABLE", "Premiere marker readback is required before scene-marker detection can run");
-        const collection = await ppro.Markers.getMarkers(context.sequence);
-        if (!collection || typeof collection.getMarkers !== "function") throw commandError("UXP_COMMAND_UNAVAILABLE", "Premiere did not expose a marker collection for scene-marker readback");
-        markersBefore = Array.from(await collection.getMarkers() || []).length;
+        markersBefore = await markerSnapshot();
       }
       const utils = ppro.SequenceUtils, names = {
         applyCuts: "SEQUENCE_OPERATION_APPLYCUT",
@@ -711,17 +726,15 @@
       const detected = await utils.performSceneEditDetectionOnSelection(operation, selected.selection);
       if (!detected) throw commandError("UXP_VERIFICATION_FAILED", "Premiere did not confirm scene-edit detection");
       if (mode === "createMarkers") {
-        const collection = await ppro.Markers.getMarkers(context.sequence);
-        if (!collection || typeof collection.getMarkers !== "function") throw commandError("UXP_VERIFICATION_FAILED", "Premiere could not read scene markers after detection");
-        const markersAfter = Array.from(await collection.getMarkers() || []).length;
-        if (markersAfter <= markersBefore) throw commandError("UXP_VERIFICATION_FAILED", "Premiere reported scene-marker detection but did not add observable markers");
+        const markersAfter = await markerSnapshot(), addedMarkerIds = markersAfter.markerIds.filter((id) => markersBefore.markerIds.indexOf(id) < 0);
+        if (!addedMarkerIds.length) throw commandError("UXP_VERIFICATION_FAILED", "Premiere reported scene-marker detection but did not add observable selected-item markers");
         return {
           detected: true, verified: true, mode, selectedItemCount: selected.items.length,
-          markerCountBefore: markersBefore, markerCountAfter: markersAfter, addedMarkerCount: markersAfter - markersBefore,
-          outcome: "verified", verificationBoundary: "marker_collection_count_readback",
+          markerOwnerCount: markersAfter.ownerIds.length, addedMarkerCount: addedMarkerIds.length,
+          outcome: "verified", verificationBoundary: "selected_project_item_marker_guid_readback",
           operation: operationSemantics({
-            mutatesProject: true, verificationStatus: "verified", verificationBoundary: "marker_collection_count_readback",
-            verificationEvidence: [{ type: "marker_count_delta", before: markersBefore, after: markersAfter }], undoSupported: false, cancellationSupported: true
+            mutatesProject: true, verificationStatus: "verified", verificationBoundary: "selected_project_item_marker_guid_readback",
+            verificationEvidence: [{ type: "selected_project_item_marker_guid_delta", addedMarkerCount: addedMarkerIds.length }], undoSupported: false, cancellationSupported: true
           })
         };
       }


### PR DESCRIPTION
Fixes #326, #327, #328, and #330.\n\n- require project-collection readback before legacy sequence creation reports success\n- withdraw unsafe legacy clip-media replacement rather than overwrite clips without trim or adjacent-track preservation\n- trim and read back each spot-workflow video/audio insertion to its previewed duration\n- require observable marker-count growth before UXP scene-marker detection reports success\n\nVerification: focused 78-test suite, TypeScript build, UXP lint, and generated supported-actions catalog. Licensed-host verification remains not_run.