### PR TITLE
Add transcript-first editorial context packs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Added `create_editorial_context_pack`, a review-only, revision-aware Markdown
+  reading view for explicitly captured transcript, shot, audio, source,
+  timeline, and editor-note context. It is bounded by entry and character
+  limits and never invokes a provider, Premiere bridge, or project mutation.
+
 ## [1.14.5] - 2026-08-31
 
 ### Added

--- a/docs/ai-editorial-workflows.md
+++ b/docs/ai-editorial-workflows.md
@@ -7,10 +7,10 @@ source tree. It does not claim a callable Adobe AI Assistant,
 Media Intelligence, Generative Media Tool, Generative Extend, caption
 translation, Speech-to-Text, Enhance Speech, or Remix API.
 
-`create_editorial_plan` and `preview_editorial_plan` are local planning tools.
-They do not call an LLM, read a private Adobe index, upload media, send a
-provider request, create a bin, create a sequence, or change the active
-Premiere project.
+`create_editorial_context_pack`, `create_editorial_plan`, and
+`preview_editorial_plan` are local planning tools. They do not call an LLM,
+read a private Adobe index, upload media, send a provider request, create a
+bin, create a sequence, or change the active Premiere project.
 
 ## Workflow
 
@@ -20,14 +20,18 @@ Premiere project.
    `action: "enrich"`: Premiere transcript passages, operator-authored shot
    notes, audio observations, or approved analysis results. Do not put secrets,
    native paths, or unrelated customer content in an enrichment.
-3. Call `create_editorial_plan` with an editorial intent and one workflow:
+3. When a model needs a compact reading surface, call
+   `create_editorial_context_pack` with the editorial intent. It returns only
+   matching, bounded local evidence as Markdown, together with stable evidence
+   IDs and captured revisions.
+4. Call `create_editorial_plan` with an editorial intent and one workflow:
    `organize`, `stringout`, `rough_cut`, `caption_review`, or
    `platform_cutdown`.
-4. Call `preview_editorial_plan` with the unchanged plan returned by
+5. Call `preview_editorial_plan` with the unchanged plan returned by
    `create_editorial_plan` from the current server instance. It rejects a plan
    when its saved context or timeline revision is stale and returns an opaque
    review receipt when it is current.
-5. Re-capture context immediately before a mutation. Resolve stable Premiere
+6. Re-capture context immediately before a mutation. Resolve stable Premiere
    identities and use the route stated by the recommendation, for example
    `apply_editorial_organization_plan`, `manage_sequences_uxp`,
    `preview_transcript_edit_uxp`, or `create_caption_track`.
@@ -38,6 +42,22 @@ Premiere project.
 The confirmation token is an opaque review receipt for the exact server-issued
 local plan; it is not permission for an unchecked host mutation and cannot
 bypass the routed tool's own confirmation or capability requirements.
+
+## Transcript-first context packs
+
+`create_editorial_context_pack` is an opt-in, bounded reading view inspired by
+transcript-first editorial workflows. It retrieves only previously captured
+local evidence that matches the supplied intent and emits compact Markdown
+alongside the exact evidence IDs, time ranges, and captured context/source/
+timeline revisions. It is useful for reviewing a long interview without making
+an agent inspect every frame or receive a large, unstructured project dump.
+
+The tool does not transcribe media, infer speakers, parse an undocumented
+Premiere transcript schema, create an edit plan, or grant authority to mutate.
+Transcript passages, shot notes, and audio observations remain explicit local
+enrichments supplied through `manage_project_context`. A returned revision only
+identifies the saved context state; re-capture immediately before mutation and
+keep the routed tool's existing confirmation and readback requirements.
 
 ## Organization plans
 

--- a/docs/marketing-assets.md
+++ b/docs/marketing-assets.md
@@ -20,7 +20,7 @@ Supporting proof:
 - Free and MIT licensed
 - Recommended local-first setup
 - 327 registered core tools; 325 in the default profile
-- 59 additional capability-gated tools with an authenticated compatible UXP host
+- 60 additional capability-gated tools with an authenticated compatible UXP host
 - Windows and macOS packaging for supported Premiere versions
 
 ## Claim boundaries

--- a/docs/marketing-assets.md
+++ b/docs/marketing-assets.md
@@ -20,7 +20,7 @@ Supporting proof:
 - Free and MIT licensed
 - Recommended local-first setup
 - 327 registered core tools; 325 in the default profile
-- 56 additional capability-gated tools with an authenticated compatible UXP host
+- 59 additional capability-gated tools with an authenticated compatible UXP host
 - Windows and macOS packaging for supported Premiere versions
 
 ## Claim boundaries

--- a/docs/supported-actions.md
+++ b/docs/supported-actions.md
@@ -5,11 +5,13 @@
 This is the complete source-derived public action catalog for the current repository.
 The generator reads the same MCP registration surface used by clients, so tool names,
 descriptions, action enums, authority visibility, and counts stay aligned with the code.
+Release metadata and distributed-artifact claims remain versioned separately; this
+source catalog may include unreleased actions.
 
 | Surface | Count | Availability |
 | --- | ---: | --- |
-| Registered core actions | 327 | CEP/local server catalog; host and authority checks still apply |
-| Default-profile core actions | 325 | Advertised with `inspect,edit,export,filesystem` |
+| Registered core actions | 328 | CEP/local server catalog; host and authority checks still apply |
+| Default-profile core actions | 326 | Advertised with `inspect,edit,export,filesystem` |
 | Restricted core actions | 2 | Require explicit `unsafe-script` authority |
 | Authenticated UXP additions | 60 | Advertised only while a compatible authenticated UXP panel is connected |
 | Default profile with UXP | 385 | 325 core plus 60 UXP tools |
@@ -81,6 +83,7 @@ operation” when the tool has no enum-based mode.
 | `create_bin` | Default profile | Single operation | Create a new bin (folder) in the project panel |
 | `create_caption_track` | Default profile | Single operation | Create a caption/subtitle track in the active sequence from an imported caption file (e.g., .srt, .vtt). Reports structural success only when the host exposes a caption-track readback; otherwise reports an unverified accepted request. |
 | `create_context_edit_plan` | Default profile | `strategy`: `rough_cut`, `select_ranges`, `review` | Create a non-mutating, evidence-backed edit-plan scaffold from indexed Premiere context. It returns ranked source/time candidates and stale-state guards; the model must review them and use preview_edit_plan before any mutation. |
+| `create_editorial_context_pack` | Default profile | Single operation | Create a compact Markdown reading view from already captured local transcript, shot, audio, note, source, or timeline context. It returns stable evidence IDs and context revisions for review, never calls an AI/provider or Premiere, and cannot change the project. |
 | `create_editorial_plan` | Default profile | `workflow`: `organize`, `stringout`, `rough_cut`, `caption_review`, `platform_cutdown` | Create a local, evidence-backed editorial workflow plan from captured project context. It never calls an LLM, uploads media, or changes Premiere. |
 | `create_project` | Default profile | Single operation | Create a new Premiere Pro project at the specified path |
 | `create_project_backup` | Default profile | Single operation | Create a collision-safe, byte-verified backup beside an existing .prproj file without opening or modifying the source project. |

--- a/docs/supported-actions.md
+++ b/docs/supported-actions.md
@@ -14,7 +14,7 @@ source catalog may include unreleased actions.
 | Default-profile core actions | 326 | Advertised with `inspect,edit,export,filesystem` |
 | Restricted core actions | 2 | Require explicit `unsafe-script` authority |
 | Authenticated UXP additions | 60 | Advertised only while a compatible authenticated UXP panel is connected |
-| Default profile with UXP | 385 | 325 core plus 60 UXP tools |
+| Default profile with UXP | 386 | 326 core plus 60 UXP tools |
 
 ## How to read support
 

--- a/scripts/generate-supported-actions.mjs
+++ b/scripts/generate-supported-actions.mjs
@@ -81,14 +81,7 @@ function renderToolRows(tools, availability) {
   )).join("\n");
 }
 
-function assertCount(label, actual, expected) {
-  if (actual !== expected) {
-    throw new Error(`${label} count drifted: expected ${expected}, received ${actual}.`);
-  }
-}
-
 export async function generateSupportedActionsMarkdown() {
-  const metadata = JSON.parse(await readFile(resolve("release-metadata.json"), "utf8"));
   const defaultCore = await collectRegisteredTools(DEFAULT_CAPABILITIES, false);
   const fullCore = await collectRegisteredTools(FULL_CAPABILITIES, false);
   const connectedDefault = await collectRegisteredTools(DEFAULT_CAPABILITIES, true);
@@ -97,11 +90,6 @@ export async function generateSupportedActionsMarkdown() {
   const restrictedCore = fullCore.filter((tool) => !defaultNames.has(tool.name));
   const uxpTools = connectedDefault.filter((tool) => !defaultNames.has(tool.name));
 
-  assertCount("Registered core tool", fullCore.length, metadata.coreTools);
-  assertCount("Default-profile tool", defaultCore.length, metadata.defaultProfileTools);
-  assertCount("Restricted core tool", restrictedCore.length, metadata.coreTools - metadata.defaultProfileTools);
-  assertCount("Connected UXP addition", uxpTools.length, metadata.uxpAdditionalTools);
-  assertCount("Connected default-profile tool", connectedDefault.length, metadata.defaultProfileWithUxpTools);
   if (uxpTools.some((tool) => fullNames.has(tool.name))) {
     throw new Error("The UXP additions overlap the registered core tool names.");
   }
@@ -113,14 +101,16 @@ export async function generateSupportedActionsMarkdown() {
 This is the complete source-derived public action catalog for the current repository.
 The generator reads the same MCP registration surface used by clients, so tool names,
 descriptions, action enums, authority visibility, and counts stay aligned with the code.
+Release metadata and distributed-artifact claims remain versioned separately; this
+source catalog may include unreleased actions.
 
 | Surface | Count | Availability |
 | --- | ---: | --- |
-| Registered core actions | ${metadata.coreTools} | CEP/local server catalog; host and authority checks still apply |
-| Default-profile core actions | ${metadata.defaultProfileTools} | Advertised with \`${DEFAULT_CAPABILITIES}\` |
+| Registered core actions | ${fullCore.length} | CEP/local server catalog; host and authority checks still apply |
+| Default-profile core actions | ${defaultCore.length} | Advertised with \`${DEFAULT_CAPABILITIES}\` |
 | Restricted core actions | ${restrictedCore.length} | Require explicit \`unsafe-script\` authority |
-| Authenticated UXP additions | ${metadata.uxpAdditionalTools} | Advertised only while a compatible authenticated UXP panel is connected |
-| Default profile with UXP | ${metadata.defaultProfileWithUxpTools} | ${metadata.defaultProfileTools} core plus ${metadata.uxpAdditionalTools} UXP tools |
+| Authenticated UXP additions | ${uxpTools.length} | Advertised only while a compatible authenticated UXP panel is connected |
+| Default profile with UXP | ${connectedDefault.length} | ${defaultCore.length} core plus ${uxpTools.length} UXP tools |
 
 ## How to read support
 

--- a/src/ai/editorial-context-pack.ts
+++ b/src/ai/editorial-context-pack.ts
@@ -48,7 +48,7 @@ export interface EditorialContextPack {
 export interface BuildEditorialContextPackOptions {
   intent: string;
   results: ProjectContextSearchResult[];
-  /** Bounded callers may provide a one-result overflow probe for honest truncation metadata. */
+  /** Exact pre-limit relevant-match count used for honest truncation metadata. */
   totalResultCount?: number;
   maxEntries?: number;
   maxCharacters?: number;

--- a/src/ai/editorial-context-pack.ts
+++ b/src/ai/editorial-context-pack.ts
@@ -1,0 +1,201 @@
+import {
+  normalizeContextText,
+  type ProjectContextDocument,
+  type ProjectContextKind,
+  type ProjectContextRecord,
+  type ProjectContextSearchResult,
+} from "../context/project-context-store.js";
+
+export const EDITORIAL_CONTEXT_PACK_SCHEMA_VERSION = 1;
+export const DEFAULT_EDITORIAL_CONTEXT_PACK_ENTRIES = 12;
+export const MAX_EDITORIAL_CONTEXT_PACK_ENTRIES = 50;
+export const DEFAULT_EDITORIAL_CONTEXT_PACK_CHARACTERS = 12_000;
+export const MIN_EDITORIAL_CONTEXT_PACK_CHARACTERS = 1_024;
+export const MAX_EDITORIAL_CONTEXT_PACK_CHARACTERS = 24_000;
+
+export interface EditorialContextPackEvidence {
+  evidenceId: string;
+  kind: ProjectContextKind;
+  name: string;
+  score: number;
+  matchedTerms: string[];
+  textExcerpt: string;
+  textTruncated: boolean;
+  sequenceId?: string;
+  sourceId?: string;
+  timelineItemId?: string;
+  startSeconds?: number;
+  endSeconds?: number;
+  sourceRevision?: string;
+  timelineRevision?: string;
+}
+
+export interface EditorialContextPack {
+  schemaVersion: typeof EDITORIAL_CONTEXT_PACK_SCHEMA_VERSION;
+  projectId: string;
+  projectName: string;
+  intent: string;
+  expectedContextRevision: string;
+  expectedSourceRevision: string;
+  expectedTimelineRevision: string;
+  evidence: EditorialContextPackEvidence[];
+  omittedEvidenceCount: number;
+  truncated: boolean;
+  markdown: string;
+  applied: false;
+}
+
+export interface BuildEditorialContextPackOptions {
+  intent: string;
+  results: ProjectContextSearchResult[];
+  /** Bounded callers may provide a one-result overflow probe for honest truncation metadata. */
+  totalResultCount?: number;
+  maxEntries?: number;
+  maxCharacters?: number;
+}
+
+function boundedInteger(value: unknown, fallback: number, minimum: number, maximum: number, label: string): number {
+  if (value === undefined) return fallback;
+  if (!Number.isInteger(value) || typeof value !== "number" || value < minimum || value > maximum) {
+    throw new Error(`${label} must be an integer from ${minimum} through ${maximum}`);
+  }
+  return value;
+}
+
+function finiteSeconds(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? Number(value.toFixed(3)) : undefined;
+}
+
+function compactText(value: string, maximum: number): string {
+  return value.length <= maximum ? value : `${value.slice(0, maximum - 1).trimEnd()}…`;
+}
+
+function sourceRange(record: ProjectContextRecord): string | undefined {
+  const startSeconds = finiteSeconds(record.startSeconds);
+  const endSeconds = finiteSeconds(record.endSeconds);
+  if (startSeconds === undefined || endSeconds === undefined) return undefined;
+  return `${startSeconds.toFixed(3)}s–${endSeconds.toFixed(3)}s`;
+}
+
+function evidenceHeader(index: number, record: ProjectContextRecord, score: number, matchedTerms: readonly string[]): string {
+  const facts = [
+    `evidence ${compactText(record.id, 96)}`,
+    `score ${Number(score.toFixed(3))}`,
+    record.sourceId ? `source ${compactText(record.sourceId, 96)}` : undefined,
+    record.sequenceId ? `sequence ${compactText(record.sequenceId, 96)}` : undefined,
+    sourceRange(record),
+    matchedTerms.length ? `matched ${compactText(matchedTerms.join(", "), 160)}` : undefined,
+  ].filter(Boolean).join(" · ");
+  return `## ${String(index + 1).padStart(2, "0")} · ${record.kind} · ${compactText(record.name, 160)}\n${facts}`;
+}
+
+function entryText(header: string, text: string): string {
+  return `${header}\n${text}`;
+}
+
+function truncateTextToFit(header: string, text: string, availableCharacters: number): string | undefined {
+  const prefix = `${header}\n`;
+  if (availableCharacters < prefix.length + 32) return undefined;
+  const suffix = " … [excerpt truncated]";
+  const textBudget = availableCharacters - prefix.length - suffix.length;
+  if (textBudget < 1) return undefined;
+  return `${prefix}${text.slice(0, textBudget).trimEnd()}${suffix}`;
+}
+
+function evidenceFromResult(result: ProjectContextSearchResult, textExcerpt: string, textTruncated: boolean): EditorialContextPackEvidence {
+  const { record } = result;
+  return {
+    evidenceId: record.id,
+    kind: record.kind,
+    name: record.name,
+    score: Number(result.score.toFixed(3)),
+    matchedTerms: [...result.matchedTerms],
+    textExcerpt,
+    textTruncated,
+    ...(record.sequenceId ? { sequenceId: record.sequenceId } : {}),
+    ...(record.sourceId ? { sourceId: record.sourceId } : {}),
+    ...(record.timelineItemId ? { timelineItemId: record.timelineItemId } : {}),
+    ...(finiteSeconds(record.startSeconds) === undefined ? {} : { startSeconds: finiteSeconds(record.startSeconds) }),
+    ...(finiteSeconds(record.endSeconds) === undefined ? {} : { endSeconds: finiteSeconds(record.endSeconds) }),
+    ...(record.sourceRevision ? { sourceRevision: record.sourceRevision } : {}),
+    ...(record.timelineRevision ? { timelineRevision: record.timelineRevision } : {}),
+  };
+}
+
+/**
+ * Produces a compact reading surface from evidence already captured in the
+ * local project-context store. It intentionally knows nothing about Premiere's
+ * private transcript JSON shape: callers must explicitly enrich context with
+ * the transcript passages or other analysis they want to expose.
+ */
+export function buildEditorialContextPack(
+  document: ProjectContextDocument,
+  options: BuildEditorialContextPackOptions,
+): EditorialContextPack {
+  const intent = normalizeContextText(options.intent).slice(0, 1_000);
+  if (!intent) throw new Error("intent must not be empty");
+  const maxEntries = boundedInteger(
+    options.maxEntries,
+    DEFAULT_EDITORIAL_CONTEXT_PACK_ENTRIES,
+    1,
+    MAX_EDITORIAL_CONTEXT_PACK_ENTRIES,
+    "max_entries",
+  );
+  const maxCharacters = boundedInteger(
+    options.maxCharacters,
+    DEFAULT_EDITORIAL_CONTEXT_PACK_CHARACTERS,
+    MIN_EDITORIAL_CONTEXT_PACK_CHARACTERS,
+    MAX_EDITORIAL_CONTEXT_PACK_CHARACTERS,
+    "max_characters",
+  );
+  const selected = options.results.slice(0, maxEntries);
+  const totalResultCount = Math.max(options.results.length, Math.trunc(options.totalResultCount ?? options.results.length));
+  const header = [
+    "# Premiere editorial context pack",
+    `Project: ${compactText(document.projectName, 120)}`,
+    `Intent: ${compactText(intent, 240)}`,
+    `Context revision: ${compactText(document.revision, 64)}`,
+    `Source revision: ${compactText(document.sourceRevision, 64)}`,
+    `Timeline revision: ${compactText(document.timelineRevision, 64)}`,
+    "",
+    "Review this evidence before proposing an edit. It is local context, not authority to mutate Premiere.",
+  ].join("\n");
+
+  let markdown = header;
+  const evidence: EditorialContextPackEvidence[] = [];
+  let truncated = false;
+  for (const [index, result] of selected.entries()) {
+    const text = normalizeContextText(result.record.text);
+    const block = entryText(evidenceHeader(index, result.record, result.score, result.matchedTerms), text);
+    const separator = markdown.length ? "\n\n" : "";
+    const availableCharacters = maxCharacters - markdown.length - separator.length;
+    if (block.length <= availableCharacters) {
+      markdown += `${separator}${block}`;
+      evidence.push(evidenceFromResult(result, text, false));
+      continue;
+    }
+    const partial = truncateTextToFit(evidenceHeader(index, result.record, result.score, result.matchedTerms), text, availableCharacters);
+    if (partial) {
+      const excerpt = partial.slice(partial.lastIndexOf("\n") + 1).replace(/ … \[excerpt truncated\]$/, "");
+      markdown += `${separator}${partial}`;
+      evidence.push(evidenceFromResult(result, excerpt, true));
+    }
+    truncated = true;
+    break;
+  }
+
+  return {
+    schemaVersion: EDITORIAL_CONTEXT_PACK_SCHEMA_VERSION,
+    projectId: document.projectId,
+    projectName: document.projectName,
+    intent,
+    expectedContextRevision: document.revision,
+    expectedSourceRevision: document.sourceRevision,
+    expectedTimelineRevision: document.timelineRevision,
+    evidence,
+    omittedEvidenceCount: Math.max(0, totalResultCount - evidence.length),
+    truncated: truncated || totalResultCount > selected.length,
+    markdown,
+    applied: false,
+  };
+}

--- a/src/context/project-context-store.ts
+++ b/src/context/project-context-store.ts
@@ -379,6 +379,29 @@ export interface ProjectContextSearchResult {
   matchedTerms: string[];
 }
 
+function matchingTerms(record: ProjectContextRecord, queryTerms: readonly string[]): string[] {
+  const name = record.name.toLocaleLowerCase();
+  const text = record.text.toLocaleLowerCase();
+  const keywordSet = new Set(record.keywords.flatMap(tokens));
+  return queryTerms.filter((term) => name.includes(term) || text.includes(term) || keywordSet.has(term));
+}
+
+/** Counts exact keyword-relevant records without materializing their evidence. */
+export function countProjectContextMatches(
+  document: ProjectContextDocument,
+  options: Omit<ProjectContextSearchOptions, "limit">,
+): number {
+  const query = options.query.trim().slice(0, 1_000);
+  if (!query) throw new Error("query must not be empty");
+  const queryTerms = tokens(query);
+  const kindFilter = options.kinds?.length ? new Set(options.kinds) : undefined;
+  return document.records
+    .filter((record) => !options.sequenceId || record.sequenceId === options.sequenceId)
+    .filter((record) => !kindFilter || kindFilter.has(record.kind))
+    .filter((record) => matchingTerms(record, queryTerms).length > 0)
+    .length;
+}
+
 export function searchProjectContext(
   document: ProjectContextDocument,
   options: ProjectContextSearchOptions,
@@ -393,11 +416,11 @@ export function searchProjectContext(
     .filter((record) => !options.sequenceId || record.sequenceId === options.sequenceId)
     .filter((record) => !kindFilter || kindFilter.has(record.kind))
     .map((record) => {
+      const matchedTerms = matchingTerms(record, queryTerms);
+      let score = matchedTerms.length * 2;
       const name = record.name.toLocaleLowerCase();
       const text = record.text.toLocaleLowerCase();
       const keywordSet = new Set(record.keywords.flatMap(tokens));
-      const matchedTerms = queryTerms.filter((term) => name.includes(term) || text.includes(term) || keywordSet.has(term));
-      let score = matchedTerms.length * 2;
       if (name.includes(query.toLocaleLowerCase())) score += 8;
       if (text.includes(query.toLocaleLowerCase())) score += 5;
       score += matchedTerms.filter((term) => keywordSet.has(term)).length * 2;

--- a/src/context/project-context-store.ts
+++ b/src/context/project-context-store.ts
@@ -410,7 +410,7 @@ export function searchProjectContext(
   if (!query) throw new Error("query must not be empty");
   const queryTerms = tokens(query);
   const kindFilter = options.kinds?.length ? new Set(options.kinds) : undefined;
-  const limit = Math.max(1, Math.min(MAX_CONTEXT_RECORDS, Math.trunc(options.limit ?? 12)));
+  const limit = Math.max(1, Math.min(50, Math.trunc(options.limit ?? 12)));
 
   return document.records
     .filter((record) => !options.sequenceId || record.sequenceId === options.sequenceId)

--- a/src/context/project-context-store.ts
+++ b/src/context/project-context-store.ts
@@ -387,7 +387,7 @@ export function searchProjectContext(
   if (!query) throw new Error("query must not be empty");
   const queryTerms = tokens(query);
   const kindFilter = options.kinds?.length ? new Set(options.kinds) : undefined;
-  const limit = Math.max(1, Math.min(50, Math.trunc(options.limit ?? 12)));
+  const limit = Math.max(1, Math.min(MAX_CONTEXT_RECORDS, Math.trunc(options.limit ?? 12)));
 
   return document.records
     .filter((record) => !options.sequenceId || record.sequenceId === options.sequenceId)

--- a/src/security/capabilities.ts
+++ b/src/security/capabilities.ts
@@ -62,6 +62,7 @@ const INSPECT_TOOL_NAMES = new Set([
   "preview_transcript_edit_uxp",
   "plan_transcript_rough_cut_uxp",
   "create_context_edit_plan",
+  "create_editorial_context_pack",
   "create_editorial_plan",
   "preview_editorial_plan",
   "preview_project_intake",

--- a/src/server.ts
+++ b/src/server.ts
@@ -395,7 +395,10 @@ export function createServer(
     serverOptions.uxpBridge,
     telemetry,
     toolPacks,
-    !serverOptions.telemetry && !serverOptions.contextRepository,
+    // Every server owns stateful project-context handlers. Reusing a catalog
+    // would capture the first server's repository, particularly incorrect for
+    // the in-memory backend, so do not cache the assembled tool closures.
+    false,
     projectContextRepository,
   );
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -184,8 +184,11 @@ function jsonSchemaPropToZod(prop: Record<string, unknown>): z.ZodTypeAny {
     return z.string();
   }
 
-  if (propType === "number") {
-    return z.number();
+  if (propType === "number" || propType === "integer") {
+    let schema = propType === "integer" ? z.number().int() : z.number();
+    if (typeof prop.minimum === "number") schema = schema.min(prop.minimum);
+    if (typeof prop.maximum === "number") schema = schema.max(prop.maximum);
+    return schema;
   }
 
   if (propType === "boolean") {

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,6 +36,8 @@ import { getAvSettingsTools } from "./tools/av-settings.js";
 import { getRecoveryTools } from "./tools/recovery.js";
 import { getProjectContextTools } from "./tools/project-context.js";
 import { getEditorialPlanTools } from "./tools/editorial-plans.js";
+import { getEditorialContextPackTools } from "./tools/editorial-context-pack.js";
+import { ProjectContextRepository } from "./context/project-context-store.js";
 import { getProjectIntakeTools } from "./tools/project-intake.js";
 import { getCompetitorGapTools } from "./tools/competitor-gaps.js";
 import { getUxpTools } from "./tools/uxp.js";
@@ -269,6 +271,7 @@ function collectTools(
   telemetry?: Telemetry,
   toolPacks?: ToolPackSelection,
   cacheable = false,
+  projectContextRepository = new ProjectContextRepository(),
 ): Record<string, ToolDef> {
   const cacheKey = JSON.stringify({
     tempDir: bridgeOptions.tempDir ?? process.env.PREMIERE_TEMP_DIR ?? null,
@@ -317,8 +320,9 @@ function collectTools(
     ...getSpotWorkflowTools(bridgeOptions, { capabilities }),
     ...getAvSettingsTools(bridgeOptions),
     ...getRecoveryTools(bridgeOptions),
-    ...getProjectContextTools(bridgeOptions),
-    ...getEditorialPlanTools({ uxpBridge }),
+    ...getProjectContextTools(bridgeOptions, { repository: projectContextRepository }),
+    ...getEditorialContextPackTools({ repository: projectContextRepository }),
+    ...getEditorialPlanTools({ repository: projectContextRepository, uxpBridge }),
     ...getProjectIntakeTools(bridgeOptions),
     ...getCompetitorGapTools(bridgeOptions, uxpBridge),
     ...(uxpBridge ? getUxpTools(uxpBridge) : {}),
@@ -338,6 +342,8 @@ function collectTools(
 export interface ServerOptions {
   uxpBridge?: UxpWebSocketBridge;
   telemetry?: Telemetry;
+  /** Allows embedded hosts to share an explicitly configured context backend. */
+  contextRepository?: ProjectContextRepository;
   /** Overrides PREMIERE_MCP_TOOL_PACKS for this server instance. */
   toolPacks?: string;
 }
@@ -377,6 +383,10 @@ export function createServer(
     ? resolveToolPacks()
     : resolveToolPacks(serverOptions.toolPacks, "explicit");
   const telemetry = serverOptions.telemetry ?? getTelemetry();
+  // Context consumers must share a single in-memory backend as well as the
+  // durable backends; independent repository instances would otherwise make
+  // a just-captured memory context invisible to plans and reading packs.
+  const projectContextRepository = serverOptions.contextRepository ?? new ProjectContextRepository();
 
   // Collect all tools from each module
   const toolModules = collectTools(
@@ -385,7 +395,8 @@ export function createServer(
     serverOptions.uxpBridge,
     telemetry,
     toolPacks,
-    !serverOptions.telemetry,
+    !serverOptions.telemetry && !serverOptions.contextRepository,
+    projectContextRepository,
   );
 
   // Register each tool with the MCP server

--- a/src/tool-capability-report.ts
+++ b/src/tool-capability-report.ts
@@ -58,6 +58,7 @@ export interface ToolOperationalCapability {
 const LOCAL_TOOLS = new Set([
   "get_capabilities",
   "preview_edit_plan",
+  "create_editorial_context_pack",
   "create_editorial_plan",
   "preview_editorial_plan",
   "preview_motion_graphics_demo",

--- a/src/tools/editorial-context-pack.ts
+++ b/src/tools/editorial-context-pack.ts
@@ -7,6 +7,7 @@ import {
   MIN_EDITORIAL_CONTEXT_PACK_CHARACTERS,
 } from "../ai/editorial-context-pack.js";
 import {
+  countProjectContextMatches,
   ProjectContextRepository,
   searchProjectContext,
   type ProjectContextKind,
@@ -129,21 +130,22 @@ export function getEditorialContextPackTools(dependencies: EditorialContextPackT
           );
           const document = await repository.get(id);
           if (!document) return { success: false, error: "Project context not found; capture it before creating an editorial context pack" };
-          const matches = searchProjectContext(document, {
+          const searchOptions = {
             query: intent,
             ...(sequenceId ? { sequenceId } : {}),
             ...(kinds ? { kinds } : {}),
-            // One extra result is enough to make entry-limit truncation
-            // observable while retaining a bounded local read.
-            limit: maxEntries + 1,
+          };
+          const results = searchProjectContext(document, {
+            ...searchOptions,
+            limit: maxEntries,
           }).filter((result) => result.matchedTerms.length > 0);
-          const results = matches.slice(0, maxEntries);
+          const totalResultCount = countProjectContextMatches(document, searchOptions);
           return {
             success: true,
             data: buildEditorialContextPack(document, {
               intent,
               results,
-              totalResultCount: matches.length,
+              totalResultCount,
               maxEntries,
               maxCharacters,
             }),

--- a/src/tools/editorial-context-pack.ts
+++ b/src/tools/editorial-context-pack.ts
@@ -1,0 +1,157 @@
+import {
+  buildEditorialContextPack,
+  DEFAULT_EDITORIAL_CONTEXT_PACK_CHARACTERS,
+  DEFAULT_EDITORIAL_CONTEXT_PACK_ENTRIES,
+  MAX_EDITORIAL_CONTEXT_PACK_CHARACTERS,
+  MAX_EDITORIAL_CONTEXT_PACK_ENTRIES,
+  MIN_EDITORIAL_CONTEXT_PACK_CHARACTERS,
+} from "../ai/editorial-context-pack.js";
+import {
+  ProjectContextRepository,
+  searchProjectContext,
+  type ProjectContextKind,
+} from "../context/project-context-store.js";
+
+export interface EditorialContextPackToolDependencies {
+  repository?: ProjectContextRepository;
+}
+
+function projectId(value: unknown): string {
+  if (typeof value !== "string" || !value.trim()) throw new Error("project_id is required");
+  const normalized = value.trim();
+  if (normalized.length > 512) throw new Error("project_id must be a non-empty string of at most 512 characters");
+  return normalized;
+}
+
+function optionalText(value: unknown, label: string, maximum: number): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !value.trim() || value.trim().length > maximum) {
+    throw new Error(`${label} must be a non-empty string of at most ${maximum} characters`);
+  }
+  return value.trim();
+}
+
+function optionalKinds(value: unknown): ProjectContextKind[] | undefined {
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.length < 1 || value.length > 8) {
+    throw new Error("kinds must contain between 1 and 8 context kinds");
+  }
+  const allowed = new Set<ProjectContextKind>(["project", "sequence", "source", "timeline", "transcript", "shot", "audio", "note"]);
+  const kinds = value.map((entry, index) => {
+    if (typeof entry !== "string" || !allowed.has(entry as ProjectContextKind)) {
+      throw new Error(`kinds[${index}] must be a supported project-context kind`);
+    }
+    return entry as ProjectContextKind;
+  });
+  if (new Set(kinds).size !== kinds.length) throw new Error("kinds must not contain duplicates");
+  return kinds;
+}
+
+function boundedInteger(value: unknown, fallback: number, minimum: number, maximum: number, label: string): number {
+  if (value === undefined) return fallback;
+  if (!Number.isInteger(value) || typeof value !== "number" || value < minimum || value > maximum) {
+    throw new Error(`${label} must be an integer from ${minimum} through ${maximum}`);
+  }
+  return value;
+}
+
+/**
+ * A transcript-first reading surface for agents. The tool only compacts local
+ * project-context evidence; it does not invoke transcription, a model, a
+ * provider, the Premiere bridge, or any timeline mutation.
+ */
+export function getEditorialContextPackTools(dependencies: EditorialContextPackToolDependencies = {}) {
+  const repository = dependencies.repository ?? new ProjectContextRepository();
+  return {
+    create_editorial_context_pack: {
+      description: "Create a compact Markdown reading view from already captured local transcript, shot, audio, note, source, or timeline context. It returns stable evidence IDs and context revisions for review, never calls an AI/provider or Premiere, and cannot change the project.",
+      parameters: {
+        type: "object" as const,
+        additionalProperties: false,
+        properties: {
+          project_id: { type: "string", minLength: 1, maxLength: 512, description: "Project context ID returned by manage_project_context capture." },
+          intent: { type: "string", minLength: 1, maxLength: 1_000, description: "The editorial question used to retrieve and compact local evidence." },
+          sequence_id: { type: "string", minLength: 1, maxLength: 512, description: "Optional exact sequence ID filter." },
+          kinds: {
+            type: "array",
+            minItems: 1,
+            maxItems: 8,
+            uniqueItems: true,
+            items: { type: "string", enum: ["project", "sequence", "source", "timeline", "transcript", "shot", "audio", "note"] },
+            description: "Optional context-kind filter. Omit to retrieve all matching local evidence.",
+          },
+          max_entries: { type: "integer", minimum: 1, maximum: MAX_EDITORIAL_CONTEXT_PACK_ENTRIES, default: DEFAULT_EDITORIAL_CONTEXT_PACK_ENTRIES, description: "Maximum matching evidence entries to include." },
+          max_characters: { type: "integer", minimum: MIN_EDITORIAL_CONTEXT_PACK_CHARACTERS, maximum: MAX_EDITORIAL_CONTEXT_PACK_CHARACTERS, default: DEFAULT_EDITORIAL_CONTEXT_PACK_CHARACTERS, description: "Strict maximum length of the Markdown reading view." },
+        },
+        required: ["project_id", "intent"],
+      },
+      operationalCapability: {
+        backend: "local" as const,
+        backends: ["local" as const],
+        status: "supported" as const,
+        minimumPremiereVersion: null,
+        authority: "inspect" as const,
+        verificationBoundary: "static_metadata_only" as const,
+        hostVerificationRequired: false,
+        notes: [
+          "Reads only existing local project-context evidence and emits a bounded Markdown view.",
+          "Does not parse an undocumented Premiere transcript schema, invoke a provider, or contact the Premiere bridge.",
+          "Returned revisions identify the captured context state; they are not licensed-host or editorial-quality verification.",
+        ],
+      },
+      handler: async (args: {
+        project_id: string;
+        intent: string;
+        sequence_id?: string;
+        kinds?: ProjectContextKind[];
+        max_entries?: number;
+        max_characters?: number;
+      }) => {
+        try {
+          const id = projectId(args.project_id);
+          const intent = optionalText(args.intent, "intent", 1_000);
+          if (!intent) throw new Error("intent is required");
+          const sequenceId = optionalText(args.sequence_id, "sequence_id", 512);
+          const kinds = optionalKinds(args.kinds);
+          const maxEntries = boundedInteger(
+            args.max_entries,
+            DEFAULT_EDITORIAL_CONTEXT_PACK_ENTRIES,
+            1,
+            MAX_EDITORIAL_CONTEXT_PACK_ENTRIES,
+            "max_entries",
+          );
+          const maxCharacters = boundedInteger(
+            args.max_characters,
+            DEFAULT_EDITORIAL_CONTEXT_PACK_CHARACTERS,
+            MIN_EDITORIAL_CONTEXT_PACK_CHARACTERS,
+            MAX_EDITORIAL_CONTEXT_PACK_CHARACTERS,
+            "max_characters",
+          );
+          const document = await repository.get(id);
+          if (!document) return { success: false, error: "Project context not found; capture it before creating an editorial context pack" };
+          const matches = searchProjectContext(document, {
+            query: intent,
+            ...(sequenceId ? { sequenceId } : {}),
+            ...(kinds ? { kinds } : {}),
+            // One extra result is enough to make entry-limit truncation
+            // observable while retaining a bounded local read.
+            limit: maxEntries + 1,
+          }).filter((result) => result.matchedTerms.length > 0);
+          const results = matches.slice(0, maxEntries);
+          return {
+            success: true,
+            data: buildEditorialContextPack(document, {
+              intent,
+              results,
+              totalResultCount: matches.length,
+              maxEntries,
+              maxCharacters,
+            }),
+          };
+        } catch (error) {
+          return { success: false, error: error instanceof Error ? error.message : String(error) };
+        }
+      },
+    },
+  };
+}

--- a/src/tools/project-context.ts
+++ b/src/tools/project-context.ts
@@ -570,7 +570,7 @@ export function getProjectContextTools(
             items: { type: "string", enum: ["project", "sequence", "source", "timeline", "transcript", "shot", "audio", "note"] },
             description: "Optional context-kind filter",
           },
-          max_results: { type: "number", description: "Maximum 50; default 12" },
+          max_results: { type: "integer", minimum: 1, maximum: 50, description: "Maximum 50; default 12" },
         },
         required: ["project_id", "query"],
       },
@@ -582,13 +582,17 @@ export function getProjectContextTools(
         max_results?: number;
       }) => {
         const projectId = requireProjectId(args.project_id);
+        if (args.max_results !== undefined &&
+          (!Number.isInteger(args.max_results) || args.max_results < 1 || args.max_results > 50)) {
+          return { success: false, error: "max_results must be an integer from 1 through 50" };
+        }
         const document = await repository.get(projectId);
         if (!document) return { success: false, error: "Project context not found" };
         const results = searchProjectContext(document, {
           query: args.query,
           sequenceId: args.sequence_id,
           kinds: args.kinds,
-          limit: args.max_results,
+          limit: args.max_results ?? 12,
         });
         return {
           success: true,

--- a/src/workflows/catalog.ts
+++ b/src/workflows/catalog.ts
@@ -38,6 +38,12 @@ export const WORKFLOW_CATALOG = [
     recommendedTools: ["manage_project_context", "search_project_context", "create_context_edit_plan", "preview_edit_plan", "apply_edit_plan"],
   },
   {
+    id: "transcript-first-context",
+    title: "Review a transcript-first context pack",
+    summary: "Capture explicit local transcript and media evidence, compact only the passages relevant to the intent, then review stable evidence IDs and revisions before proposing an edit.",
+    recommendedTools: ["manage_project_context", "create_editorial_context_pack", "create_editorial_plan", "preview_editorial_plan"],
+  },
+  {
     id: "transcript-rough-cut",
     title: "Plan a transcript-driven rough cut",
     summary: "Export Premiere's native transcript, select revision-locked source ranges, map them to verified 1x placements in a duplicate sequence, then execute the descending cut plan with re-query verification.",

--- a/src/workflows/tool-metadata.ts
+++ b/src/workflows/tool-metadata.ts
@@ -3,6 +3,7 @@ import type { ToolAnnotations } from "@modelcontextprotocol/server";
 const READ_PREFIXES = ["get_", "list_", "inspect_", "find_", "check_", "search_"];
 const READ_ONLY_TOOLS = new Set([
   "create_context_edit_plan",
+  "create_editorial_context_pack",
   "create_editorial_plan",
   "preview_editorial_plan",
   "preview_project_intake",

--- a/tests/editorial-context-pack.test.ts
+++ b/tests/editorial-context-pack.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildEditorialContextPack,
+  MAX_EDITORIAL_CONTEXT_PACK_CHARACTERS,
+  MIN_EDITORIAL_CONTEXT_PACK_CHARACTERS,
+} from "../src/ai/editorial-context-pack.js";
+import {
+  ProjectContextRepository,
+  searchProjectContext,
+  type ProjectContextDocument,
+} from "../src/context/project-context-store.js";
+import { getEditorialContextPackTools } from "../src/tools/editorial-context-pack.js";
+import { createServer } from "../src/server.js";
+import { Client, InMemoryTransport } from "@modelcontextprotocol/client";
+
+function document(): ProjectContextDocument {
+  return {
+    schemaVersion: 1,
+    projectId: "project-1",
+    projectName: "Launch interview",
+    revision: "context-r1",
+    sourceRevision: "source-r1",
+    timelineRevision: "timeline-r1",
+    updatedAt: "2026-09-02T00:00:00.000Z",
+    records: [
+      {
+        id: "source-1",
+        kind: "source",
+        name: "Founder interview",
+        text: "Source Founder interview. Media type mov.",
+        keywords: ["interview", "mov"],
+        sourceId: "source-item-1",
+        sourceRevision: "source-r1",
+        indexedAt: "2026-09-02T00:00:00.000Z",
+      },
+      {
+        id: "transcript-1",
+        kind: "transcript",
+        name: "Founder on the launch budget",
+        text: "We made the launch budget work by simplifying the onboarding flow.",
+        keywords: ["launch", "budget", "onboarding"],
+        sequenceId: "sequence-1",
+        sourceId: "source-item-1",
+        startSeconds: 12.5,
+        endSeconds: 17.25,
+        sourceRevision: "source-r1",
+        timelineRevision: "timeline-r1",
+        metadata: { secret: "must-not-appear" },
+        indexedAt: "2026-09-02T00:00:00.000Z",
+      },
+      {
+        id: "shot-1",
+        kind: "shot",
+        name: "Product close-up",
+        text: "Product close-up during the onboarding explanation.",
+        keywords: ["product", "onboarding"],
+        sequenceId: "sequence-1",
+        sourceId: "source-item-2",
+        startSeconds: 30,
+        endSeconds: 35,
+        sourceRevision: "source-r1",
+        indexedAt: "2026-09-02T00:00:00.000Z",
+      },
+    ],
+  };
+}
+
+describe("editorial context pack", () => {
+  it("renders stable, compact evidence without leaking metadata", () => {
+    const source = document();
+    const results = searchProjectContext(source, { query: "launch budget onboarding", limit: 12 });
+    const first = buildEditorialContextPack(source, { intent: "launch budget onboarding", results });
+    const second = buildEditorialContextPack(source, { intent: "launch budget onboarding", results });
+
+    expect(first).toMatchObject({
+      schemaVersion: 1,
+      projectId: "project-1",
+      expectedContextRevision: "context-r1",
+      expectedSourceRevision: "source-r1",
+      expectedTimelineRevision: "timeline-r1",
+      applied: false,
+      truncated: false,
+    });
+    expect(first.markdown).toContain("# Premiere editorial context pack");
+    expect(first.markdown).toContain("evidence transcript-1");
+    expect(first.markdown).toContain("12.500s–17.250s");
+    expect(first.markdown).toContain("We made the launch budget work");
+    expect(first.markdown).not.toContain("must-not-appear");
+    expect(first.evidence[0]).toMatchObject({
+      evidenceId: "transcript-1",
+      kind: "transcript",
+      sourceId: "source-item-1",
+      startSeconds: 12.5,
+      endSeconds: 17.25,
+      textTruncated: false,
+    });
+    expect(first).toEqual(second);
+  });
+
+  it("enforces a strict Markdown cap and labels partial evidence", () => {
+    const source = document();
+    source.records[1].text = `Budget evidence ${"with supporting detail ".repeat(3_000)}`;
+    const results = searchProjectContext(source, { query: "budget", limit: 12 });
+    const pack = buildEditorialContextPack(source, {
+      intent: "budget",
+      results,
+      maxCharacters: MIN_EDITORIAL_CONTEXT_PACK_CHARACTERS,
+    });
+
+    expect(pack.markdown.length).toBeLessThanOrEqual(MIN_EDITORIAL_CONTEXT_PACK_CHARACTERS);
+    expect(pack.truncated).toBe(true);
+    expect(pack.evidence[0]).toMatchObject({ evidenceId: "transcript-1", textTruncated: true });
+    expect(pack.markdown).toContain("[excerpt truncated]");
+  });
+
+  it("preserves the Markdown cap when project labels and revisions are long", () => {
+    const source = document();
+    source.projectName = "Project ".repeat(80);
+    source.revision = "context-".repeat(100);
+    source.sourceRevision = "source-".repeat(100);
+    source.timelineRevision = "timeline-".repeat(100);
+    const intent = `budget ${"review ".repeat(140)}`;
+    const results = searchProjectContext(source, { query: "budget", limit: 12 });
+    const pack = buildEditorialContextPack(source, {
+      intent,
+      results,
+      maxCharacters: MIN_EDITORIAL_CONTEXT_PACK_CHARACTERS,
+    });
+
+    expect(pack.intent).toBe(intent.trim());
+    expect(pack.markdown.length).toBeLessThanOrEqual(MIN_EDITORIAL_CONTEXT_PACK_CHARACTERS);
+  });
+
+  it("validates pack bounds before producing output", () => {
+    const source = document();
+    const results = searchProjectContext(source, { query: "budget" });
+    expect(() => buildEditorialContextPack(source, { intent: " ", results })).toThrow("intent must not be empty");
+    expect(() => buildEditorialContextPack(source, { intent: "budget", results, maxEntries: 0 })).toThrow("max_entries");
+    expect(() => buildEditorialContextPack(source, { intent: "budget", results, maxCharacters: MIN_EDITORIAL_CONTEXT_PACK_CHARACTERS - 1 })).toThrow("max_characters");
+    expect(() => buildEditorialContextPack(source, { intent: "budget", results, maxCharacters: MAX_EDITORIAL_CONTEXT_PACK_CHARACTERS + 1 })).toThrow("max_characters");
+  });
+
+  it("reads only stored local context and rejects invalid tool input", async () => {
+    const repository = new ProjectContextRepository({ backend: "memory" });
+    const tools = getEditorialContextPackTools({ repository });
+    await repository.put(document());
+
+    await expect(tools.create_editorial_context_pack.handler({
+      project_id: "project-1",
+      intent: "launch budget",
+      kinds: ["transcript"],
+      max_entries: 4,
+      max_characters: 2_000,
+    })).resolves.toMatchObject({
+      success: true,
+      data: {
+        applied: false,
+        evidence: [expect.objectContaining({ kind: "transcript" })],
+      },
+    });
+    await expect(tools.create_editorial_context_pack.handler({
+      project_id: "missing",
+      intent: "launch budget",
+    })).resolves.toMatchObject({ success: false, error: expect.stringContaining("not found") });
+    await expect(tools.create_editorial_context_pack.handler({
+      project_id: "project-1",
+      intent: "launch budget",
+      kinds: ["transcript", "transcript"],
+    })).resolves.toMatchObject({ success: false, error: expect.stringContaining("duplicates") });
+    await expect(tools.create_editorial_context_pack.handler({
+      project_id: "project-1",
+      intent: "launch budget",
+      max_characters: 1,
+    })).resolves.toMatchObject({ success: false, error: expect.stringContaining("max_characters") });
+    await expect(tools.create_editorial_context_pack.handler({
+      project_id: "p".repeat(513),
+      intent: "launch budget",
+    })).resolves.toMatchObject({ success: false, error: expect.stringContaining("at most 512") });
+  });
+
+  it("reports entry overflow and excludes records with no matched intent term", async () => {
+    const repository = new ProjectContextRepository({ backend: "memory" });
+    const source = document();
+    for (let index = 2; index <= 13; index++) {
+      source.records.push({
+        ...source.records[1], id: `transcript-${index}`, name: `Budget answer ${index}`,
+        text: `The launch budget answer ${index}.`,
+      });
+    }
+    await repository.put(source);
+    const tool = getEditorialContextPackTools({ repository }).create_editorial_context_pack;
+
+    await expect(tool.handler({ project_id: "project-1", intent: "budget", max_entries: 12 }))
+      .resolves.toMatchObject({
+        success: true,
+        data: { evidence: expect.any(Array), omittedEvidenceCount: 1, truncated: true },
+      });
+    await expect(tool.handler({ project_id: "project-1", intent: "unrelated", kinds: ["transcript"] }))
+      .resolves.toMatchObject({ success: true, data: { evidence: [], omittedEvidenceCount: 0, truncated: false } });
+  });
+
+  it("shares the injected server context repository with the reading tool", async () => {
+    const repository = new ProjectContextRepository({ backend: "memory" });
+    await repository.put(document());
+    const server = createServer({}, { contextRepository: repository });
+    const client = new Client({ name: "editorial-context-pack-test", version: "1.0.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+    try {
+      const result = await client.callTool({
+        name: "create_editorial_context_pack",
+        arguments: { project_id: "project-1", intent: "launch budget" },
+      });
+      expect((result.structuredContent as any).data).toMatchObject({ projectId: "project-1", applied: false });
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});

--- a/tests/editorial-context-pack.test.ts
+++ b/tests/editorial-context-pack.test.ts
@@ -140,6 +140,26 @@ describe("editorial context pack", () => {
     expect(() => buildEditorialContextPack(source, { intent: "budget", results, maxCharacters: MAX_EDITORIAL_CONTEXT_PACK_CHARACTERS + 1 })).toThrow("max_characters");
   });
 
+  it("omits unavailable record metadata from compact evidence", () => {
+    const source = document();
+    const record = source.records[0];
+    delete record.sourceId;
+    delete record.sourceRevision;
+    const results = searchProjectContext(source, { query: "interview" }).filter((result) => result.record.id === record.id);
+
+    const pack = buildEditorialContextPack(source, { intent: "interview", results });
+
+    expect(pack.evidence).toHaveLength(1);
+    expect(pack.evidence[0]).not.toHaveProperty("sequenceId");
+    expect(pack.evidence[0]).not.toHaveProperty("sourceId");
+    expect(pack.evidence[0]).not.toHaveProperty("timelineItemId");
+    expect(pack.evidence[0]).not.toHaveProperty("startSeconds");
+    expect(pack.evidence[0]).not.toHaveProperty("endSeconds");
+    expect(pack.evidence[0]).not.toHaveProperty("sourceRevision");
+    expect(pack.evidence[0]).not.toHaveProperty("timelineRevision");
+    expect(pack.markdown).not.toContain("source source-item-1");
+  });
+
   it("reads only stored local context and rejects invalid tool input", async () => {
     const repository = new ProjectContextRepository({ backend: "memory" });
     const tools = getEditorialContextPackTools({ repository });
@@ -176,6 +196,21 @@ describe("editorial context pack", () => {
       project_id: "p".repeat(513),
       intent: "launch budget",
     })).resolves.toMatchObject({ success: false, error: expect.stringContaining("at most 512") });
+  });
+
+  it("rejects malformed optional filters before searching context", async () => {
+    const repository = new ProjectContextRepository({ backend: "memory" });
+    const tool = getEditorialContextPackTools({ repository }).create_editorial_context_pack;
+    await repository.put(document());
+
+    await expect(tool.handler({ project_id: "project-1", intent: "budget", sequence_id: " " }))
+      .resolves.toMatchObject({ success: false, error: expect.stringContaining("sequence_id") });
+    await expect(tool.handler({ project_id: "project-1", intent: "budget", kinds: [] }))
+      .resolves.toMatchObject({ success: false, error: expect.stringContaining("between 1 and 8") });
+    await expect(tool.handler({ project_id: "project-1", intent: "budget", kinds: ["unsupported"] as any }))
+      .resolves.toMatchObject({ success: false, error: expect.stringContaining("supported project-context kind") });
+    await expect(tool.handler({ project_id: "project-1", intent: "budget", kinds: [1] as any }))
+      .resolves.toMatchObject({ success: false, error: expect.stringContaining("supported project-context kind") });
   });
 
   it("reports entry overflow and excludes records with no matched intent term", async () => {

--- a/tests/editorial-context-pack.test.ts
+++ b/tests/editorial-context-pack.test.ts
@@ -181,7 +181,7 @@ describe("editorial context pack", () => {
   it("reports entry overflow and excludes records with no matched intent term", async () => {
     const repository = new ProjectContextRepository({ backend: "memory" });
     const source = document();
-    for (let index = 2; index <= 13; index++) {
+    for (let index = 2; index <= 100; index++) {
       source.records.push({
         ...source.records[1], id: `transcript-${index}`, name: `Budget answer ${index}`,
         text: `The launch budget answer ${index}.`,
@@ -193,7 +193,7 @@ describe("editorial context pack", () => {
     await expect(tool.handler({ project_id: "project-1", intent: "budget", max_entries: 12 }))
       .resolves.toMatchObject({
         success: true,
-        data: { evidence: expect.any(Array), omittedEvidenceCount: 1, truncated: true },
+        data: { evidence: expect.any(Array), omittedEvidenceCount: 88, truncated: true },
       });
     await expect(tool.handler({ project_id: "project-1", intent: "unrelated", kinds: ["transcript"] }))
       .resolves.toMatchObject({ success: true, data: { evidence: [], omittedEvidenceCount: 0, truncated: false } });

--- a/tests/mcp-modernization.test.ts
+++ b/tests/mcp-modernization.test.ts
@@ -150,6 +150,17 @@ describe("modern MCP surface", () => {
         "create_editorial_plan",
         "preview_editorial_plan",
       ]));
+      expect(tools.tools.find((tool) => tool.name === "create_editorial_context_pack")?.inputSchema)
+        .toMatchObject({
+          properties: {
+            max_entries: { type: "integer", minimum: 1, maximum: 50 },
+            max_characters: { type: "integer", minimum: 1024, maximum: 24_000 },
+          },
+        });
+      expect(tools.tools.find((tool) => tool.name === "search_project_context")?.inputSchema)
+        .toMatchObject({
+          properties: { max_results: { type: "integer", minimum: 1, maximum: 50 } },
+        });
 
       const capabilities = await client.callTool({
         name: "get_capabilities",

--- a/tests/mcp-modernization.test.ts
+++ b/tests/mcp-modernization.test.ts
@@ -18,12 +18,14 @@ describe("modern MCP surface", () => {
   it("exposes a machine-readable workflow resource", () => {
     const resource = JSON.parse(WORKFLOW_RESOURCE);
     expect(resource.version).toBe(1);
-    expect(resource.workflows).toHaveLength(11);
+    expect(resource.workflows).toHaveLength(12);
     expect(resource.workflows[0].recommendedTools).toContain("get_premiere_state");
     const organization = resource.workflows.find((workflow: { id: string }) => workflow.id === "project-organization");
     expect(organization.recommendedTools).toContain("apply_editorial_organization_plan");
     expect(organization.recommendedTools).not.toContain("organize_project_items_uxp");
     expect(organization.summary).toContain("advanced/manual only");
+    const transcriptFirst = resource.workflows.find((workflow: { id: string }) => workflow.id === "transcript-first-context");
+    expect(transcriptFirst.recommendedTools).toContain("create_editorial_context_pack");
   });
 
   it("marks inspection as read-only and script execution as open-world", () => {
@@ -39,6 +41,7 @@ describe("modern MCP surface", () => {
     expect(annotationsForTool("execute_extendscript").openWorldHint).toBe(true);
     expect(annotationsForTool("search_project_context")).toMatchObject({ readOnlyHint: true, idempotentHint: true });
     expect(annotationsForTool("create_context_edit_plan")).toMatchObject({ readOnlyHint: true, idempotentHint: true });
+    expect(annotationsForTool("create_editorial_context_pack")).toMatchObject({ readOnlyHint: true, idempotentHint: true });
     expect(annotationsForTool("create_editorial_plan")).toMatchObject({ readOnlyHint: true, idempotentHint: true });
     expect(annotationsForTool("preview_editorial_plan")).toMatchObject({ readOnlyHint: true, idempotentHint: true });
     expect(annotationsForTool("verify_delivery_conformance")).toMatchObject({ readOnlyHint: true, idempotentHint: true, openWorldHint: false });
@@ -122,7 +125,7 @@ describe("modern MCP surface", () => {
       // unsafe-script, so the two scripting tools are not advertised.
       expect(tools.tools.map((tool) => tool.name)).not.toContain("execute_extendscript");
       expect(tools.tools.map((tool) => tool.name)).not.toContain("evaluate_expression");
-      expect(tools.tools).toHaveLength(325);
+      expect(tools.tools).toHaveLength(326);
       const capabilityTool = tools.tools.find((tool) => tool.name === "get_capabilities");
       expect(capabilityTool?.outputSchema).toMatchObject({
         type: "object",
@@ -143,6 +146,7 @@ describe("modern MCP surface", () => {
         "manage_project_context",
         "search_project_context",
         "create_context_edit_plan",
+        "create_editorial_context_pack",
         "create_editorial_plan",
         "preview_editorial_plan",
       ]));
@@ -160,6 +164,14 @@ describe("modern MCP surface", () => {
       expect(capabilityData.tools.tools.map((tool: any) => tool.name)).toEqual(
         expect.arrayContaining(tools.tools.map((tool) => tool.name)),
       );
+      expect(
+        capabilityData.tools.tools.find((tool: any) => tool.name === "create_editorial_context_pack"),
+      ).toMatchObject({
+        backend: "local",
+        authority: { required: "inspect", enabled: true },
+        verificationBoundary: "static_metadata_only",
+        hostVerificationRequired: false,
+      });
       expect(
         capabilityData.tools.tools.find((tool: any) => tool.name === "execute_extendscript")
           ?.authority,
@@ -189,7 +201,7 @@ describe("modern MCP surface", () => {
       ]));
       expect(names).not.toContain("create_bin");
       // Essential is a 14-tool focused path (including the two always-visible
-      // diagnostics), versus 325 tools in the default full catalog.
+      // diagnostics), versus 326 tools in the default full catalog.
       expect(names).toHaveLength(14);
 
       const capabilities = await client.callTool({

--- a/tests/project-context.test.ts
+++ b/tests/project-context.test.ts
@@ -257,6 +257,11 @@ describe("project context index", () => {
     });
     expect(search.data.results[0]).toMatchObject({ kind: "transcript", sourceId: "source-1" });
     expect(search.data.results[0].metadata).toEqual({ confidence: 0.97 });
+    await expect((tools.search_project_context.handler as any)({
+      project_id: built.document.projectId,
+      query: "budget",
+      max_results: 51,
+    })).resolves.toMatchObject({ success: false, error: expect.stringContaining("1 through 50") });
 
     const plan = await (tools.create_context_edit_plan.handler as any)({
       project_id: built.document.projectId,

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -50,6 +50,7 @@ describe("canonical release metadata", () => {
     const llms = read("landing/public/llms.txt");
     const llmsFull = read("landing/public/llms-full.txt");
     const landingProduct = read("landing/lib/product.ts");
+    const marketingAssets = read("docs/marketing-assets.md");
 
     expect(readme).toContain(`${release.coreTools} core tools`);
     expect(readme).toContain(
@@ -65,6 +66,9 @@ describe("canonical release metadata", () => {
     expect(llmsFull).toContain(`Current release: ${release.version}`);
     expect(llmsFull).toContain(
       `${release.uxpAdditionalTools} capability-gated tools`,
+    );
+    expect(marketingAssets).toContain(
+      `${release.uxpAdditionalTools} additional capability-gated tools`,
     );
     expect(landingProduct).toContain(`version: "${release.version}"`);
     expect(landingProduct).toContain(`coreToolCount: ${release.coreTools}`);

--- a/tests/tools/adobe-26-3-uxp-catalog.test.ts
+++ b/tests/tools/adobe-26-3-uxp-catalog.test.ts
@@ -43,7 +43,7 @@ describe("Adobe Premiere 26.3 UXP public MCP catalog", () => {
       expect(listed.tools.map((tool) => tool.name)).toEqual(
         expect.arrayContaining(ADOBE_26_3_TOOLS),
       );
-      expect(listed.tools).toHaveLength(385);
+      expect(listed.tools).toHaveLength(386);
     } finally {
       await client.close();
       await server.close();

--- a/tests/tools/tool-modules.test.ts
+++ b/tests/tools/tool-modules.test.ts
@@ -51,6 +51,7 @@ import { getProjectManagerTools } from "../../src/tools/project-manager.js";
 import { getRecoveryTools } from "../../src/tools/recovery.js";
 import { getAvSettingsTools } from "../../src/tools/av-settings.js";
 import { getProjectContextTools } from "../../src/tools/project-context.js";
+import { getEditorialContextPackTools } from "../../src/tools/editorial-context-pack.js";
 import { getEditorialPlanTools } from "../../src/tools/editorial-plans.js";
 import { getProjectIntakeTools } from "../../src/tools/project-intake.js";
 import { getCompetitorGapTools } from "../../src/tools/competitor-gaps.js";
@@ -104,6 +105,7 @@ const ALL_MODULES: Array<{
   { name: "recovery", getter: getRecoveryTools, minTools: 2 },
   { name: "av-settings", getter: getAvSettingsTools, minTools: 4 },
   { name: "project-context", getter: getProjectContextTools, minTools: 3 },
+  { name: "editorial-context-pack", getter: getEditorialContextPackTools, minTools: 1 },
   { name: "editorial-plans", getter: () => getEditorialPlanTools(), minTools: 2 },
   { name: "project-intake", getter: getProjectIntakeTools, minTools: 1 },
   { name: "competitor-gaps", getter: getCompetitorGapTools, minTools: 8 },
@@ -192,16 +194,16 @@ describe("Tool Module Structure", () => {
 });
 
 describe("Total Tool Count", () => {
-  it("all modules together have 325 tools", () => {
+  it("all modules together have 326 tools", () => {
     let total = 0;
     for (const mod of ALL_MODULES) {
       total += Object.keys(mod.getter(bridgeOptions)).length;
     }
-    expect(total).toBe(325);
+    expect(total).toBe(326);
   });
 
-  it("there are 37 directly enumerated modules", () => {
-    expect(ALL_MODULES.length).toBe(37);
+  it("there are 38 directly enumerated modules", () => {
+    expect(ALL_MODULES.length).toBe(38);
   });
 });
 

--- a/tests/tools/uxp-tools.test.ts
+++ b/tests/tools/uxp-tools.test.ts
@@ -194,7 +194,7 @@ describe("UXP MCP tools", () => {
       // transcript workflow and documented Premiere 26.3 tools add nineteen,
       // and the two stable workflow expansions, confirmed organization application, four bounded native migration adapters, and beat-grid marker application add twenty-seven consolidated UXP tools;
       // connection verification and delivery conformance add two default-profile core tools.
-      expect(tools.tools).toHaveLength(385);
+      expect(tools.tools).toHaveLength(386);
     } finally {
       await client.close();
       await server.close();


### PR DESCRIPTION
Summary: adds create_editorial_context_pack, a bounded transcript-first Markdown reading view of explicitly captured local context. Exact relevant-match counts are calculated without widening the public context-search response bound; stateful context repositories are never captured through a reusable tool catalog. The generated source catalog is current while released v1.14.5 metadata remains unchanged; the marketing-assets capability count is corrected to the existing release metadata. Safety boundary: local inspection only; no transcription, provider, Premiere bridge, or timeline mutation. Validation: focused context tests, build, lint, supported-actions check, and diff check. No licensed-host verification was run.