### PR TITLE
Fail closed for unsupported sequence pixel aspect ratio

### DIFF
--- a/docs/supported-actions.md
+++ b/docs/supported-actions.md
@@ -328,7 +328,7 @@ operation” when the tool has no enum-based mode.
 | `set_sequence_field_type` | Default profile | Single operation | Set the field order of the active sequence. |
 | `set_sequence_frame_rate` | Default profile | Single operation | Change the frame rate of the active sequence. |
 | `set_sequence_in_out_points` | Default profile | Single operation | Set the sequence in and out points (for export range, etc.) |
-| `set_sequence_pixel_aspect_ratio` | Default profile | Single operation | Change the pixel aspect ratio of the active sequence. |
+| `set_sequence_pixel_aspect_ratio` | Default profile | Single operation | Change the pixel aspect ratio of the active sequence, or return a capability error when the legacy host does not expose a writable setting. |
 | `set_sequence_resolution` | Default profile | Single operation | Change the resolution (frame size) of the active sequence. |
 | `set_sequence_settings` | Default profile | Single operation | Modify and read back sequence frame-size settings. |
 | `set_source_in_out` | Default profile | Single operation | Set in and/or out points on the clip currently open in the Source Monitor. |

--- a/src/tools/utility.ts
+++ b/src/tools/utility.ts
@@ -525,10 +525,14 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
           } catch (eAssign) {
             return __error("This Premiere host rejected the sequence pixel-aspect-ratio update. No sequence settings were changed: " + eAssign.toString());
           }
+          var settingsApplied;
           try {
-            seq.setSettings(settings);
+            settingsApplied = seq.setSettings(settings);
           } catch (eSet) {
             return __error("Premiere could not apply the sequence pixel-aspect-ratio update: " + eSet.toString());
+          }
+          if (settingsApplied === false) {
+            return __error("Premiere rejected the sequence pixel-aspect-ratio update. No sequence settings were changed.");
           }
 
           var observed;

--- a/src/tools/utility.ts
+++ b/src/tools/utility.ts
@@ -481,7 +481,8 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
     },
 
     set_sequence_pixel_aspect_ratio: {
-      description: "Change the pixel aspect ratio of the active sequence.",
+      description:
+        "Change the pixel aspect ratio of the active sequence, or return a capability error when the legacy host does not expose a writable setting.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -494,6 +495,9 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
         required: ["ratio"],
       },
       handler: async (args: { ratio: string }) => {
+        if (typeof args.ratio !== "string") {
+          return { success: false, error: "ratio must be a positive decimal string such as '1.0' or '1.4222'." };
+        }
         const ratio = args.ratio.trim();
         if (!/^(?:0|[1-9]\d*)(?:\.\d+)?$/.test(ratio) || Number(ratio) <= 0) {
           return { success: false, error: "ratio must be a positive decimal string such as '1.0' or '1.4222'." };
@@ -505,14 +509,47 @@ export function getUtilityTools(bridgeOptions: BridgeOptions) {
           var settings = seq.getSettings();
           if (!settings) return __error("Could not get sequence settings");
 
-          settings.videoPixelAspectRatio = "${ratio}";
-          seq.setSettings(settings);
-          var observed = seq.getSettings();
-          if (!observed || String(observed.videoPixelAspectRatio) !== "${ratio}") {
+          var requestedRatio = "${ratio}";
+          var currentRatio;
+          try {
+            currentRatio = settings.videoPixelAspectRatio;
+          } catch (eRead) {
+            return __error("This Premiere host does not expose a readable sequence pixel-aspect-ratio setting: " + eRead.toString());
+          }
+          if (typeof currentRatio === "undefined") {
+            return __error("This Premiere host does not expose a writable sequence pixel-aspect-ratio setting. No sequence settings were changed.");
+          }
+
+          try {
+            settings.videoPixelAspectRatio = requestedRatio;
+          } catch (eAssign) {
+            return __error("This Premiere host rejected the sequence pixel-aspect-ratio update. No sequence settings were changed: " + eAssign.toString());
+          }
+          try {
+            seq.setSettings(settings);
+          } catch (eSet) {
+            return __error("Premiere could not apply the sequence pixel-aspect-ratio update: " + eSet.toString());
+          }
+
+          var observed;
+          try {
+            observed = seq.getSettings();
+          } catch (eVerify) {
+            return __error("Premiere could not read back the sequence pixel-aspect-ratio update: " + eVerify.toString());
+          }
+          if (!observed) return __error("Premiere did not return sequence settings after the pixel-aspect-ratio update");
+
+          var observedRatio;
+          try {
+            observedRatio = String(observed.videoPixelAspectRatio);
+          } catch (eObserved) {
+            return __error("Premiere did not expose the applied sequence pixel-aspect ratio for verification: " + eObserved.toString());
+          }
+          if (observedRatio !== requestedRatio) {
             return __error("Premiere did not apply the requested sequence pixel aspect ratio.");
           }
 
-          return __result({ ratio: "${ratio}", sequence: seq.name, verified: true });
+          return __result({ ratio: requestedRatio, sequence: seq.name, verified: true });
         `);
         return sendCommand(script, bridgeOptions);
       },

--- a/tests/tools/regressions.test.ts
+++ b/tests/tools/regressions.test.ts
@@ -465,6 +465,32 @@ describe("issue #37 — sequence frame rate uses ticks per frame", () => {
   });
 });
 
+// https://github.com/leancoderkavy/premiere-pro-mcp/issues/335
+describe("issue #335 — pixel aspect ratio must fail closed on unsupported CEP hosts", () => {
+  const utility = getUtilityTools(bridgeOptions);
+
+  it("checks host support and verifies the readback before reporting success", async () => {
+    const script = await codeFor(utility.set_sequence_pixel_aspect_ratio, { ratio: "1.0" });
+
+    expect(script).toContain("currentRatio = settings.videoPixelAspectRatio");
+    expect(script).toContain('typeof currentRatio === "undefined"');
+    expect(script).toContain("No sequence settings were changed");
+    expect(script).toContain("settings.videoPixelAspectRatio = requestedRatio");
+    expect(script).toContain("observed = seq.getSettings()");
+    expect(script).toContain("observedRatio = String(observed.videoPixelAspectRatio)");
+    expect(script.indexOf('typeof currentRatio === "undefined"'))
+      .toBeLessThan(script.indexOf("settings.videoPixelAspectRatio = requestedRatio"));
+  });
+
+  it("rejects non-string aspect ratios before sending a Premiere command", async () => {
+    mockedSendCommand.mockClear();
+    const result = await utility.set_sequence_pixel_aspect_ratio.handler({ ratio: 1 as never });
+
+    expect(result).toMatchObject({ success: false });
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+  });
+});
+
 // https://github.com/leancoderkavy/premiere-pro-mcp/issues/235
 describe("issue #235 — CEP tool calls use the host's documented argument types", () => {
   const utility = getUtilityTools(bridgeOptions);
@@ -475,7 +501,8 @@ describe("issue #235 — CEP tool calls use the host's documented argument types
     const script = await scriptFor(utility.set_sequence_pixel_aspect_ratio, { ratio: "1.0" });
 
     expect(utility.set_sequence_pixel_aspect_ratio.parameters.properties.ratio).toMatchObject({ type: "string" });
-    expect(script).toContain('settings.videoPixelAspectRatio = "1.0"');
+    expect(script).toContain('var requestedRatio = "1.0"');
+    expect(script).toContain("settings.videoPixelAspectRatio = requestedRatio");
     expect(script).toContain("seq.getSettings()");
     expect(script).toContain("Premiere did not apply the requested sequence pixel aspect ratio");
   });

--- a/tests/tools/regressions.test.ts
+++ b/tests/tools/regressions.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { runInNewContext } from "node:vm";
 import { getHelpersSource } from "../../src/bridge/script-builder.js";
 import { BridgeOptions } from "../../src/bridge/file-bridge.js";
 
@@ -45,6 +46,14 @@ async function scriptFor(tool: { handler: (args: never) => Promise<unknown> }, a
 async function codeFor(tool: { handler: (args: never) => Promise<unknown> }, args: unknown) {
   const script = await scriptFor(tool, args);
   return script.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^[ \t]*\/\/.*$/gm, "");
+}
+
+async function executePixelAspectRatioScript(sequence: unknown, ratio = "1.4222") {
+  const utility = getUtilityTools(bridgeOptions);
+  const script = await scriptFor(utility.set_sequence_pixel_aspect_ratio, { ratio });
+  return JSON.parse(String(runInNewContext(`${getHelpersSource()}\n${script}`, {
+    app: { project: { activeSequence: sequence } },
+  })));
 }
 
 beforeEach(() => vi.clearAllMocks());
@@ -480,6 +489,79 @@ describe("issue #335 — pixel aspect ratio must fail closed on unsupported CEP 
     expect(script).toContain("observedRatio = String(observed.videoPixelAspectRatio)");
     expect(script.indexOf('typeof currentRatio === "undefined"'))
       .toBeLessThan(script.indexOf("settings.videoPixelAspectRatio = requestedRatio"));
+  });
+
+  it("returns structured failures for unavailable and rejected host settings", async () => {
+    const unavailableSetSettings = vi.fn();
+    await expect(executePixelAspectRatioScript({
+      name: "Unsupported setting",
+      getSettings: () => ({}),
+      setSettings: unavailableSetSettings,
+    })).resolves.toMatchObject({
+      success: false,
+      error: expect.stringContaining("does not expose a writable"),
+    });
+    expect(unavailableSetSettings).not.toHaveBeenCalled();
+
+    const lockedSettings: Record<string, string> = {};
+    Object.defineProperty(lockedSettings, "videoPixelAspectRatio", {
+      get: () => "1.0",
+      set: () => { throw new Error("locked"); },
+    });
+    const rejectedSetSettings = vi.fn();
+    await expect(executePixelAspectRatioScript({
+      name: "Read-only setting",
+      getSettings: () => lockedSettings,
+      setSettings: rejectedSetSettings,
+    })).resolves.toMatchObject({
+      success: false,
+      error: expect.stringContaining("rejected the sequence pixel-aspect-ratio update"),
+    });
+    expect(rejectedSetSettings).not.toHaveBeenCalled();
+
+    await expect(executePixelAspectRatioScript({
+      name: "Apply failure",
+      getSettings: () => ({ videoPixelAspectRatio: "1.0" }),
+      setSettings: () => { throw new Error("host refused"); },
+    })).resolves.toMatchObject({
+      success: false,
+      error: expect.stringContaining("could not apply the sequence pixel-aspect-ratio update"),
+    });
+  });
+
+  it("treats a false host result and mismatched readback as unverified", async () => {
+    await expect(executePixelAspectRatioScript({
+      name: "Rejected return value",
+      getSettings: () => ({ videoPixelAspectRatio: "1.0" }),
+      setSettings: () => false,
+    })).resolves.toMatchObject({
+      success: false,
+      error: expect.stringContaining("rejected the sequence pixel-aspect-ratio update"),
+    });
+
+    const initialSettings = { videoPixelAspectRatio: "1.0" };
+    await expect(executePixelAspectRatioScript({
+      name: "Mismatched readback",
+      getSettings: vi.fn().mockReturnValueOnce(initialSettings).mockReturnValueOnce({ videoPixelAspectRatio: "1.0" }),
+      setSettings: () => undefined,
+    })).resolves.toMatchObject({
+      success: false,
+      error: expect.stringContaining("did not apply the requested sequence pixel aspect ratio"),
+    });
+  });
+
+  it("reports success only after an applied setting reads back exactly", async () => {
+    const settings = { videoPixelAspectRatio: "1.0" };
+    const result = await executePixelAspectRatioScript({
+      name: "Verified sequence",
+      getSettings: () => settings,
+      setSettings: () => true,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      data: { ratio: "1.4222", sequence: "Verified sequence", verified: true },
+    });
   });
 
   it("rejects non-string aspect ratios before sending a Premiere command", async () => {


### PR DESCRIPTION
Fixes #335.\n\nThe legacy CEP pixel-aspect-ratio tool now validates the declared string input, checks that the host exposes the setting before assignment, catches host-side read/assignment/application failures, and requires an exact settings readback before returning success.\n\nVerification: 
pm test -- tests/tools/regressions.test.ts (52 passing), 
pm run build, 
pm run lint, and git diff --check.\n\nProof boundary: static contract/build validation only; no licensed Premiere host was available for runtime validation.