### PR TITLE
test: raise unit coverage margin

### DIFF
--- a/tests/bridge/bridge-edge-coverage.test.ts
+++ b/tests/bridge/bridge-edge-coverage.test.ts
@@ -1,0 +1,347 @@
+import { once } from "node:events";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  watch,
+  writeFileSync,
+} from "node:fs";
+import { WebSocket } from "ws";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { sendCommand } from "../../src/bridge/file-bridge.js";
+import {
+  UxpWebSocketBridge,
+  type UxpHello,
+} from "../../src/bridge/uxp-websocket-bridge.js";
+
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  readFileSync: vi.fn(),
+  unlinkSync: vi.fn(),
+  readdirSync: vi.fn(),
+  renameSync: vi.fn(),
+  statSync: vi.fn(),
+  chmodSync: vi.fn(),
+  watch: vi.fn(),
+}));
+
+const fs = {
+  exists: vi.mocked(existsSync),
+  mkdir: vi.mocked(mkdirSync),
+  write: vi.mocked(writeFileSync),
+  read: vi.mocked(readFileSync),
+  unlink: vi.mocked(unlinkSync),
+  readdir: vi.mocked(readdirSync),
+  rename: vi.mocked(renameSync),
+  stat: vi.mocked(statSync),
+  chmod: vi.mocked(chmodSync),
+  watch: vi.mocked(watch),
+};
+
+const originalGetuid = Object.getOwnPropertyDescriptor(process, "getuid");
+
+function ownedStat(mode = 0o700): ReturnType<typeof statSync> {
+  return {
+    uid: 4242,
+    mode,
+    mtimeMs: Date.now(),
+  } as unknown as ReturnType<typeof statSync>;
+}
+
+function usePosixProcess(uid = 4242): void {
+  vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+  Object.defineProperty(process, "getuid", {
+    configurable: true,
+    value: () => uid,
+  });
+}
+
+function restoreGetuid(): void {
+  if (originalGetuid) {
+    Object.defineProperty(process, "getuid", originalGetuid);
+  } else {
+    delete (process as { getuid?: () => number }).getuid;
+  }
+}
+
+describe("file bridge uncovered security and fallback paths", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    fs.watch.mockImplementation(() => {
+      throw new Error("watch unavailable");
+    });
+    fs.stat.mockReturnValue(ownedStat());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    restoreGetuid();
+  });
+
+  it("rejects a pre-existing POSIX directory owned by another user", async () => {
+    usePosixProcess();
+    fs.exists.mockReturnValue(true);
+    fs.stat.mockReturnValue(ownedStat());
+    fs.stat.mockReturnValueOnce({
+      uid: 31337,
+      mode: 0o700,
+      mtimeMs: Date.now(),
+    } as unknown as ReturnType<typeof statSync>);
+
+    await expect(sendCommand("var unsafe = true;", {
+      tempDir: "/tmp/untrusted-bridge",
+    })).rejects.toThrow(/owned by uid 31337/);
+  });
+
+  it("restores private POSIX permissions on an owned directory", async () => {
+    usePosixProcess();
+    fs.exists.mockReturnValue(true);
+    fs.stat.mockReturnValueOnce(ownedStat(0o755));
+    fs.read.mockReturnValue('{"success":true,"data":{"repaired":true}}');
+
+    await expect(sendCommand("var repair = true;", {
+      tempDir: "/tmp/owned-bridge",
+    })).resolves.toEqual({ success: true, data: { repaired: true } });
+
+    expect(fs.chmod).toHaveBeenCalledWith("/tmp/owned-bridge", 0o700);
+  });
+
+  it("reports a busy Premiere operation when its heartbeat cannot be statted", async () => {
+    fs.exists.mockImplementation((path) => {
+      const value = String(path);
+      if (value.includes("res_")) return false;
+      if (value.includes("busy_")) return true;
+      return true;
+    });
+    fs.stat.mockImplementation(((path) => {
+      if (String(path).includes("busy_")) throw new Error("heartbeat locked");
+      return ownedStat();
+    }) as typeof statSync);
+
+    const response = sendCommand("var waiting = true;", {
+      tempDir: "/tmp/busy-stat-error",
+      timeoutMs: 25,
+    });
+    await vi.advanceTimersByTimeAsync(110);
+
+    await expect(response).resolves.toMatchObject({
+      success: false,
+      error: expect.stringContaining("modal dialog"),
+    });
+  });
+
+  it("normalizes non-Error response read failures into command results", async () => {
+    fs.exists.mockImplementation((path) => !String(path).includes("busy_"));
+    fs.read.mockImplementation(() => {
+      throw "response file is locked";
+    });
+
+    const response = sendCommand("var parse = true;", {
+      tempDir: "/tmp/non-error-read-failure",
+      timeoutMs: 25,
+    });
+    await vi.advanceTimersByTimeAsync(110);
+
+    await expect(response).resolves.toEqual({
+      success: false,
+      error: "Failed to parse response: response file is locked",
+    });
+  });
+});
+
+const TOKEN = "bridge-edge-token-at-least-16-characters";
+const liveBridges: UxpWebSocketBridge[] = [];
+
+async function startBridge(options: {
+  port?: number;
+  handshakeTimeoutMs?: number;
+  requestTimeoutMs?: number;
+} = {}): Promise<UxpWebSocketBridge> {
+  const bridge = new UxpWebSocketBridge({ token: TOKEN, port: 0, ...options });
+  liveBridges.push(bridge);
+  await bridge.start();
+  return bridge;
+}
+
+function bridgeUrl(bridge: UxpWebSocketBridge, token = TOKEN): string {
+  const address = bridge.address();
+  return `ws://${address.host}:${address.port}${address.path}?token=${encodeURIComponent(token)}`;
+}
+
+async function connectHost(
+  bridge: UxpWebSocketBridge,
+  protocolVersion = 1,
+  commands: Record<string, { supported: boolean }> = { "state.get": { supported: true } },
+): Promise<WebSocket> {
+  const client = new WebSocket(bridgeUrl(bridge));
+  await once(client, "open");
+  const connected = once(bridge, "connected");
+  client.send(JSON.stringify({
+    protocolVersion,
+    type: "hello",
+    payload: {
+      backend: "uxp",
+      protocolVersion,
+      commands,
+    },
+  }));
+  await connected;
+  return client;
+}
+
+afterEach(async () => {
+  await Promise.all(liveBridges.splice(0).map((bridge) => bridge.stop()));
+});
+
+describe("UXP WebSocket bridge rejected-message and cleanup paths", () => {
+  it("serves a 404 for regular HTTP traffic and ignores duplicate starts", async () => {
+    const bridge = await startBridge();
+    const listening = vi.fn();
+    bridge.on("listening", listening);
+
+    await bridge.start();
+    const address = bridge.address();
+    const response = await fetch(`http://${address.host}:${address.port}/not-a-websocket`);
+
+    expect(listening).not.toHaveBeenCalled();
+    expect(response.status).toBe(404);
+    await expect(response.text()).resolves.toBe("Not found");
+  });
+
+  it("uses configured address data before it has started", () => {
+    const bridge = new UxpWebSocketBridge({ token: TOKEN, port: 7911, path: "/panel" });
+    expect(bridge.address()).toEqual({ host: "127.0.0.1", port: 7911, path: "/panel" });
+    expect(bridge.getState()).toEqual({ status: "stopped", connected: false });
+  });
+
+  it("uses a timing-safe comparison for equal-length incorrect tokens", async () => {
+    const bridge = await startBridge();
+    const client = new WebSocket(bridgeUrl(bridge, "x".repeat(TOKEN.length)));
+    client.on("error", () => {});
+    const [, response] = await once(client, "unexpected-response");
+
+    expect(response.statusCode).toBe(401);
+    response.resume();
+  });
+
+  it("closes a host that never sends the versioned hello", async () => {
+    const bridge = await startBridge({ handshakeTimeoutMs: 20 });
+    const client = new WebSocket(bridgeUrl(bridge));
+    await once(client, "open");
+
+    const [code, reason] = await once(client, "close");
+    expect(code).toBe(1008);
+    expect(reason.toString()).toContain("Versioned hello required");
+  });
+
+  it("rejects each malformed hello shape before accepting capabilities", async () => {
+    const bridge = await startBridge();
+    const malformedMessages = [
+      { protocolVersion: 1, type: "event", payload: {} },
+      { protocolVersion: 1, type: "hello", payload: { backend: "cep", protocolVersion: 1, commands: {} } },
+      { protocolVersion: 3, type: "hello", payload: { backend: "uxp", protocolVersion: 3, commands: {} } },
+      { protocolVersion: 1, type: "hello", payload: { backend: "uxp", protocolVersion: 2, commands: {} } },
+      { protocolVersion: 1, type: "hello", payload: { backend: "uxp", protocolVersion: 1 } },
+      { protocolVersion: 1, type: "hello", payload: { backend: "uxp", protocolVersion: 1, commands: "invalid" } },
+      { protocolVersion: 1, type: "hello", payload: { backend: "uxp", protocolVersion: 1, commands: [] } },
+    ];
+
+    for (const message of malformedMessages) {
+      const client = new WebSocket(bridgeUrl(bridge));
+      await once(client, "open");
+      const closed = once(client, "close");
+      client.send(JSON.stringify(message));
+      const [code] = await closed;
+      expect(code).toBe(1008);
+    }
+  });
+
+  it("accepts protocol 2 and closes the connection when its protocol changes", async () => {
+    const bridge = await startBridge();
+    const client = await connectHost(bridge, 2);
+    expect(bridge.getState()).toMatchObject({ connected: true, protocolVersion: 2 });
+
+    const closed = once(client, "close");
+    client.send(JSON.stringify({ protocolVersion: 1, type: "event", payload: { kind: "wrong-version" } }));
+    const [code, reason] = await closed;
+    expect(code).toBe(1008);
+    expect(reason.toString()).toContain("Protocol version changed");
+  });
+
+  it("ignores unknown messages and reports default host command failures", async () => {
+    const bridge = await startBridge();
+    const client = await connectHost(bridge);
+    client.send(JSON.stringify({ protocolVersion: 1, type: "notice", payload: {} }));
+    client.send(JSON.stringify({
+      protocolVersion: 1,
+      type: "result",
+      requestId: "unknown-request",
+      payload: { ok: true, result: "ignored" },
+    }));
+
+    client.once("message", (data) => {
+      const command = JSON.parse(data.toString());
+      client.send(JSON.stringify({
+        protocolVersion: 1,
+        type: "result",
+        requestId: command.requestId,
+        payload: { ok: false },
+      }));
+    });
+    await expect(bridge.request("state.get")).rejects.toMatchObject({
+      code: "UXP_COMMAND_FAILED",
+      message: "UXP command 'state.get' failed",
+    });
+    expect(bridge.getState()).toMatchObject({ connected: true });
+  });
+
+  it("forwards client errors from an accepted connection", async () => {
+    const bridge = await startBridge();
+    await connectHost(bridge);
+    const emitted = once(bridge, "clientError");
+    const expected = new Error("client transport error");
+    const serverClient = (bridge as unknown as { socket: WebSocket }).socket;
+
+    serverClient.emit("error", expected);
+    await expect(emitted).resolves.toEqual([expected]);
+  });
+
+  it("rejects a request if the socket reports a send failure exactly once", async () => {
+    const bridge = new UxpWebSocketBridge({ token: TOKEN });
+    const internal = bridge as unknown as {
+      socket: {
+        readyState: number;
+        send: (message: string, callback: (error?: Error) => void) => void;
+        close: () => void;
+      } | null;
+      hello: UxpHello | null;
+    };
+    internal.socket = {
+      readyState: WebSocket.OPEN,
+      send: (_message, callback) => {
+        callback(new Error("socket write failed"));
+        callback(new Error("duplicate completion"));
+      },
+      close: vi.fn(),
+    };
+    internal.hello = {
+      backend: "uxp",
+      protocolVersion: 1,
+      commands: { "state.get": { supported: true } },
+    };
+
+    await expect(bridge.request("state.get")).rejects.toMatchObject({
+      code: "UXP_SEND_FAILED",
+      message: "socket write failed",
+    });
+  });
+});

--- a/tests/bridge/bridge-edge-coverage.test.ts
+++ b/tests/bridge/bridge-edge-coverage.test.ts
@@ -116,6 +116,7 @@ describe("file bridge uncovered security and fallback paths", () => {
   });
 
   it("reports a busy Premiere operation when its heartbeat cannot be statted", async () => {
+    usePosixProcess();
     fs.exists.mockImplementation((path) => {
       const value = String(path);
       if (value.includes("res_")) return false;
@@ -140,6 +141,7 @@ describe("file bridge uncovered security and fallback paths", () => {
   });
 
   it("normalizes non-Error response read failures into command results", async () => {
+    usePosixProcess();
     fs.exists.mockImplementation((path) => !String(path).includes("busy_"));
     fs.read.mockImplementation(() => {
       throw "response file is locked";

--- a/tests/tools/audio-edit-export-coverage.test.ts
+++ b/tests/tools/audio-edit-export-coverage.test.ts
@@ -1,0 +1,302 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { mockExecFile } = vi.hoisted(() => ({
+  mockExecFile: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({ execFile: mockExecFile }));
+vi.mock("node:util", async (importOriginal) => {
+  const original = await importOriginal<typeof import("node:util")>();
+  return {
+    ...original,
+    promisify: () => (...args: any[]) => new Promise((resolve, reject) => {
+      mockExecFile(...args, (error: Error | null, stdout: string, stderr: string) => {
+        if (error) reject(error);
+        else resolve({ stdout, stderr });
+      });
+    }),
+  };
+});
+vi.mock("../../src/bridge/file-bridge.js", () => ({
+  sendCommand: vi.fn(),
+}));
+
+import { sendCommand } from "../../src/bridge/file-bridge.js";
+import { getAudioTools } from "../../src/tools/audio.js";
+import { confirmationToken, getEditPlanTools, validateEditPlan } from "../../src/tools/edit-plans.js";
+import {
+  getExportTools,
+  inspectExportPresetFile,
+  verifyDeliveryFile,
+} from "../../src/tools/export.js";
+
+const mockedSendCommand = vi.mocked(sendCommand);
+const temporaryDirectories: string[] = [];
+const bridgeOptions = { tempDir: "/tmp/coverage-tools", timeoutMs: 500 };
+
+function temporaryPath(name: string, contents = "test content"): string {
+  const directory = mkdtempSync(join(tmpdir(), "premiere-tool-coverage-"));
+  temporaryDirectories.push(directory);
+  const path = join(directory, name);
+  writeFileSync(path, contents);
+  return path;
+}
+
+function temporaryDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "premiere-tool-coverage-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+function execSucceeds(stderr = ""): void {
+  mockExecFile.mockImplementationOnce((...args: any[]) => {
+    args.at(-1)(null, "", stderr);
+  });
+}
+
+function execFails(error: Error): void {
+  mockExecFile.mockImplementationOnce((...args: any[]) => {
+    args.at(-1)(error, "", "");
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedSendCommand.mockResolvedValue({ success: true, data: { host: "ok" } });
+});
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe("audio tool analysis coverage", () => {
+  it("resolves a project item, runs ffmpeg, and returns silent and retained ranges", async () => {
+    const mediaPath = temporaryPath("speech.mp4");
+    mockedSendCommand.mockResolvedValueOnce({
+      success: true,
+      data: { mediaPath, name: "Interview" },
+    });
+    execSucceeds();
+    execSucceeds([
+      "Duration: 00:00:12.00, start: 0.000000",
+      "[silencedetect] silence_start: 2",
+      "[silencedetect] silence_end: 4.5 | silence_duration: 2.5",
+      "[silencedetect] silence_start: 10",
+    ].join("\n"));
+
+    const result = await getAudioTools(bridgeOptions).detect_silence.handler({
+      project_item_id: "interview-item",
+      noise_threshold_db: -42,
+      min_duration_seconds: 0.75,
+    });
+
+    expect(mockedSendCommand).toHaveBeenCalledOnce();
+    expect(mockedSendCommand.mock.calls[0][0]).toContain("getMediaPath");
+    expect(mockExecFile).toHaveBeenCalledTimes(2);
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        mediaPath,
+        projectItemName: "Interview",
+        noiseThresholdDb: -42,
+        minDurationSeconds: 0.75,
+        totalDurationSeconds: 12,
+        silenceIntervals: [
+          { start: 2, end: 4.5, duration: 2.5 },
+          { start: 10, end: 12, duration: 2 },
+        ],
+        segments: [
+          { start: 0, end: 2, duration: 2 },
+          { start: 4.5, end: 10, duration: 5.5 },
+        ],
+        silentSeconds: 4.5,
+      },
+    });
+  });
+
+  it("reports missing ffmpeg, timeouts, and useful analyser failure details", async () => {
+    const mediaPath = temporaryPath("speech.mp4");
+    const tools = getAudioTools(bridgeOptions);
+
+    execFails(new Error("ENOENT"));
+    await expect(tools.detect_silence.handler({ media_path: mediaPath }))
+      .resolves.toMatchObject({ success: false, error: expect.stringContaining("ffmpeg was not found") });
+
+    execSucceeds();
+    execFails(Object.assign(new Error("slow"), { killed: true }));
+    await expect(tools.detect_silence.handler({ media_path: mediaPath }))
+      .resolves.toMatchObject({ success: false, error: expect.stringContaining("timed out after 300s") });
+
+    execSucceeds();
+    execFails(Object.assign(new Error("failed"), {
+      stderr: "first line\n\nsecond line\nthird line\nfourth line",
+    }));
+    await expect(tools.detect_silence.handler({ media_path: mediaPath }))
+      .resolves.toMatchObject({ success: false, error: expect.stringContaining("second line third line fourth line") });
+  });
+
+  it("renders audio adjustment, keyframe, and unmute options into the bridge script", async () => {
+    const tools = getAudioTools(bridgeOptions);
+
+    await tools.adjust_audio_levels.handler({ node_id: "clip\"id", level_db: -6 });
+    // Premiere's Volume > Level uses +15 dB as its normalized maximum.
+    expect(mockedSendCommand.mock.calls.at(-1)?.[0]).toContain("0.08912509381337455");
+
+    await tools.add_audio_keyframes.handler({
+      node_id: "clip",
+      keyframes: [{ time_seconds: 1.25, level_db: -Infinity }],
+    });
+    expect(mockedSendCommand.mock.calls.at(-1)?.[0]).toContain("1e-7");
+
+    await tools.mute_track.handler({ track_index: 3, muted: false });
+    expect(mockedSendCommand.mock.calls.at(-1)?.[0]).toContain("track.setMute(0)");
+  });
+});
+
+describe("edit plan validation and apply coverage", () => {
+  it.each([
+    [null, "plan must be an object"],
+    [{}, "plan.operations must contain at least one operation"],
+    [{ operations: Array.from({ length: 101 }, () => ({ type: "remove_clip", node_id: "clip" })) }, "limited to 100"],
+    [{ operations: [null] }, "operation 0 must be an object"],
+    [{ operations: [{ type: "insert_clip", start_seconds: 0 }] }, "requires item_id"],
+    [{ operations: [{ type: "insert_clip", item_id: "item", start_seconds: Number.NaN }] }, "non-negative number"],
+    [{ operations: [{ type: "insert_clip", item_id: "item", start_seconds: 0, video_track_index: -1 }] }, "video_track_index"],
+    [{ operations: [{ type: "insert_clip", item_id: "item", start_seconds: 0, audio_track_index: 1.5 }] }, "audio_track_index"],
+    [{ operations: [{ type: "remove_clip", node_id: "" }] }, "requires node_id"],
+  ])("rejects %j", (value, message) => {
+    expect(() => validateEditPlan(value)).toThrow(message);
+  });
+
+  it("previews destructive and non-destructive work with stable confirmation", async () => {
+    const plan = {
+      operations: [
+        { type: "insert_clip" as const, item_id: "source", start_seconds: 2 },
+        { type: "remove_clip" as const, node_id: "old-clip", ripple: true },
+      ],
+    };
+    const tools = getEditPlanTools(bridgeOptions, {
+      capabilities: { capabilities: new Set(["inspect"]), source: "explicit" },
+      operationIdFactory: () => "preview-mixed",
+    });
+
+    const result = await tools.preview_edit_plan.handler({ plan });
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        operationId: "preview-mixed",
+        confirmationToken: confirmationToken(plan),
+        changes: [
+          { type: "insert_clip", target: "source", destructive: false },
+          { type: "remove_clip", target: "old-clip", destructive: true },
+        ],
+      },
+    });
+    expect(confirmationToken({ ...plan, sequence_id: "other" })).not.toBe(confirmationToken(plan));
+  });
+
+  it("builds a remove plan against a named sequence and decorates bridge failures", async () => {
+    const plan = {
+      sequence_id: "seq\"one",
+      operations: [
+        { type: "remove_clip" as const, node_id: "old-clip", ripple: true },
+        { type: "insert_clip" as const, item_id: "new-item", start_seconds: 3, video_track_index: 2, audio_track_index: 4 },
+      ],
+    };
+    const auditSink = vi.fn();
+    mockedSendCommand.mockResolvedValueOnce({ success: false, error: "Premiere rejected the edit" });
+    const tools = getEditPlanTools(bridgeOptions, {
+      capabilities: { capabilities: new Set(["inspect", "edit"]), source: "explicit" },
+      auditSink,
+      operationIdFactory: () => "apply-remove",
+    });
+
+    const result = await tools.apply_edit_plan.handler({
+      plan,
+      confirmation_token: confirmationToken(plan),
+    });
+    const script = String(mockedSendCommand.mock.calls[0][0]);
+
+    expect(script).toContain('__findSequence("seq\\"one")');
+    expect(script).toContain("function __planFindClip");
+    expect(script).toContain("found0.remove(true, true)");
+    expect(result).toEqual({ success: false, error: "Premiere rejected the edit (operation apply-remove)" });
+    expect(auditSink.mock.calls.map(([event]) => event.outcome)).toEqual(["started", "failed"]);
+  });
+});
+
+describe("export verification and host-result coverage", () => {
+  it("validates a SHA-512 delivery and rejects malformed size constraints", async () => {
+    const delivery = temporaryPath("delivery.mov", "delivery data");
+    const checksum = createHash("sha512").update("delivery data").digest("hex");
+
+    await expect(verifyDeliveryFile(delivery, { minimumSizeBytes: -1 })).rejects.toThrow("minimum_size_bytes");
+    await expect(verifyDeliveryFile(delivery, { expectedSizeBytes: 1.5 })).rejects.toThrow("expected_size_bytes");
+    await expect(verifyDeliveryFile(temporaryDirectory())).rejects.toThrow("not a regular file");
+
+    await expect(verifyDeliveryFile(delivery, {
+      algorithm: "sha512",
+      expectedChecksum: ` ${checksum.toUpperCase()} `,
+      expectedSizeBytes: 13,
+      minimumSizeBytes: 0,
+    })).resolves.toMatchObject({
+      checksum: { algorithm: "sha512", value: checksum },
+      matchesExpectedChecksum: true,
+      matchesExpectedSize: true,
+      valid: true,
+    });
+  });
+
+  it("surfaces local preset and delivery errors, then merges a host-validated preset response", async () => {
+    const tools = getExportTools(bridgeOptions);
+    const invalid = temporaryPath("preset.xml", "preset");
+    await expect(tools.validate_export_preset.handler({ preset_path: invalid }))
+      .resolves.toMatchObject({ success: false, error: expect.stringContaining(".epr") });
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+
+    const preset = temporaryPath("preset.epr", "preset");
+    mockedSendCommand.mockResolvedValueOnce({ success: false, error: "No active sequence" });
+    await expect(tools.validate_export_preset.handler({ preset_path: preset }))
+      .resolves.toEqual({ success: false, error: "No active sequence" });
+
+    mockedSendCommand.mockResolvedValueOnce({ success: true, data: { outputExtension: ".mov" } });
+    await expect(tools.validate_export_preset.handler({ preset_path: preset }))
+      .resolves.toMatchObject({ success: true, data: { path: preset, outputExtension: ".mov", hostValidated: true } });
+    expect(inspectExportPresetFile(preset).sizeBytes).toBe(6);
+
+    await expect(tools.verify_delivery_file.handler({ output_path: join(tmpdir(), "missing-delivery.mov") }))
+      .resolves.toMatchObject({ success: false, error: expect.stringContaining("does not exist") });
+  });
+
+  it("reads a host-exported frame, reports unreadable output, and covers proxy script choices", async () => {
+    const tools = getExportTools(bridgeOptions);
+    const frame = temporaryPath("frame.png", "png bytes");
+    mockedSendCommand.mockResolvedValueOnce({ success: true, data: { outputPath: frame } });
+    await expect(tools.capture_frame.handler({ time_seconds: 3 })).resolves.toMatchObject({
+      success: true,
+      data: { captured: true, mimeType: "image/png", base64: Buffer.from("png bytes").toString("base64") },
+    });
+    expect(existsSync(frame)).toBe(false);
+
+    mockedSendCommand.mockResolvedValueOnce({ success: true, data: { outputPath: temporaryDirectory() } });
+    await expect(tools.capture_frame.handler({})).resolves.toMatchObject({
+      success: false,
+      error: expect.stringContaining("Failed to read captured frame"),
+    });
+
+    await tools.manage_proxies.handler({ item_id: "item", action: "create" });
+    expect(mockedSendCommand.mock.calls.at(-1)?.[0]).toContain("output_path is required");
+    await tools.manage_proxies.handler({ item_id: "item", action: "create", output_path: "proxy.mov" });
+    expect(mockedSendCommand.mock.calls.at(-1)?.[0]).toContain("__findProxyPreset()");
+    await tools.manage_proxies.handler({ item_id: "item", action: "create", output_path: "proxy.mov", preset_path: "proxy.epr" });
+    expect(mockedSendCommand.mock.calls.at(-1)?.[0]).toContain('var presetPath = "proxy.epr"');
+    await tools.manage_proxies.handler({ item_id: "item", action: "attach" });
+    expect(mockedSendCommand.mock.calls.at(-1)?.[0]).toContain("proxy_path is required for attach action");
+  });
+});

--- a/tests/tools/health-coverage.test.ts
+++ b/tests/tools/health-coverage.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/bridge/file-bridge.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/bridge/file-bridge.js")>();
+  return { ...actual, sendCommand: vi.fn() };
+});
+
+vi.mock("../../src/telemetry.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/telemetry.js")>();
+  return { ...actual, captureActivationEvent: vi.fn() };
+});
+
+import { sendCommand } from "../../src/bridge/file-bridge.js";
+import { getHealthTools } from "../../src/tools/health.js";
+
+const mockedSendCommand = vi.mocked(sendCommand);
+
+afterEach(() => vi.clearAllMocks());
+
+describe("health connection diagnostics", () => {
+  it("returns an explicit local feature-support report and safely surfaces invalid version input", async () => {
+    const tools = getHealthTools(
+      { tempDir: "/tmp/health" },
+      undefined,
+      () => ({}),
+    );
+    await expect(tools.get_advanced_feature_support.handler({
+      backend: "uxp",
+      premiere_version: "26.3.0",
+      frameio_entitled: true,
+      generative_ai_entitled: true,
+      network_available: true,
+    })).resolves.toMatchObject({
+      success: true,
+      data: {
+        context: { backend: "uxp", premiereVersion: "26.3.0" },
+        features: { productions: { staticEligibility: { eligible: true } } },
+      },
+    });
+    await expect(tools.get_advanced_feature_support.handler({
+      premiere_version: "26.beta",
+    })).resolves.toEqual({
+      success: false,
+      error: "premiere_version must contain only numeric version components",
+    });
+  });
+
+  it("reports an unavailable UXP bridge without falling back to CEP", async () => {
+    const telemetry = { enabled: true, capture: vi.fn(), shutdown: vi.fn() };
+    const result = await getHealthTools({ tempDir: "/tmp/health" }, undefined, undefined, { telemetry })
+      .verify_premiere_connection.handler({ backend: "uxp" });
+
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        backend: "uxp",
+        overall: "needs_attention",
+        components: expect.arrayContaining([
+          expect.objectContaining({ id: "premiere_connector", state: "needs_attention" }),
+        ]),
+      },
+    });
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+    expect(telemetry.capture).not.toHaveBeenCalled();
+  });
+
+  it("treats a malformed UXP state response as a reachable host with no open project", async () => {
+    const request = vi.fn().mockResolvedValue(null);
+    const result = await getHealthTools(
+      { tempDir: "/tmp/health" },
+      undefined,
+      undefined,
+      { uxpBridge: { request } as any },
+    ).verify_premiere_connection.handler({ backend: "uxp" });
+
+    expect(request).toHaveBeenCalledWith("state.get");
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        backend: "uxp",
+        overall: "needs_attention",
+        components: expect.arrayContaining([
+          expect.objectContaining({ id: "premiere_connector", state: "ready" }),
+          expect.objectContaining({ id: "active_project", state: "needs_attention" }),
+          expect.objectContaining({ id: "active_sequence", state: "needs_attention" }),
+        ]),
+      },
+    });
+  });
+
+  it("reports an unreachable UXP bridge when its read-only request rejects", async () => {
+    const request = vi.fn().mockRejectedValue(new Error("panel closed"));
+    const result = await getHealthTools(
+      { tempDir: "/tmp/health" },
+      undefined,
+      undefined,
+      { uxpBridge: { request } as any },
+    ).verify_premiere_connection.handler({ backend: "uxp" });
+
+    expect(result).toMatchObject({
+      success: true,
+      data: { backend: "uxp", overall: "needs_attention" },
+    });
+  });
+
+  it("handles failed and thrown CEP probes as unavailable diagnostics", async () => {
+    mockedSendCommand.mockResolvedValueOnce({ success: false, error: "CEP unavailable" });
+    const tools = getHealthTools({ tempDir: "/tmp/health" });
+    await expect(tools.verify_premiere_connection.handler({ backend: "cep" }))
+      .resolves.toMatchObject({ success: true, data: { backend: "cep", overall: "needs_attention" } });
+
+    mockedSendCommand.mockRejectedValueOnce(new Error("bridge directory unreadable"));
+    await expect(tools.verify_premiere_connection.handler({ backend: "cep" }))
+      .resolves.toMatchObject({ success: true, data: { backend: "cep", overall: "needs_attention" } });
+  });
+});

--- a/tests/tools/recovery-edge-coverage.test.ts
+++ b/tests/tools/recovery-edge-coverage.test.ts
@@ -1,0 +1,224 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fsFaults = vi.hoisted(() => ({
+  inaccessibleDirectories: new Set<string>(),
+  vanishedFiles: new Set<string>(),
+}));
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readdirSync: (...args: Parameters<typeof actual.readdirSync>) => {
+      if (fsFaults.inaccessibleDirectories.has(resolve(String(args[0])))) {
+        const error = Object.assign(new Error("permission denied"), { code: "EACCES" });
+        throw error;
+      }
+      return actual.readdirSync(...args);
+    },
+    statSync: (...args: Parameters<typeof actual.statSync>) => {
+      if (fsFaults.vanishedFiles.has(resolve(String(args[0])))) {
+        const error = Object.assign(new Error("file disappeared"), { code: "ENOENT" });
+        throw error;
+      }
+      return actual.statSync(...args);
+    },
+  };
+});
+
+vi.mock("../../src/bridge/file-bridge.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/bridge/file-bridge.js")>();
+  return { ...actual, sendCommand: vi.fn() };
+});
+
+import { sendCommand } from "../../src/bridge/file-bridge.js";
+import {
+  collectBridgeTelemetry,
+  discoverAdjacentRecoveryCandidates,
+  getRecoveryTools,
+} from "../../src/tools/recovery.js";
+
+const mockedSendCommand = vi.mocked(sendCommand);
+const temporaryDirectories: string[] = [];
+
+function temporaryDirectory(): string {
+  const directory = mkdtempSync(join(tmpdir(), "premiere-recovery-edge-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+afterEach(() => {
+  fsFaults.inaccessibleDirectories.clear();
+  fsFaults.vanishedFiles.clear();
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("recovery discovery filesystem edges", () => {
+  it("keeps an autosave for a missing project path but marks its project timestamp as unknown", () => {
+    const directory = temporaryDirectory();
+    const missingProject = join(directory, "Rough Cut.prproj");
+    const autosaveDirectory = join(directory, "Premiere Pro Auto-Save");
+    mkdirSync(autosaveDirectory);
+    const autosave = join(autosaveDirectory, "Rough Cut backup.PRPROJ");
+    writeFileSync(autosave, "autosave");
+    mkdirSync(join(autosaveDirectory, "Rough Cut folder.prproj"));
+
+    const candidates = discoverAdjacentRecoveryCandidates(missingProject);
+
+    expect(candidates).toEqual([
+      expect.objectContaining({
+        path: autosave,
+        fileName: "Rough Cut backup.PRPROJ",
+        newerThanProjectFile: null,
+      }),
+    ]);
+  });
+
+  it("omits inaccessible autosave directories and candidates that disappear during inspection", () => {
+    const directory = temporaryDirectory();
+    const project = join(directory, "Episode.prproj");
+    writeFileSync(project, "project");
+    const inaccessibleAutosaves = join(directory, "Adobe Premiere Pro Auto-Save");
+    mkdirSync(inaccessibleAutosaves);
+    writeFileSync(join(inaccessibleAutosaves, "Episode inaccessible.prproj"), "autosave");
+    fsFaults.inaccessibleDirectories.add(resolve(inaccessibleAutosaves));
+    const vanishing = join(directory, "Episode vanishing.prproj");
+    writeFileSync(vanishing, "autosave");
+    fsFaults.vanishedFiles.add(resolve(vanishing));
+
+    expect(discoverAdjacentRecoveryCandidates(project)).toEqual([]);
+  });
+
+  it("bounds discovery to fifty candidates even when more matching autosaves exist", () => {
+    const directory = temporaryDirectory();
+    const project = join(directory, "Assembly.prproj");
+    writeFileSync(project, "project");
+    const autosaveDirectory = join(directory, "Adobe Premiere Pro Auto-Save");
+    mkdirSync(autosaveDirectory);
+    for (let index = 0; index < 51; index++) {
+      const candidate = join(autosaveDirectory, `Assembly-${String(index).padStart(2, "0")}.prproj`);
+      writeFileSync(candidate, String(index));
+      utimesSync(candidate, new Date(1_000 + index), new Date(1_000 + index));
+    }
+
+    const candidates = discoverAdjacentRecoveryCandidates(project);
+    expect(candidates).toHaveLength(50);
+    expect(candidates[0].modifiedMs).toBeGreaterThanOrEqual(candidates.at(-1)!.modifiedMs);
+  });
+});
+
+describe("bridge telemetry filesystem edges", () => {
+  it("remains useful when an individual pending file disappears", () => {
+    const directory = temporaryDirectory();
+    const pending = join(directory, "cmd_transient.jsx");
+    writeFileSync(pending, "private script");
+    fsFaults.vanishedFiles.add(resolve(pending));
+
+    expect(collectBridgeTelemetry({ tempDir: directory }, 50_000)).toMatchObject({
+      directoryAccessible: true,
+      pendingCommands: 1,
+      pendingResponses: 0,
+      busyOperations: 0,
+      oldestPendingAgeMs: null,
+      healthy: false,
+    });
+  });
+
+  it("reports an inaccessible bridge directory as unhealthy without exposing its details", async () => {
+    const directory = temporaryDirectory();
+    fsFaults.inaccessibleDirectories.add(resolve(directory));
+    const tools = getRecoveryTools({ tempDir: directory });
+
+    const result = await tools.get_bridge_telemetry.handler();
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        directoryAccessible: false,
+        pendingCommands: 0,
+        pendingResponses: 0,
+        busyOperations: 0,
+        healthy: false,
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain(directory);
+  });
+
+  it("marks an old response unhealthy while ignoring unrelated bridge files", () => {
+    const directory = temporaryDirectory();
+    const response = join(directory, "res_old.json");
+    writeFileSync(response, "{}");
+    writeFileSync(join(directory, "not-a-queue-file.txt"), "private");
+    utimesSync(response, new Date(1_000), new Date(1_000));
+
+    expect(collectBridgeTelemetry({ tempDir: directory }, 32_000)).toMatchObject({
+      directoryAccessible: true,
+      pendingCommands: 0,
+      pendingResponses: 1,
+      busyOperations: 0,
+      oldestPendingAgeMs: 31_000,
+      healthy: false,
+    });
+  });
+});
+
+describe("recovery inspection snapshots", () => {
+  it.each([
+    [null],
+    [{}],
+    [{ name: "Project", path: 17 }],
+    [{ name: 17, path: "project.prproj" }],
+  ])("rejects an invalid Premiere snapshot: %j", async (data) => {
+    mockedSendCommand.mockResolvedValueOnce({ success: true, data });
+    const result = await getRecoveryTools({ tempDir: temporaryDirectory() }).inspect_project_recovery.handler();
+    expect(result).toEqual({ success: false, error: "Premiere returned an invalid project snapshot" });
+  });
+
+  it("preserves bridge failures instead of attempting local recovery discovery", async () => {
+    mockedSendCommand.mockResolvedValueOnce({ success: false, error: "No project is open" });
+    await expect(getRecoveryTools({ tempDir: temporaryDirectory() }).inspect_project_recovery.handler())
+      .resolves.toEqual({ success: false, error: "No project is open" });
+  });
+
+  it("explains the unsaved-project boundary and missing saved project boundary distinctly", async () => {
+    const tools = getRecoveryTools({ tempDir: temporaryDirectory() });
+    mockedSendCommand.mockResolvedValueOnce({ success: true, data: { name: "Untitled", path: "" } });
+    await expect(tools.inspect_project_recovery.handler()).resolves.toMatchObject({
+      success: true,
+      data: {
+        project: { name: "Untitled", path: null, hasSavedPath: false, fileExists: false },
+        recovery: {
+          candidateCount: 0,
+          guidance: expect.stringContaining("Save the project"),
+        },
+      },
+    });
+
+    const missingProject = join(temporaryDirectory(), "missing.prproj");
+    mockedSendCommand.mockResolvedValueOnce({ success: true, data: { name: "Missing", path: missingProject } });
+    await expect(tools.inspect_project_recovery.handler()).resolves.toMatchObject({
+      success: true,
+      data: {
+        project: { name: "Missing", path: missingProject, hasSavedPath: true, fileExists: false },
+        recovery: {
+          candidateCount: 0,
+          guidance: expect.stringContaining("No adjacent .prproj"),
+        },
+      },
+    });
+  });
+});

--- a/tests/tools/transcript-edits-edge-coverage.test.ts
+++ b/tests/tools/transcript-edits-edge-coverage.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeTranscriptDeletionRanges,
+  previewTranscriptEdit,
+  transcriptRevision,
+} from "../../src/tools/transcript-edits.js";
+
+describe("transcript edit range edge cases", () => {
+  it.each([
+    [null, "deletion 0 must be an object"],
+    ["not a range", "deletion 0 must be an object"],
+    [{ start_seconds: -0.01, end_seconds: 1 }, "start_seconds must be a non-negative number"],
+    [{ start_seconds: Number.NaN, end_seconds: 1 }, "start_seconds must be a non-negative number"],
+    [{ start_seconds: 1, end_seconds: Number.POSITIVE_INFINITY }, "end_seconds must be greater than start_seconds"],
+    [{ start_seconds: 1, end_seconds: 1 }, "end_seconds must be greater than start_seconds"],
+  ])("rejects invalid deletion input %j", (deletion, message) => {
+    expect(() => normalizeTranscriptDeletionRanges([deletion])).toThrow(message);
+  });
+
+  it("rounds normalized values and merges precisely adjacent ranges", () => {
+    expect(normalizeTranscriptDeletionRanges([
+      { start_seconds: 2, end_seconds: 3.00000049 },
+      { start_seconds: 1.00000031, end_seconds: 2 },
+    ], 0.0000004)).toEqual([
+      { start_seconds: 1, end_seconds: 3.000001 },
+    ]);
+  });
+
+  it("uses end time as a stable secondary sort key before merging equal-start ranges", () => {
+    expect(normalizeTranscriptDeletionRanges([
+      { start_seconds: 5.0000004, end_seconds: 8 },
+      { start_seconds: 5.0000003, end_seconds: 6 },
+    ])).toEqual([
+      { start_seconds: 5, end_seconds: 8 },
+    ]);
+  });
+});
+
+describe("transcript preview revision guard", () => {
+  it("rejects empty transcript payloads before creating a revision", () => {
+    expect(() => previewTranscriptEdit("", "", [{ start_seconds: 1, end_seconds: 2 }]))
+      .toThrow("Premiere returned an empty transcript");
+    expect(() => previewTranscriptEdit(null as unknown as string, "", [{ start_seconds: 1, end_seconds: 2 }]))
+      .toThrow("Premiere returned an empty transcript");
+  });
+
+  it("does not treat an empty requested revision as a valid transcript lock", () => {
+    const json = '{"segments":[{"text":"approve"}]}';
+    expect(transcriptRevision(json)).not.toBe("");
+    expect(() => previewTranscriptEdit(json, "", [{ start_seconds: 1, end_seconds: 2 }]))
+      .toThrow("Transcript revision does not match");
+  });
+});

--- a/tests/tools/uxp-optional-arguments-coverage.test.ts
+++ b/tests/tools/uxp-optional-arguments-coverage.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import type { UxpWebSocketBridge } from "../../src/bridge/uxp-websocket-bridge.js";
+import { getUxpTools } from "../../src/tools/uxp.js";
+
+function createTools(result: unknown = { accepted: true }) {
+  const request = vi.fn().mockResolvedValue(result);
+  const bridge = { request, getState: vi.fn() } as unknown as UxpWebSocketBridge;
+  return { request, tools: getUxpTools(bridge) };
+}
+
+describe("UXP tool optional argument mappings", () => {
+  it("keeps an explicitly empty AAF options object distinct from omitted options", async () => {
+    const { request, tools } = createTools({ path: "/exports/mix.aaf" });
+
+    await expect(tools.export_aaf_uxp.handler({
+      output_file_path: "/exports/mix.aaf",
+      options: {},
+    })).resolves.toEqual({
+      success: true,
+      data: { backend: "uxp", result: { path: "/exports/mix.aaf" } },
+    });
+    expect(request).toHaveBeenCalledWith("interchange.aaf.export", {
+      outputFilePath: "/exports/mix.aaf",
+      options: {},
+    });
+  });
+
+  it("maps explicitly false AAF toggles and the optional operation id", async () => {
+    const { request, tools } = createTools();
+
+    await tools.export_aaf_uxp.handler({
+      output_file_path: "/exports/final.aaf",
+      operation_id: "aaf-optional-1",
+      options: {
+        mixdown_video: false,
+        explode_to_mono: false,
+        sample_rate: 48_000,
+        bits_per_sample: 24,
+        embed_audio: false,
+        audio_file_format: "wav",
+        trim_sources: false,
+        handle_frames: 0,
+        video_mixdown_preset_path: "/presets/none.epr",
+        render_audio_effects: false,
+        interleave_without_effects: false,
+        preserve_parent_folder: false,
+      },
+    });
+
+    expect(request).toHaveBeenCalledWith("interchange.aaf.export", {
+      outputFilePath: "/exports/final.aaf",
+      operationId: "aaf-optional-1",
+      options: {
+        mixdownVideo: false,
+        explodeToMono: false,
+        sampleRate: 48_000,
+        bitsPerSample: 24,
+        embedAudio: false,
+        audioFileFormat: "wav",
+        trimSources: false,
+        handleFrames: 0,
+        videoMixdownPresetPath: "/presets/none.epr",
+        renderAudioEffects: false,
+        interleaveWithoutEffects: false,
+        preserveParentFolder: false,
+      },
+    });
+  });
+
+  it("normalizes a non-Error transcript export failure while mapping name selection", async () => {
+    const { request, tools } = createTools();
+    request.mockRejectedValueOnce("host disconnected");
+
+    await expect(tools.get_clip_transcript_uxp.handler({
+      project_item_name: "Interview A",
+    })).resolves.toEqual({ success: false, error: "host disconnected" });
+    expect(request).toHaveBeenCalledWith("transcript.export", {
+      projectItemName: "Interview A",
+    });
+  });
+
+  it("rejects an invalid transcript before generating a preview token", async () => {
+    const { request, tools } = createTools({ projectItemId: "clip-9" });
+
+    await expect(tools.preview_transcript_edit_uxp.handler({
+      project_item_id: "clip-9",
+      transcript_revision: `sha256:${"a".repeat(64)}`,
+      deletions: [{ start_seconds: 1, end_seconds: 2 }],
+    })).resolves.toEqual({
+      success: false,
+      error: "Premiere returned an empty transcript",
+    });
+    expect(request).toHaveBeenCalledWith("transcript.export", { projectItemId: "clip-9" });
+  });
+
+  it("normalizes a non-Error transcript preview export failure", async () => {
+    const { request, tools } = createTools();
+    request.mockRejectedValueOnce(null);
+
+    await expect(tools.preview_transcript_edit_uxp.handler({
+      transcript_revision: `sha256:${"b".repeat(64)}`,
+      deletions: [{ start_seconds: 1, end_seconds: 2 }],
+    })).resolves.toEqual({ success: false, error: "null" });
+  });
+
+  it("maps the explicit sequence marker scope to the wire protocol spelling", async () => {
+    const { request, tools } = createTools();
+
+    await tools.list_markers_uxp.handler({ scope: "sequence" });
+    expect(request).toHaveBeenCalledWith("marker.list", { scope: "sequence" });
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for bridge command publication, UXP argument mapping, audio/edit/export branches, recovery edge cases, health diagnostics, and transcript edit validation
- keep all additions test-only and current-main compatible

## Validation
- npm run check
- npm run test:coverage

Coverage: 95.26% statements, 91.73% branches, 96.45% functions, 96.82% lines (2,069 tests passed).