### PR TITLE
Verify native SDK header receipts

### DIFF
--- a/docs/native-sdk-header-inventory.md
+++ b/docs/native-sdk-header-inventory.md
@@ -26,6 +26,21 @@ For `uxp-hybrid`, the command requires the public-guide layout:
 is hashed independently. `--check` compares a regenerated receipt with a
 reviewed one; `--validate-only` verifies the supplied artifact without writing.
 
+Use the standalone verifier when a reviewer needs to inspect a receipt without
+receiving the SDK extraction or archive. It rejects extra fields (including
+header contents and absolute paths), inconsistent totals, non-canonical or
+duplicate paths, incorrect hashes, and Hybrid receipts missing the public-guide
+headers:
+
+```powershell
+npm run native:sdk-header-inventory:verify -- `
+  --input C:\sdk-evidence\uxp-hybrid-headers.json
+```
+
+This checks receipt structure and declared provenance only. It cannot verify
+the private archive bytes, compile the SDK, or establish that an addon can load
+in Premiere.
+
 For `premiere-prsdk`, pass each documented include directory explicitly because
 Adobe does not publicly publish a stable header layout:
 

--- a/docs/native-sdk-header-inventory.md
+++ b/docs/native-sdk-header-inventory.md
@@ -29,7 +29,7 @@ reviewed one; `--validate-only` verifies the supplied artifact without writing.
 Use the standalone verifier when a reviewer needs to inspect a receipt without
 receiving the SDK extraction or archive. It rejects extra fields (including
 header contents and absolute paths), inconsistent totals, non-canonical or
-duplicate paths, incorrect hashes, and Hybrid receipts missing the public-guide
+duplicate paths, malformed digest fields, and Hybrid receipts missing the public-guide
 headers:
 
 ```powershell

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "validate:marketplace-branding": "node scripts/validate-adobe-marketplace-branding.mjs",
     "benchmark:uxp-hybrid:verify": "node scripts/verify-uxp-hybrid-benchmark.mjs",
     "native:sdk-header-inventory": "node scripts/generate-native-sdk-header-inventory.mjs",
+    "native:sdk-header-inventory:verify": "node scripts/verify-native-sdk-header-inventory.mjs",
     "docs:supported-actions": "npm run build && node scripts/generate-supported-actions.mjs",
     "docs:supported-actions:check": "node scripts/generate-supported-actions.mjs --check",
     "docs:quickstart:check": "node scripts/check-quickstart-locales.mjs",

--- a/scripts/generate-native-sdk-header-inventory.mjs
+++ b/scripts/generate-native-sdk-header-inventory.mjs
@@ -4,23 +4,13 @@ import { createHash } from "node:crypto";
 import { readFile, readdir, realpath, stat, writeFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { relative, resolve, sep } from "node:path";
-
-const SDK_FAMILIES = {
-  "uxp-hybrid": {
-    authorityUrl: "https://developer.adobe.com/premiere-pro/uxp/plugins/hybrid-plugins/",
-    includeDirectories: ["src/api", "src/utilities"],
-    requiredHeaders: [
-      "src/api/UxpAddonShared.h",
-      "src/api/UxpAddonTypes.h",
-      "src/utilities/UxpAddon.h",
-    ],
-  },
-  "premiere-prsdk": {
-    authorityUrl: "https://developer.adobe.com/premiere-pro/",
-    includeDirectories: null,
-    requiredHeaders: [],
-  },
-};
+import {
+  compareNativeSdkPaths,
+  hasNativeSdkFamily,
+  NATIVE_SDK_FAMILIES,
+  NATIVE_SDK_HEADER_INVENTORY_SCHEMA_VERSION,
+  NATIVE_SDK_HEADER_INVENTORY_SEMANTICS,
+} from "./native-sdk-header-inventory-contract.mjs";
 
 function inventoryError(message) {
   const error = new Error(message);
@@ -32,10 +22,6 @@ function sha256(value) {
   return createHash("sha256").update(value).digest("hex");
 }
 
-function comparePaths(left, right) {
-  return left < right ? -1 : left > right ? 1 : 0;
-}
-
 function normalRelativePath(value, label) {
   if (typeof value !== "string" || !value || value.includes("\0")) {
     throw inventoryError(`${label} must be a non-empty relative path`);
@@ -44,7 +30,11 @@ function normalRelativePath(value, label) {
   if (normalized.startsWith("/") || /^[A-Za-z]:\//.test(normalized) || normalized.split("/").includes("..")) {
     throw inventoryError(`${label} must stay relative to the SDK root`);
   }
-  return normalized.replace(/\/$/, "");
+  const segments = normalized.split("/");
+  if (normalized !== "." && segments.some((segment) => segment === "" || segment === ".")) {
+    throw inventoryError(`${label} must use a canonical relative path`);
+  }
+  return normalized;
 }
 
 function stringOption(value, label, maximum = 512) {
@@ -90,7 +80,7 @@ async function listHeaders(root, includeDirectories) {
   const headers = [];
   const visit = async (directory) => {
     const entries = await readdir(directory, { withFileTypes: true });
-    entries.sort((left, right) => comparePaths(left.name, right.name));
+    entries.sort((left, right) => compareNativeSdkPaths(left.name, right.name));
     for (const entry of entries) {
       const candidate = resolve(directory, entry.name);
       if (entry.isSymbolicLink()) throw inventoryError(`SDK header inventory refuses symbolic link: ${relative(root, candidate)}`);
@@ -110,7 +100,7 @@ async function listHeaders(root, includeDirectories) {
     const path = await resolvedDirectoryInside(root, resolve(root, includeDirectory), `include directory ${includeDirectory}`);
     await visit(path);
   }
-  headers.sort((left, right) => comparePaths(left.path, right.path));
+  headers.sort((left, right) => compareNativeSdkPaths(left.path, right.path));
   if (headers.length === 0) throw inventoryError("No C/C++ headers were found in the selected SDK include directories");
   if (new Set(headers.map((header) => header.path)).size !== headers.length) {
     throw inventoryError("SDK include directories overlap and produced duplicate headers");
@@ -120,7 +110,7 @@ async function listHeaders(root, includeDirectories) {
 
 export async function generateNativeSdkHeaderInventory(options) {
   const sdk = options?.sdk;
-  const family = Object.prototype.hasOwnProperty.call(SDK_FAMILIES, sdk) ? SDK_FAMILIES[sdk] : undefined;
+  const family = hasNativeSdkFamily(sdk) ? NATIVE_SDK_FAMILIES[sdk] : undefined;
   if (!family) throw inventoryError("sdk must be uxp-hybrid or premiere-prsdk");
   const sdkVersion = stringOption(options?.sdkVersion, "sdkVersion", 128);
   const suppliedSdkRoot = resolve(stringOption(options?.sdkRoot, "sdkRoot", 4096));
@@ -151,7 +141,7 @@ export async function generateNativeSdkHeaderInventory(options) {
   }
   const archive = await readFile(archivePath);
   return {
-    schemaVersion: 1,
+    schemaVersion: NATIVE_SDK_HEADER_INVENTORY_SCHEMA_VERSION,
     source: {
       sdk,
       sdkVersion,
@@ -160,10 +150,7 @@ export async function generateNativeSdkHeaderInventory(options) {
       inventoryScope: "header_files_only",
       includeDirectories,
     },
-    semantics: {
-      listed: "Each listed item is a header file observed in a locally supplied Adobe SDK extraction. Paths are relative to that extraction and contents are not copied into this inventory.",
-      doesNotEstablish: "This receipt does not establish Adobe entitlement, complete C/C++ declaration coverage, a compiled addon, a loaded plugin, MCP exposure, or licensed-host behavior.",
-    },
+    semantics: NATIVE_SDK_HEADER_INVENTORY_SEMANTICS,
     stats: {
       headers: headers.length,
       bytes: headers.reduce((total, header) => total + header.bytes, 0),

--- a/scripts/generate-native-sdk-header-inventory.mjs
+++ b/scripts/generate-native-sdk-header-inventory.mjs
@@ -27,7 +27,7 @@ function normalRelativePath(value, label) {
     throw inventoryError(`${label} must be a non-empty relative path`);
   }
   const normalized = value.replaceAll("\\", "/");
-  if (normalized.startsWith("/") || /^[A-Za-z]:\//.test(normalized) || normalized.split("/").includes("..")) {
+  if (normalized.startsWith("/") || /^[A-Za-z]:/.test(normalized) || normalized.split("/").includes("..")) {
     throw inventoryError(`${label} must stay relative to the SDK root`);
   }
   const segments = normalized.split("/");

--- a/scripts/native-sdk-header-inventory-contract.mjs
+++ b/scripts/native-sdk-header-inventory-contract.mjs
@@ -1,0 +1,31 @@
+export const NATIVE_SDK_HEADER_INVENTORY_SCHEMA_VERSION = 1;
+
+export const NATIVE_SDK_HEADER_INVENTORY_SEMANTICS = Object.freeze({
+  listed: "Each listed item is a header file observed in a locally supplied Adobe SDK extraction. Paths are relative to that extraction and contents are not copied into this inventory.",
+  doesNotEstablish: "This receipt does not establish Adobe entitlement, complete C/C++ declaration coverage, a compiled addon, a loaded plugin, MCP exposure, or licensed-host behavior.",
+});
+
+export const NATIVE_SDK_FAMILIES = Object.freeze({
+  "uxp-hybrid": Object.freeze({
+    authorityUrl: "https://developer.adobe.com/premiere-pro/uxp/plugins/hybrid-plugins/",
+    includeDirectories: Object.freeze(["src/api", "src/utilities"]),
+    requiredHeaders: Object.freeze([
+      "src/api/UxpAddonShared.h",
+      "src/api/UxpAddonTypes.h",
+      "src/utilities/UxpAddon.h",
+    ]),
+  }),
+  "premiere-prsdk": Object.freeze({
+    authorityUrl: "https://developer.adobe.com/premiere-pro/",
+    includeDirectories: null,
+    requiredHeaders: Object.freeze([]),
+  }),
+});
+
+export function compareNativeSdkPaths(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+export function hasNativeSdkFamily(value) {
+  return Object.prototype.hasOwnProperty.call(NATIVE_SDK_FAMILIES, value);
+}

--- a/scripts/verify-native-sdk-header-inventory.mjs
+++ b/scripts/verify-native-sdk-header-inventory.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+import {
+  compareNativeSdkPaths,
+  hasNativeSdkFamily,
+  NATIVE_SDK_FAMILIES,
+  NATIVE_SDK_HEADER_INVENTORY_SCHEMA_VERSION,
+  NATIVE_SDK_HEADER_INVENTORY_SEMANTICS,
+} from "./native-sdk-header-inventory-contract.mjs";
+
+const SHA256_PATTERN = /^[a-f0-9]{64}$/;
+const HEADER_PATH_PATTERN = /\.(h|hpp)$/i;
+const MAX_HEADERS = 100_000;
+const MAX_PATH_LENGTH = 4_096;
+
+function verificationError(message) {
+  const error = new Error(message);
+  error.code = "NATIVE_SDK_INVENTORY_INVALID";
+  return error;
+}
+
+function record(value, label, expectedKeys) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw verificationError(`${label} must be an object`);
+  }
+  const keys = Object.keys(value).sort(compareNativeSdkPaths);
+  const expected = [...expectedKeys].sort(compareNativeSdkPaths);
+  if (keys.length !== expected.length || keys.some((key, index) => key !== expected[index])) {
+    throw verificationError(`${label} must contain only the documented receipt fields`);
+  }
+  return value;
+}
+
+function string(value, label, maximum = MAX_PATH_LENGTH) {
+  if (typeof value !== "string" || !value.trim() || value.length > maximum || value.includes("\0")) {
+    throw verificationError(`${label} must be a non-empty string of at most ${maximum} characters`);
+  }
+  return value;
+}
+
+function canonicalRelativePath(value, label) {
+  const path = string(value, label).replaceAll("\\", "/");
+  const segments = path.split("/");
+  if (path !== value || path.startsWith("/") || /^[A-Za-z]:\//.test(path) || path !== "." && segments.some((segment) => segment === "" || segment === "." || segment === "..")) {
+    throw verificationError(`${label} must be a canonical relative path`);
+  }
+  return path;
+}
+
+function sha256(value, label) {
+  if (typeof value !== "string" || !SHA256_PATTERN.test(value)) {
+    throw verificationError(`${label} must be a lowercase SHA-256 hex digest`);
+  }
+  return value;
+}
+
+function nonNegativeSafeInteger(value, label) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw verificationError(`${label} must be a non-negative safe integer`);
+  }
+  return value;
+}
+
+function headerIsInsideIncludeDirectory(path, includeDirectory) {
+  return includeDirectory === "." || path.startsWith(`${includeDirectory}/`);
+}
+
+export function verifyNativeSdkHeaderInventory(inventory) {
+  const receipt = record(inventory, "receipt", ["schemaVersion", "source", "semantics", "stats", "headers"]);
+  if (receipt.schemaVersion !== NATIVE_SDK_HEADER_INVENTORY_SCHEMA_VERSION) {
+    throw verificationError(`schemaVersion must be ${NATIVE_SDK_HEADER_INVENTORY_SCHEMA_VERSION}`);
+  }
+
+  const source = record(receipt.source, "source", ["sdk", "sdkVersion", "authorityUrl", "archiveSha256", "inventoryScope", "includeDirectories"]);
+  if (!hasNativeSdkFamily(source.sdk)) throw verificationError("source.sdk must be uxp-hybrid or premiere-prsdk");
+  const family = NATIVE_SDK_FAMILIES[source.sdk];
+  string(source.sdkVersion, "source.sdkVersion", 128);
+  if (source.authorityUrl !== family.authorityUrl) throw verificationError("source.authorityUrl does not match the documented SDK family");
+  sha256(source.archiveSha256, "source.archiveSha256");
+  if (source.inventoryScope !== "header_files_only") throw verificationError("source.inventoryScope must be header_files_only");
+  if (!Array.isArray(source.includeDirectories) || source.includeDirectories.length === 0 || source.includeDirectories.length > 64) {
+    throw verificationError("source.includeDirectories must contain one to 64 documented relative directories");
+  }
+  const includeDirectories = source.includeDirectories.map((directory) => canonicalRelativePath(directory, "source.includeDirectories entry"));
+  if (new Set(includeDirectories).size !== includeDirectories.length) {
+    throw verificationError("source.includeDirectories must not contain duplicates");
+  }
+  if (family.includeDirectories && (includeDirectories.length !== family.includeDirectories.length || includeDirectories.some((directory, index) => directory !== family.includeDirectories[index]))) {
+    throw verificationError(`${source.sdk} must use the documented fixed include directories`);
+  }
+
+  const semantics = record(receipt.semantics, "semantics", ["listed", "doesNotEstablish"]);
+  if (semantics.listed !== NATIVE_SDK_HEADER_INVENTORY_SEMANTICS.listed || semantics.doesNotEstablish !== NATIVE_SDK_HEADER_INVENTORY_SEMANTICS.doesNotEstablish) {
+    throw verificationError("semantics must retain the documented evidence boundary");
+  }
+
+  if (!Array.isArray(receipt.headers) || receipt.headers.length === 0 || receipt.headers.length > MAX_HEADERS) {
+    throw verificationError(`headers must contain one to ${MAX_HEADERS} entries`);
+  }
+  const headers = receipt.headers.map((header, index) => {
+    const value = record(header, `headers[${index}]`, ["path", "bytes", "sha256"]);
+    const path = canonicalRelativePath(value.path, `headers[${index}].path`);
+    if (!HEADER_PATH_PATTERN.test(path)) throw verificationError(`headers[${index}].path must name a .h or .hpp file`);
+    if (!includeDirectories.some((directory) => headerIsInsideIncludeDirectory(path, directory))) {
+      throw verificationError(`headers[${index}].path must stay within source.includeDirectories`);
+    }
+    return { path, bytes: nonNegativeSafeInteger(value.bytes, `headers[${index}].bytes`), sha256: sha256(value.sha256, `headers[${index}].sha256`) };
+  });
+  if (headers.some((header, index) => index > 0 && compareNativeSdkPaths(headers[index - 1].path, header.path) >= 0)) {
+    throw verificationError("headers must be strictly sorted by canonical path without duplicates");
+  }
+  for (const requiredHeader of family.requiredHeaders) {
+    if (!headers.some((header) => header.path === requiredHeader)) {
+      throw verificationError(`Missing required UXP Hybrid SDK header: ${requiredHeader}`);
+    }
+  }
+
+  const stats = record(receipt.stats, "stats", ["headers", "bytes"]);
+  if (stats.headers !== headers.length) throw verificationError("stats.headers does not match headers");
+  const totalBytes = headers.reduce((total, header) => total + header.bytes, 0);
+  if (!Number.isSafeInteger(totalBytes) || stats.bytes !== totalBytes) throw verificationError("stats.bytes does not match headers");
+
+  return Object.freeze({ sdk: source.sdk, headers: headers.length, bytes: totalBytes });
+}
+
+function parseArguments(argv) {
+  if (argv.length !== 2 || argv[0] !== "--input" || !argv[1] || argv[1].startsWith("--")) {
+    throw verificationError("Usage: node scripts/verify-native-sdk-header-inventory.mjs --input <receipt.json>");
+  }
+  return resolve(argv[1]);
+}
+
+async function main() {
+  const inputPath = parseArguments(process.argv.slice(2));
+  let inventory;
+  try { inventory = JSON.parse(await readFile(inputPath, "utf8")); } catch { throw verificationError("input must be a readable JSON receipt"); }
+  const summary = verifyNativeSdkHeaderInventory(inventory);
+  process.stdout.write(`Native SDK header receipt is valid: ${summary.headers} ${summary.sdk} header files, ${summary.bytes} bytes.\n`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/verify-native-sdk-header-inventory.mjs
+++ b/scripts/verify-native-sdk-header-inventory.mjs
@@ -44,7 +44,7 @@ function string(value, label, maximum = MAX_PATH_LENGTH) {
 function canonicalRelativePath(value, label) {
   const path = string(value, label).replaceAll("\\", "/");
   const segments = path.split("/");
-  if (path !== value || path.startsWith("/") || /^[A-Za-z]:\//.test(path) || path !== "." && segments.some((segment) => segment === "" || segment === "." || segment === "..")) {
+  if (path !== value || path.startsWith("/") || /^[A-Za-z]:/.test(path) || path !== "." && segments.some((segment) => segment === "" || segment === "." || segment === "..")) {
     throw verificationError(`${label} must be a canonical relative path`);
   }
   return path;

--- a/src/resources/premiere-surface-registry.json
+++ b/src/resources/premiere-surface-registry.json
@@ -72,8 +72,9 @@
       "inventoryState": "blocked_external_artifact",
       "implementationState": "gated",
       "inventoryCommand": "npm run native:sdk-header-inventory",
+      "inventoryVerificationCommand": "npm run native:sdk-header-inventory:verify",
       "inventoryDocumentation": "docs/native-sdk-header-inventory.md",
-      "notes": "The downloadable SDK headers are access-controlled. The header receipt can account for an authorized artifact without copying it; the existing benchmark remains disabled until exact SDK and cross-platform evidence are available."
+      "notes": "The downloadable SDK headers are access-controlled. The header receipt and standalone verifier can account for an authorized artifact without copying it; the existing benchmark remains disabled until exact SDK and cross-platform evidence are available."
     },
     {
       "id": "premiere-cpp-sdk",
@@ -87,8 +88,9 @@
       "inventoryState": "blocked_external_artifact",
       "implementationState": "not_started",
       "inventoryCommand": "npm run native:sdk-header-inventory",
+      "inventoryVerificationCommand": "npm run native:sdk-header-inventory:verify",
       "inventoryDocumentation": "docs/native-sdk-header-inventory.md",
-      "notes": "The standalone PrSDK for native importers, exporters, effects, transitions, devices, and related plug-ins is distinct from UXP Hybrid addons. The header receipt can account for an authorized artifact, but the access-controlled SDK documentation and headers are still required."
+      "notes": "The standalone PrSDK for native importers, exporters, effects, transitions, devices, and related plug-ins is distinct from UXP Hybrid addons. The header receipt and standalone verifier can account for an authorized artifact, but the access-controlled SDK documentation and headers are still required."
     },
     {
       "id": "cep-extendscript",

--- a/tests/native-sdk-header-inventory.test.ts
+++ b/tests/native-sdk-header-inventory.test.ts
@@ -83,6 +83,10 @@ describe("native SDK header-inventory receipt", () => {
         stats: { headers: 1 },
       });
       await expect(generateNativeSdkHeaderInventory({
+        sdk: "premiere-prsdk", sdkVersion: "fixture", archivePath, sdkRoot,
+        includeDirectories: ["Headers/"],
+      })).rejects.toThrow("must use a canonical relative path");
+      await expect(generateNativeSdkHeaderInventory({
         sdk: "constructor", sdkVersion: "fixture", archivePath, sdkRoot,
       })).rejects.toThrow("sdk must be uxp-hybrid or premiere-prsdk");
     } finally {

--- a/tests/native-sdk-header-inventory.test.ts
+++ b/tests/native-sdk-header-inventory.test.ts
@@ -87,6 +87,10 @@ describe("native SDK header-inventory receipt", () => {
         includeDirectories: ["Headers/"],
       })).rejects.toThrow("must use a canonical relative path");
       await expect(generateNativeSdkHeaderInventory({
+        sdk: "premiere-prsdk", sdkVersion: "fixture", archivePath, sdkRoot,
+        includeDirectories: ["C:Headers"],
+      })).rejects.toThrow("must stay relative to the SDK root");
+      await expect(generateNativeSdkHeaderInventory({
         sdk: "constructor", sdkVersion: "fixture", archivePath, sdkRoot,
       })).rejects.toThrow("sdk must be uxp-hybrid or premiere-prsdk");
     } finally {

--- a/tests/premiere-surface-registry.test.ts
+++ b/tests/premiere-surface-registry.test.ts
@@ -11,6 +11,7 @@ type Surface = {
   inventoryState: string;
   implementationState: string;
   inventoryCommand?: string;
+  inventoryVerificationCommand?: string;
   inventoryDocumentation?: string;
   notes: string;
 };
@@ -109,6 +110,7 @@ describe("Premiere API and competitor surface registry", () => {
         inventoryArtifact: null,
         inventoryState: "blocked_external_artifact",
         inventoryCommand: "npm run native:sdk-header-inventory",
+        inventoryVerificationCommand: "npm run native:sdk-header-inventory:verify",
         inventoryDocumentation: "docs/native-sdk-header-inventory.md",
       });
     }

--- a/tests/verify-native-sdk-header-inventory.test.ts
+++ b/tests/verify-native-sdk-header-inventory.test.ts
@@ -1,0 +1,102 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { describe, expect, it } from "vitest";
+import { NATIVE_SDK_HEADER_INVENTORY_SEMANTICS } from "../scripts/native-sdk-header-inventory-contract.mjs";
+import { verifyNativeSdkHeaderInventory } from "../scripts/verify-native-sdk-header-inventory.mjs";
+
+const hash = (character: string) => character.repeat(64);
+
+function hybridReceipt() {
+  return {
+    schemaVersion: 1,
+    source: {
+      sdk: "uxp-hybrid",
+      sdkVersion: "fixture",
+      authorityUrl: "https://developer.adobe.com/premiere-pro/uxp/plugins/hybrid-plugins/",
+      archiveSha256: hash("a"),
+      inventoryScope: "header_files_only",
+      includeDirectories: ["src/api", "src/utilities"],
+    },
+    semantics: NATIVE_SDK_HEADER_INVENTORY_SEMANTICS,
+    stats: { headers: 3, bytes: 24 },
+    headers: [
+      { path: "src/api/UxpAddonShared.h", bytes: 7, sha256: hash("b") },
+      { path: "src/api/UxpAddonTypes.h", bytes: 8, sha256: hash("c") },
+      { path: "src/utilities/UxpAddon.h", bytes: 9, sha256: hash("d") },
+    ],
+  };
+}
+
+function clone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+describe("native SDK header receipt verifier", () => {
+  it("accepts a complete hash-only Hybrid receipt and a PrSDK receipt with explicit roots", () => {
+    expect(verifyNativeSdkHeaderInventory(hybridReceipt())).toEqual({ sdk: "uxp-hybrid", headers: 3, bytes: 24 });
+    const prsdk = hybridReceipt();
+    prsdk.source = {
+      sdk: "premiere-prsdk",
+      sdkVersion: "fixture",
+      authorityUrl: "https://developer.adobe.com/premiere-pro/",
+      archiveSha256: hash("e"),
+      inventoryScope: "header_files_only",
+      includeDirectories: ["Headers"],
+    };
+    prsdk.headers = [{ path: "Headers/PrSDKFixture.hpp", bytes: 3, sha256: hash("f") }];
+    prsdk.stats = { headers: 1, bytes: 3 };
+    expect(verifyNativeSdkHeaderInventory(prsdk)).toEqual({ sdk: "premiere-prsdk", headers: 1, bytes: 3 });
+  });
+
+  it("rejects receipt fields that could leak SDK material or rewrite the evidence boundary", () => {
+    const leaked = clone(hybridReceipt());
+    leaked.headers[0] = { ...leaked.headers[0], contents: "typedef void* addon_value;" };
+    expect(() => verifyNativeSdkHeaderInventory(leaked)).toThrow("must contain only the documented receipt fields");
+
+    const rewrittenBoundary = clone(hybridReceipt());
+    rewrittenBoundary.semantics.doesNotEstablish = "This proves native support.";
+    expect(() => verifyNativeSdkHeaderInventory(rewrittenBoundary)).toThrow("must retain the documented evidence boundary");
+  });
+
+  it("rejects malformed provenance, header paths, ordering, totals, and missing public Hybrid headers", () => {
+    const absolutePath = clone(hybridReceipt());
+    absolutePath.headers[0].path = "C:/sdk/UxpAddonShared.h";
+    expect(() => verifyNativeSdkHeaderInventory(absolutePath)).toThrow("must be a canonical relative path");
+
+    const unsorted = clone(hybridReceipt());
+    [unsorted.headers[0], unsorted.headers[1]] = [unsorted.headers[1], unsorted.headers[0]];
+    expect(() => verifyNativeSdkHeaderInventory(unsorted)).toThrow("must be strictly sorted");
+
+    const incorrectStats = clone(hybridReceipt());
+    incorrectStats.stats.bytes = 25;
+    expect(() => verifyNativeSdkHeaderInventory(incorrectStats)).toThrow("stats.bytes does not match headers");
+
+    const missingExpectedHeader = clone(hybridReceipt());
+    missingExpectedHeader.headers = missingExpectedHeader.headers.slice(1);
+    missingExpectedHeader.stats = { headers: 2, bytes: 17 };
+    expect(() => verifyNativeSdkHeaderInventory(missingExpectedHeader)).toThrow("Missing required UXP Hybrid SDK header");
+  });
+
+  it("validates JSON through the CLI without printing receipt contents", () => {
+    const directory = mkdtempSync(join(tmpdir(), "premiere-native-sdk-receipt-"));
+    const input = join(directory, "receipt.json");
+    try {
+      writeFileSync(input, `${JSON.stringify(hybridReceipt(), null, 2)}\n`);
+      const result = spawnSync(process.execPath, ["scripts/verify-native-sdk-header-inventory.mjs", "--input", input], { encoding: "utf8" });
+      expect(result.status).toBe(0);
+      expect(result.stdout).toContain("Native SDK header receipt is valid: 3 uxp-hybrid header files, 24 bytes.");
+      expect(result.stdout).not.toContain("UxpAddonShared.h");
+
+      const malformed = clone(hybridReceipt());
+      malformed.headers[0].contents = "private SDK header";
+      writeFileSync(input, `${JSON.stringify(malformed, null, 2)}\n`);
+      const rejected = spawnSync(process.execPath, ["scripts/verify-native-sdk-header-inventory.mjs", "--input", input], { encoding: "utf8" });
+      expect(rejected.status).not.toBe(0);
+      expect(rejected.stderr).toContain("must contain only the documented receipt fields");
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/verify-native-sdk-header-inventory.test.ts
+++ b/tests/verify-native-sdk-header-inventory.test.ts
@@ -65,6 +65,10 @@ describe("native SDK header receipt verifier", () => {
     absolutePath.headers[0].path = "C:/sdk/UxpAddonShared.h";
     expect(() => verifyNativeSdkHeaderInventory(absolutePath)).toThrow("must be a canonical relative path");
 
+    const driveRelativePath = clone(hybridReceipt());
+    driveRelativePath.headers[0].path = "C:Headers/UxpAddonShared.h";
+    expect(() => verifyNativeSdkHeaderInventory(driveRelativePath)).toThrow("must be a canonical relative path");
+
     const unsorted = clone(hybridReceipt());
     [unsorted.headers[0], unsorted.headers[1]] = [unsorted.headers[1], unsorted.headers[0]];
     expect(() => verifyNativeSdkHeaderInventory(unsorted)).toThrow("must be strictly sorted");


### PR DESCRIPTION
## Summary
- adds an offline verifier for the existing hash-only Native SDK header receipt
- rejects schema drift, SDK-content fields, absolute or non-canonical paths, mismatched hashes/totals, malformed provenance, and missing public Hybrid header names
- shares the receipt contract with the generator and records the verifier for both blocked native surfaces

## Boundaries
- no access-controlled SDK artifact, native addon, MCP tool, beta API, build, signing result, or licensed-host claim is added
- receipt verification is accounting evidence only; it cannot establish archive authenticity, compile/load behavior, or Premiere support

## Validation
- npm run check
- npm run test:coverage (95.20% statements, 91.61% branches, 96.53% functions, 96.84% lines)
- npm run pack:check