### PR TITLE
release: prepare v1.14.6

### DIFF
--- a/.agents/product-marketing.md
+++ b/.agents/product-marketing.md
@@ -137,7 +137,7 @@
 
 ## Proof Points
 
-**Release facts:** v1.14.5 registers 327 core tools; the default profile exposes 325; an authenticated compatible UXP host can add 61 capability-gated tools for a 386-tool connected surface. The release also declares 37 modules, 4 MCP resources, and 11 workflow prompts. It includes focused tool packs, explicit output schemas, a read-only review report, npm package verification compatible with the current npm CLI, verified razor and batch-effect checks, and optional fail-closed OAuth resource-server validation for allowlisted trusted operators. OAuth does not provide public desktop pairing or per-user Premiere routing. These are catalog, packaging, and HTTP authorization facts from the repository, not a promise that a particular host operation will work.
+**Release facts:** v1.14.6 registers 327 core tools; the default profile exposes 325; an authenticated compatible UXP host can add 61 capability-gated tools for a 386-tool connected surface. The release also declares 37 modules, 4 MCP resources, and 11 workflow prompts. It adds guarded UXP sequence, marker, transition, caption, and silence-removal workflows alongside local-only delivery and editorial review evidence. These are catalog, packaging, and HTTP authorization facts from the repository, not a promise that a particular host operation will work.
 
 **Compatibility boundary:** The release targets Premiere Pro 2020–2026; UXP workflows require a compatible Premiere Pro 25.6.0+ host and advertised capabilities. CEP remains the default compatibility route. A compatibility range, package validation, CI pass, HTTP health check, or local build is not real-host proof.
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "premiere-pro",
       "source": "./claude-plugins/premiere-pro",
       "description": "Inspect, edit, verify, and export local Premiere Pro projects through MCP.",
-      "version": "1.14.5",
+      "version": "1.14.6",
       "category": "creative",
       "tags": ["premiere-pro", "video-editing", "mcp"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.14.6] - 2026-09-02
+
 ### Added
 
 - Added `create_editorial_context_pack`, a review-only, revision-aware Markdown
   reading view for explicitly captured transcript, shot, audio, source,
   timeline, and editor-note context. It is bounded by entry and character
   limits and never invokes a provider, Premiere bridge, or project mutation.
+- Added guarded UXP workflows for sequence playhead and range updates, marker
+  batch removal, native transition application, caption-track inventory,
+  silence-cut stringouts, atomic split edits, and beat-grid markers.
+- Added local-only delivery conformance, sampled video scopes and motion
+  analysis, Warp Stabilizer status inspection, and shot-match planning.
+- Added source-backed inventories for documented UXP, CEP, ExtendScript, and
+  native SDK integration surfaces.
+
+### Fixed
+
+- Made unsupported sequence pixel-aspect ratios, partial transitions,
+  unavailable media timing readback, and incomplete delivery probes fail
+  closed instead of reporting unverified success.
+- Corrected marker, encoder, duplicate-media, caption, and capability
+  inference contracts, with expanded mutation verification coverage.
 
 ## [1.14.5] - 2026-08-31
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,9 @@ The AI handles the entire workflow through 327 core tools spanning the supported
   playhead, marker, transition, caption, silence-cut, and split-edit workflows.
 - **Review-first evidence:** local delivery checks, sampled media analysis, and
   editorial context packs remain bounded and avoid unapproved provider writes.
-- **Fail-closed host behavior:** unavailable readback, partial writes, and
-  unsupported sequence formats are explicit errors rather than success claims.
+- **Narrowed host behavior:** unsupported sequence pixel-aspect ratios and
+  partial UXP transition writes fail closed; other mutations retain their
+  documented verified or explicitly `committed_unverified` outcome.
 - **Explicit boundary:** the hosted endpoint remains an operator-managed MCP
   service; unauthenticated callers are rejected and it does not pair users to
   local Premiere processes.

--- a/README.md
+++ b/README.md
@@ -33,20 +33,19 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 
 The AI handles the entire workflow through 327 core tools spanning the supported ExtendScript, QE DOM, local media and interchange analysis, revisioned project-context retrieval, safe edit-planning, project-intake preview, review handoff, and connection-verification surfaces. A compatible, authenticated UXP panel adds 56 documented, capability-gated tools without replacing the production CEP bridge.
 
-### Latest release: 1.14.5
+### Latest release: 1.14.6
 
-- **Verified editing semantics:** QE razor operations use sequence timecode and
-  batch effect application preflights every target before reporting a verified
-  component readback.
-- **Honest playback state:** legacy playback tools report an accepted request,
-  not movement or stoppage, until a separate position readback confirms it.
-- **Fail-closed catalogs:** empty QE audio-transition catalogs are errors, and
-  effect fallback results are explicitly bounded and partial.
+- **Guarded UXP editing:** compatible hosts can use verified sequence ranges,
+  playhead, marker, transition, caption, silence-cut, and split-edit workflows.
+- **Review-first evidence:** local delivery checks, sampled media analysis, and
+  editorial context packs remain bounded and avoid unapproved provider writes.
+- **Fail-closed host behavior:** unavailable readback, partial writes, and
+  unsupported sequence formats are explicit errors rather than success claims.
 - **Explicit boundary:** the hosted endpoint remains an operator-managed MCP
   service; unauthenticated callers are rejected and it does not pair users to
   local Premiere processes.
 
-See the [v1.14.5 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.14.5)
+See the [v1.14.6 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.14.6)
 for complete details. Live installation in Premiere Pro still requires host verification.
 
 ### Current MCP protocol support
@@ -88,9 +87,9 @@ their bins, media rules, and organization rules before a facility uses one.
 
 ### Easiest supported path: Claude Desktop
 
-1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.5/premiere-pro-mcp-1.14.5.mcpb).
+1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.6/premiere-pro-mcp-1.14.6.mcpb).
 2. In Claude Desktop, open **Settings > Extensions > Advanced settings > Install Extension**, select the downloaded bundle, and restart Claude Desktop.
-3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.5/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
+3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.6/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
 4. Restart Premiere, open a project, then open **Window > Extensions > MCP for Adobe Premiere Pro**.
 5. In Claude, enter: `Safely check my Premiere connection with verify_premiere_connection. Make no changes.`
 
@@ -369,11 +368,11 @@ From a clone of this repository:
 ```bash
 codex plugin marketplace add .
 codex plugin add premiere-pro@premiere-pro-mcp
-npx -y premiere-pro-mcp@1.14.5 --install-cep
+npx -y premiere-pro-mcp@1.14.6 --install-cep
 ```
 
 Restart Premiere Pro and start a new Codex session after installation. The plugin
-launches `premiere-pro-mcp@1.14.5` through `npx`; the separate CEP installation is
+launches `premiere-pro-mcp@1.14.6` through `npx`; the separate CEP installation is
 required because the MCP server communicates with the running Premiere host through
 the local bridge.
 
@@ -393,7 +392,7 @@ For Claude Code, add this repository as a marketplace and install the plugin:
 Then install the Premiere bridge and start a new Claude Code session:
 
 ```bash
-npx -y premiere-pro-mcp@1.14.5 --install-cep
+npx -y premiere-pro-mcp@1.14.6 --install-cep
 ```
 
 The Claude Code package lives in

--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.14.5" ExtensionBundleName="MCP for Adobe Premiere Pro">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.14.6" ExtensionBundleName="MCP for Adobe Premiere Pro">
   <ExtensionList>
-    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.14.5"/>
-    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.14.5"/>
+    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.14.6"/>
+    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.14.6"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/cep-plugin/index.html
+++ b/cep-plugin/index.html
@@ -81,7 +81,7 @@
     <section class="update-section" aria-live="polite">
       <div class="update-copy">
         <span class="section-label">Connector updates</span>
-        <strong id="updateTitle">Version 1.14.5</strong>
+        <strong id="updateTitle">Version 1.14.6</strong>
         <span id="updateDetail">Checking for updates…</span>
       </div>
       <button id="btnUpdate" class="button button-update" onclick="handleUpdateClick()" type="button" disabled>

--- a/cep-plugin/updater.cjs
+++ b/cep-plugin/updater.cjs
@@ -7,7 +7,7 @@
 })(this, function () {
   "use strict";
 
-  var CURRENT_VERSION = "1.14.5";
+  var CURRENT_VERSION = "1.14.6";
   var LATEST_RELEASE_API =
     "https://api.github.com/repos/leancoderkavy/premiere-pro-mcp/releases/latest";
   var RELEASES_URL =

--- a/claude-desktop/manifest.json
+++ b/claude-desktop/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "premiere-pro-mcp",
   "display_name": "MCP for Adobe Premiere Pro",
-  "version": "1.14.5",
+  "version": "1.14.6",
   "description": "Control a local Adobe Premiere Pro project through MCP.",
   "long_description": "Inspect projects, assemble and modify timelines, manage media, effects, audio and captions, and export deliverables through a local bridge to Adobe Premiere Pro.",
   "author": {

--- a/claude-plugins/premiere-pro/.claude-plugin/plugin.json
+++ b/claude-plugins/premiere-pro/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "premiere-pro",
   "displayName": "Premiere Pro MCP",
-  "version": "1.14.5",
+  "version": "1.14.6",
   "description": "Inspect, edit, verify, and export local Adobe Premiere Pro projects through MCP.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/claude-plugins/premiere-pro/.mcp.json
+++ b/claude-plugins/premiere-pro/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "premiere-pro": {
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.14.5"]
+      "args": ["-y", "premiere-pro-mcp@1.14.6"]
     }
   }
 }

--- a/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.14.5 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.14.6 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -20,7 +20,29 @@ const releases = [
       {
         title: "Safety",
         items: [
-          "Unsupported sequence formats, unavailable readback, incomplete delivery probes, and partial transition writes fail closed. Automated contracts remain distinct from licensed-Premiere host proof.",
+          "Unsupported sequence pixel-aspect ratios, incomplete delivery probes, and partial transition writes fail closed. Mutations without a complete Adobe readback retain their documented verified or committed-unverified outcome; automated contracts remain distinct from licensed-Premiere host proof.",
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.14.5",
+    date: "2026-08-31",
+    label: "Verified mutation and playback hotfixes",
+    groups: [
+      {
+        title: "Fixed",
+        items: [
+          "QE razor operations now pass sequence timecode instead of ticks, with regression coverage for split and all-track cuts.",
+          "Batch effect application preflights every target, resolves QE clips without assuming gap-free indexes, and requires component-count readback.",
+          "Legacy playback tools now report request acceptance rather than unverified playhead movement or stoppage.",
+          "Empty QE audio-transition catalogs fail closed, while effect fallback results are explicitly bounded and partial.",
+        ],
+      },
+      {
+        title: "Validation",
+        items: [
+          "Automated contracts cover the repaired behaviors; real licensed-Premiere host execution remains a separate evidence gate.",
         ],
       },
     ],

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -5,23 +5,22 @@ import { product } from "@/lib/product"
 
 const releases = [
   {
-    version: "1.14.5",
-    date: "2026-08-31",
-    label: "Verified mutation and playback hotfixes",
+    version: "1.14.6",
+    date: "2026-09-02",
+    label: "Guarded UXP editing and local review evidence",
     groups: [
       {
-        title: "Fixed",
+        title: "Added",
         items: [
-          "QE razor operations now pass sequence timecode instead of ticks, with regression coverage for split and all-track cuts.",
-          "Batch effect application preflights every target, resolves QE clips without assuming gap-free indexes, and requires component-count readback.",
-          "Legacy playback tools now report request acceptance rather than unverified playhead movement or stoppage.",
-          "Empty QE audio-transition catalogs fail closed, while effect fallback results are explicitly bounded and partial.",
+          "Compatible UXP hosts gain guarded sequence range and playhead control, marker batch removal, native video transitions, caption inventory, silence-cut stringouts, and atomic split edits.",
+          "Local review workflows add delivery conformance, sampled media analysis, Warp Stabilizer status, shot-match planning, and revision-aware editorial context packs.",
+          "The release records UXP, CEP, ExtendScript, and native SDK integration surfaces with source-backed inventories.",
         ],
       },
       {
-        title: "Validation",
+        title: "Safety",
         items: [
-          "Automated contracts cover the repaired behaviors; real licensed-Premiere host execution remains a separate evidence gate.",
+          "Unsupported sequence formats, unavailable readback, incomplete delivery probes, and partial transition writes fail closed. Automated contracts remain distinct from licensed-Premiere host proof.",
         ],
       },
     ],

--- a/landing/lib/product.ts
+++ b/landing/lib/product.ts
@@ -1,7 +1,7 @@
 export const product = {
   name: "MCP for Adobe Premiere Pro",
-  version: "1.14.5",
-  releaseDate: "2026-08-31",
+  version: "1.14.6",
+  releaseDate: "2026-09-02",
   coreToolCount: 327,
   defaultProfileToolCount: 325,
   connectedUxpToolCount: 386,
@@ -10,10 +10,10 @@ export const product = {
   uxpMinimumVersion: "25.6",
   downloads: {
     claudeBundle:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.5/premiere-pro-mcp-1.14.5.mcpb",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.6/premiere-pro-mcp-1.14.6.mcpb",
     signedCepConnector:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.5/MCPBridgeCEP.zxp",
-    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.14.5",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.6/MCPBridgeCEP.zxp",
+    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.14.6",
   },
   links: {
     repository: "https://github.com/leancoderkavy/premiere-pro-mcp",

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -20,7 +20,7 @@ Guide: Premiere Pro delivery QC and loudness checklist: https://premiere-pro-mcp
 Source: https://github.com/leancoderkavy/premiere-pro-mcp
 npm: https://www.npmjs.com/package/premiere-pro-mcp
 License: MIT
-Current release: 1.14.5
+Current release: 1.14.6
 
 ## What it does
 

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -41,7 +41,7 @@ The Project Intake guide includes no-sensitive-data starter templates for a path
 
 ## Verified facts
 
-- Current project release: 1.14.5.
+- Current project release: 1.14.6.
 - Tool surface: 327 core structured MCP tools are registered; the default profile exposes 325. With an authenticated compatible UXP panel, 61 additional capability-gated tools bring the connected surface to 386. The server also exposes 4 resources and 11 workflow prompts.
 - Supported desktop platforms: Windows and macOS.
 - Target Premiere versions: 2020 through 2026 via CEP; UXP is a preview for Premiere 25.6 and newer.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.14.5",
+  "version": "1.14.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "premiere-pro-mcp",
-      "version": "1.14.5",
+      "version": "1.14.6",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/node": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "premiere-pro-mcp",
   "mcpName": "io.github.leancoderkavy/premiere-pro",
-  "version": "1.14.5",
+  "version": "1.14.6",
   "description": "MCP server for Adobe Premiere Pro with 327 core AI video editing tools and a capability-aware UXP bridge for supported Premiere workflows.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/premiere-pro/.codex-plugin/plugin.json
+++ b/plugins/premiere-pro/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro",
-  "version": "1.14.5",
+  "version": "1.14.6",
   "description": "Plan, execute, verify, and export video edits in Adobe Premiere Pro through the Premiere Pro MCP server.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/plugins/premiere-pro/.mcp.json
+++ b/plugins/premiere-pro/.mcp.json
@@ -4,7 +4,7 @@
       "title": "Premiere Pro MCP",
       "description": "Inspect and edit a local Adobe Premiere Pro project through the Premiere Pro MCP bridge.",
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.14.5"]
+      "args": ["-y", "premiere-pro-mcp@1.14.6"]
     }
   }
 }

--- a/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -14,7 +14,7 @@ project state, make only requested changes, and verify the timeline after mutati
 2. Call `ping` before any other Premiere operation.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.14.5 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.14.6 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/registry/server.json
+++ b/registry/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/leancoderkavy/premiere-pro-mcp",
     "source": "github"
   },
-  "version": "1.14.5",
+  "version": "1.14.6",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "premiere-pro-mcp",
-      "version": "1.14.5",
+      "version": "1.14.6",
       "transport": {
         "type": "stdio"
       }

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.14.5",
+  "version": "1.14.6",
   "coreTools": 327,
   "defaultProfileTools": 325,
   "uxpAdditionalTools": 61,

--- a/tests/entrypoints-unit.test.ts
+++ b/tests/entrypoints-unit.test.ts
@@ -18,7 +18,7 @@ const mocks = vi.hoisted(() => ({
   uxpStop: vi.fn(async () => {}),
   execFileSync: vi.fn(),
   spawnSync: vi.fn(),
-  fetchLatestNpmVersion: vi.fn(async () => "1.14.5"),
+  fetchLatestNpmVersion: vi.fn(async () => "1.14.6"),
   fsExists: vi.fn(() => false),
   fsStat: vi.fn(() => ({ isDirectory: () => false, isFile: () => true })),
   fsCreateReadStream: vi.fn(),
@@ -129,7 +129,7 @@ beforeEach(() => {
   vi.resetModules();
   vi.clearAllMocks();
   mocks.requestHandler = undefined;
-  mocks.fetchLatestNpmVersion.mockResolvedValue("1.14.5");
+  mocks.fetchLatestNpmVersion.mockResolvedValue("1.14.6");
   mocks.spawnSync.mockReturnValue({ status: 1, stdout: "" });
   mocks.fsExists.mockReturnValue(false);
   mocks.fsStat.mockReturnValue({ isDirectory: () => false, isFile: () => true });
@@ -210,15 +210,15 @@ describe("stdio CLI entry point", () => {
 
   it("checks for a newer release and updates a global npm installation", async () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
-    mocks.fetchLatestNpmVersion.mockResolvedValueOnce("1.14.6");
+    mocks.fetchLatestNpmVersion.mockResolvedValueOnce("1.14.7");
     let loaded = await importCli(["--check-update"]);
     await expect(loaded.promise).rejects.toThrow("EXIT:0");
-    expect(log).toHaveBeenCalledWith(expect.stringContaining("1.14.5 → 1.14.6"));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("1.14.6 → 1.14.7"));
 
     vi.resetModules();
     vi.clearAllMocks();
     log.mockClear();
-    mocks.fetchLatestNpmVersion.mockResolvedValueOnce("1.14.6");
+    mocks.fetchLatestNpmVersion.mockResolvedValueOnce("1.14.7");
     mocks.spawnSync.mockReturnValue({ status: 0, stdout: `${dirname(process.cwd())}\n` });
     loaded = await importCli(["--update"]);
     await expect(loaded.promise).rejects.toThrow("EXIT:0");
@@ -243,7 +243,7 @@ describe("stdio CLI entry point", () => {
     vi.resetModules();
     vi.clearAllMocks();
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
-    mocks.fetchLatestNpmVersion.mockResolvedValueOnce("1.14.5");
+    mocks.fetchLatestNpmVersion.mockResolvedValueOnce("1.14.6");
     loaded = await importCli(["--update"]);
     await expect(loaded.promise).rejects.toThrow("EXIT:0");
     expect(log).toHaveBeenCalledWith(expect.stringContaining("is current"));

--- a/uxp-plugin/manifest.json
+++ b/uxp-plugin/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.ppmcp.premiere.uxp",
   "name": "MCP for Adobe Premiere Pro",
-  "version": "1.14.5",
+  "version": "1.14.6",
   "main": "index.html",
   "host": { "app": "premierepro", "minVersion": "25.6.0" },
   "entrypoints": [


### PR DESCRIPTION
## Release v1.14.6

- Align package, connector manifests, client metadata, registry, docs, and download links on v1.14.6.
- Document the guarded UXP and review-workflow changes already merged to main.
- Advance CLI update fixtures to model the next available patch version.

Validation: `npm run check`, `npm run pack:check`, `RELEASE_TAG=v1.14.6 node scripts/verify-release-tag.mjs`, and `npm run publish:npm:dry-run`.