### PR TITLE
test(native): bind Hybrid benchmark evidence to SDK receipts

### DIFF
--- a/benchmarks/uxp-hybrid/evidence.schema.json
+++ b/benchmarks/uxp-hybrid/evidence.schema.json
@@ -4,7 +4,7 @@
   "title": "Premiere Pro MCP UXP hybrid benchmark evidence",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schemaVersion", "workloadId", "configuration", "memoryMeasurement", "runs"],
+  "required": ["schemaVersion", "workloadId", "configuration", "memoryMeasurement", "sdkHeaderReceiptSha256", "runs"],
   "properties": {
     "schemaVersion": { "const": 1 },
     "workloadId": { "const": "weighted-energy-v1" },
@@ -21,6 +21,7 @@
       }
     },
     "memoryMeasurement": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "sdkHeaderReceiptSha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
     "runs": {
       "type": "array",
       "minItems": 3,

--- a/benchmarks/uxp-hybrid/evidence.template.json
+++ b/benchmarks/uxp-hybrid/evidence.template.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "workloadId": "weighted-energy-v1",
   "configuration": {
     "sampleCount": 30,

--- a/benchmarks/uxp-hybrid/evidence.template.json
+++ b/benchmarks/uxp-hybrid/evidence.template.json
@@ -9,5 +9,6 @@
     "seed": 1337
   },
   "memoryMeasurement": "Replace with the identical process peak-working-set collection method used on every target",
+  "sdkHeaderReceiptSha256": "Replace with the canonical digest printed by native:sdk-header-inventory:verify",
   "runs": []
 }

--- a/benchmarks/uxp-hybrid/evidence.v1.schema.json
+++ b/benchmarks/uxp-hybrid/evidence.v1.schema.json
@@ -1,12 +1,12 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://premiere-pro-mcp.com/schemas/uxp-hybrid-benchmark-evidence-v2.json",
-  "title": "Premiere Pro MCP UXP hybrid benchmark evidence v2",
+  "$id": "https://premiere-pro-mcp.com/schemas/uxp-hybrid-benchmark-evidence-v1.json",
+  "title": "Premiere Pro MCP UXP hybrid benchmark evidence v1",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schemaVersion", "workloadId", "configuration", "memoryMeasurement", "sdkHeaderReceiptSha256", "runs"],
+  "required": ["schemaVersion", "workloadId", "configuration", "memoryMeasurement", "runs"],
   "properties": {
-    "schemaVersion": { "const": 2 },
+    "schemaVersion": { "const": 1 },
     "workloadId": { "const": "weighted-energy-v1" },
     "configuration": {
       "type": "object",
@@ -21,7 +21,6 @@
       }
     },
     "memoryMeasurement": { "type": "string", "minLength": 1, "maxLength": 256 },
-    "sdkHeaderReceiptSha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
     "runs": {
       "type": "array",
       "minItems": 3,

--- a/docs/native-sdk-header-inventory.md
+++ b/docs/native-sdk-header-inventory.md
@@ -37,6 +37,20 @@ npm run native:sdk-header-inventory:verify -- `
   --input C:\sdk-evidence\uxp-hybrid-headers.json
 ```
 
+For a Hybrid benchmark candidate, append `--print-canonical-sha256` and copy
+only the resulting lowercase digest into `sdkHeaderReceiptSha256` in the
+benchmark evidence:
+
+```powershell
+npm run native:sdk-header-inventory:verify -- `
+  --input C:\sdk-evidence\uxp-hybrid-headers.json `
+  --print-canonical-sha256
+```
+
+The receipt itself stays in the authorized local evidence location and is
+supplied separately to the benchmark verifier; this repository does not receive
+the SDK extraction or archive.
+
 This checks receipt structure and declared provenance only. It cannot verify
 the private archive bytes, compile the SDK, or establish that an addon can load
 in Premiere.

--- a/docs/premiere-surface-registry.md
+++ b/docs/premiere-surface-registry.md
@@ -30,7 +30,10 @@ When an authorized SDK artifact becomes available, the
 its archive hash and relative header hashes without copying access-controlled
 files into this repository. That receipt leaves both C++ surfaces blocked until
 the relevant declaration classification, reproducible native build, and
-licensed-host evidence are supplied.
+licensed-host evidence are supplied. A future Hybrid benchmark must also bind
+its submitted runs to a matching verified receipt, as described by the
+[Hybrid benchmark gate](uxp-hybrid-benchmark.md); the digest binding is not a
+native-build or host-behavior claim.
 
 The same registry pins the exact competitor commits reviewed for feature-gap
 work. A competitor feature family becomes an implementation candidate only

--- a/docs/uxp-hybrid-benchmark.md
+++ b/docs/uxp-hybrid-benchmark.md
@@ -73,13 +73,25 @@ schema, and add one run for each required target: Windows x64, macOS x64, and ma
 arm64. Every run must use the same full source commit, an identified SDK version, a
 Release binary SHA-256, matching output, and stable Premiere 26.2+.
 
+Create and structurally verify a hash-only UXP Hybrid header receipt from the
+authorized SDK download first. Add the canonical digest printed by the receipt
+verifier as `sdkHeaderReceiptSha256`, retain the actual receipt outside this
+repository, and give its local path to the benchmark verifier. The receipt must
+identify `uxp-hybrid`, and its `source.sdkVersion` must exactly match every run's
+`sdkVersion`.
+
 The native implementation must improve both p50 and p95 by at least 30% on every
 target while keeping peak working-set regression at or below 10%. Verify with:
 
 ```powershell
-npm run benchmark:uxp-hybrid:verify -- --input .\path\to\evidence.json
+npm run benchmark:uxp-hybrid:verify -- `
+  --input .\path\to\evidence.json `
+  --sdk-header-receipt C:\sdk-evidence\uxp-hybrid-headers.json
 ```
 
 Only a zero exit code and `promotionEligible: true` support a later PR that adds the
 native source, reproducible build files, signed/notarized artifacts, manifest v6, and
-addon permission. This benchmark PR itself is not that promotion.
+addon permission. This receipt binding verifies only the documented hash-only receipt
+structure and the submitted evidence's SDK identity; it does not verify the private
+archive bytes, establish access entitlement, compile an addon, or prove behavior in a
+licensed Premiere host. This benchmark PR itself is not that promotion.

--- a/docs/uxp-hybrid-benchmark.md
+++ b/docs/uxp-hybrid-benchmark.md
@@ -68,10 +68,11 @@ diagnostic only and are not accepted as process memory evidence.
 
 ## Promotion criteria
 
-Copy `benchmarks/uxp-hybrid/evidence.template.json`, validate it against the adjacent
-schema, and add one run for each required target: Windows x64, macOS x64, and macOS
-arm64. Every run must use the same full source commit, an identified SDK version, a
-Release binary SHA-256, matching output, and stable Premiere 26.2+.
+Copy `benchmarks/uxp-hybrid/evidence.template.json` (schema version 2), validate it
+against the adjacent v2 schema, and add one run for each required target: Windows x64,
+macOS x64, and macOS arm64. Every run must use the same full source commit, an
+identified SDK version, a Release binary SHA-256, matching output, and stable Premiere
+26.2+.
 
 Create and structurally verify a hash-only UXP Hybrid header receipt from the
 authorized SDK download first. Add the canonical digest printed by the receipt
@@ -79,6 +80,10 @@ verifier as `sdkHeaderReceiptSha256`, retain the actual receipt outside this
 repository, and give its local path to the benchmark verifier. The receipt must
 identify `uxp-hybrid`, and its `source.sdkVersion` must exactly match every run's
 `sdkVersion`.
+
+The frozen `evidence.v1.schema.json` and verifier compatibility path remain for
+historical v1 benchmark records. They do not bind a receipt, so new benchmark
+candidates must use v2 rather than changing a published v1 receipt's meaning.
 
 The native implementation must improve both p50 and p95 by at least 30% on every
 target while keeping peak working-set regression at or below 10%. Verify with:

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "docs/uxp-js-api-inventory.md",
     "docs/premiere-doc-inventory.md",
     "docs/native-sdk-header-inventory.md",
+    "docs/uxp-hybrid-benchmark.md",
     "docs/cep-reference-inventory.md",
     "docs/extendscript-api-inventory.md",
     "docs/premiere-surface-registry.md",

--- a/scripts/verify-native-sdk-header-inventory.mjs
+++ b/scripts/verify-native-sdk-header-inventory.mjs
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
@@ -126,19 +127,41 @@ export function verifyNativeSdkHeaderInventory(inventory) {
   return Object.freeze({ sdk: source.sdk, headers: headers.length, bytes: totalBytes });
 }
 
-function parseArguments(argv) {
-  if (argv.length !== 2 || argv[0] !== "--input" || !argv[1] || argv[1].startsWith("--")) {
-    throw verificationError("Usage: node scripts/verify-native-sdk-header-inventory.mjs --input <receipt.json>");
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.keys(value).sort(compareNativeSdkPaths).map((key) => [key, canonicalize(value[key])]));
   }
-  return resolve(argv[1]);
+  return value;
+}
+
+export function canonicalNativeSdkHeaderInventorySha256(inventory) {
+  verifyNativeSdkHeaderInventory(inventory);
+  return createHash("sha256").update(JSON.stringify(canonicalize(inventory))).digest("hex");
+}
+
+function parseArguments(argv) {
+  const options = { input: null, printCanonicalSha256: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--print-canonical-sha256") options.printCanonicalSha256 = true;
+    else if (argument === "--input") {
+      const value = argv[++index];
+      if (!value || value.startsWith("--")) throw verificationError("--input requires a receipt path");
+      options.input = value;
+    } else throw verificationError(`Unknown argument: ${argument}`);
+  }
+  if (!options.input) throw verificationError("Usage: node scripts/verify-native-sdk-header-inventory.mjs --input <receipt.json> [--print-canonical-sha256]");
+  return { inputPath: resolve(options.input), printCanonicalSha256: options.printCanonicalSha256 };
 }
 
 async function main() {
-  const inputPath = parseArguments(process.argv.slice(2));
+  const options = parseArguments(process.argv.slice(2));
   let inventory;
-  try { inventory = JSON.parse(await readFile(inputPath, "utf8")); } catch { throw verificationError("input must be a readable JSON receipt"); }
+  try { inventory = JSON.parse(await readFile(options.inputPath, "utf8")); } catch { throw verificationError("input must be a readable JSON receipt"); }
   const summary = verifyNativeSdkHeaderInventory(inventory);
   process.stdout.write(`Native SDK header receipt is valid: ${summary.headers} ${summary.sdk} header files, ${summary.bytes} bytes.\n`);
+  if (options.printCanonicalSha256) process.stdout.write(`Canonical receipt SHA-256: ${canonicalNativeSdkHeaderInventorySha256(inventory)}\n`);
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/scripts/verify-npm-package.mjs
+++ b/scripts/verify-npm-package.mjs
@@ -23,6 +23,7 @@ const requiredFiles = [
   "package/docs/uxp-js-api-inventory.md",
   "package/docs/premiere-doc-inventory.md",
   "package/docs/native-sdk-header-inventory.md",
+  "package/docs/uxp-hybrid-benchmark.md",
   "package/docs/cep-reference-inventory.md",
   "package/docs/extendscript-api-inventory.md",
   "package/dist/resources/premiere-surface-registry.json",

--- a/scripts/verify-uxp-hybrid-benchmark.mjs
+++ b/scripts/verify-uxp-hybrid-benchmark.mjs
@@ -14,12 +14,16 @@ export function verifyHybridBenchmarkEvidence(document, options = {}) {
   if (!document || typeof document !== "object" || Array.isArray(document)) {
     return verdict(errors.concat("Evidence must be a JSON object."), [], minimumSpeedupPercent, maximumMemoryRegressionPercent);
   }
-  if (!sameKeys(document, ["schemaVersion", "workloadId", "configuration", "memoryMeasurement", "sdkHeaderReceiptSha256", "runs"])) {
+  const receiptBound = document.schemaVersion === 2;
+  const expectedEvidenceKeys = receiptBound
+    ? ["schemaVersion", "workloadId", "configuration", "memoryMeasurement", "sdkHeaderReceiptSha256", "runs"]
+    : ["schemaVersion", "workloadId", "configuration", "memoryMeasurement", "runs"];
+  if (!sameKeys(document, expectedEvidenceKeys)) {
     errors.push("Evidence must contain only the documented benchmark receipt fields.");
   }
-  if (document.schemaVersion !== 1) errors.push("schemaVersion must be 1.");
+  if (document.schemaVersion !== 1 && document.schemaVersion !== 2) errors.push("schemaVersion must be 1 or 2.");
   if (document.workloadId !== "weighted-energy-v1") errors.push("workloadId must be weighted-energy-v1.");
-  if (!/^[a-f0-9]{64}$/.test(String(document.sdkHeaderReceiptSha256 || ""))) {
+  if (receiptBound && !/^[a-f0-9]{64}$/.test(String(document.sdkHeaderReceiptSha256 || ""))) {
     errors.push("sdkHeaderReceiptSha256 must be a canonical SDK header receipt SHA-256 digest.");
   }
   const expectedConfiguration = { sampleCount: 30, warmupCount: 3, iterations: 4, inputLength: 131072, seed: 1337 };
@@ -79,8 +83,8 @@ export function verifyHybridBenchmarkEvidence(document, options = {}) {
   if (commits.size > 1) errors.push("All runs must measure the same sourceCommit.");
   if (commits.size === 0) errors.push("A shared full sourceCommit is required.");
   if (sdkVersions.size > 1) errors.push("All runs must use the same UXP Hybrid SDK version.");
-  validateSdkReceipt(document, options.sdkHeaderReceipt, sdkVersions, errors);
-  return verdict(errors, Array.from(targets.keys()).sort(), minimumSpeedupPercent, maximumMemoryRegressionPercent);
+  if (receiptBound) validateSdkReceipt(document, options.sdkHeaderReceipt, sdkVersions, errors);
+  return verdict(errors, Array.from(targets.keys()).sort(), minimumSpeedupPercent, maximumMemoryRegressionPercent, document.schemaVersion);
 }
 
 function validateSdkReceipt(document, receipt, sdkVersions, errors) {
@@ -155,13 +159,15 @@ function finiteOption(value, fallback, name) {
   return result;
 }
 
-function verdict(errors, targets, minimumSpeedupPercent, maximumMemoryRegressionPercent) {
+function verdict(errors, targets, minimumSpeedupPercent, maximumMemoryRegressionPercent, schemaVersion) {
   return {
     promotionEligible: errors.length === 0,
     errors,
     targets,
     thresholds: { minimumSpeedupPercent, maximumMemoryRegressionPercent },
-    verificationBoundary: "submitted_cross_platform_release_build_and_verified_sdk_receipt_evidence"
+    verificationBoundary: schemaVersion === 2
+      ? "submitted_cross_platform_release_build_and_verified_sdk_receipt_evidence"
+      : "submitted_cross_platform_release_build_evidence"
   };
 }
 
@@ -175,16 +181,16 @@ function parseArguments(argv) {
     else if (value === "--max-memory-regression-percent") result.maximumMemoryRegressionPercent = Number(argv[++index]);
     else throw new Error(`Unknown argument: ${value}`);
   }
-  if (!result.input || !result.sdkHeaderReceipt) throw new Error("--input <evidence.json> and --sdk-header-receipt <receipt.json> are required.");
+  if (!result.input) throw new Error("--input <evidence.json> is required.");
   return result;
 }
 
 async function main() {
   const args = parseArguments(process.argv.slice(2));
-  const [document, sdkHeaderReceipt] = await Promise.all([
-    readEvidenceJson(args.input, "benchmark evidence"),
-    readEvidenceJson(args.sdkHeaderReceipt, "SDK header receipt"),
-  ]);
+  const document = await readEvidenceJson(args.input, "benchmark evidence");
+  const sdkHeaderReceipt = args.sdkHeaderReceipt
+    ? await readEvidenceJson(args.sdkHeaderReceipt, "SDK header receipt")
+    : undefined;
   const result = verifyHybridBenchmarkEvidence(document, { ...args, sdkHeaderReceipt });
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
   if (!result.promotionEligible) process.exitCode = 1;

--- a/scripts/verify-uxp-hybrid-benchmark.mjs
+++ b/scripts/verify-uxp-hybrid-benchmark.mjs
@@ -182,12 +182,20 @@ function parseArguments(argv) {
 async function main() {
   const args = parseArguments(process.argv.slice(2));
   const [document, sdkHeaderReceipt] = await Promise.all([
-    readFile(args.input, "utf8").then(JSON.parse),
-    readFile(args.sdkHeaderReceipt, "utf8").then(JSON.parse),
+    readEvidenceJson(args.input, "benchmark evidence"),
+    readEvidenceJson(args.sdkHeaderReceipt, "SDK header receipt"),
   ]);
   const result = verifyHybridBenchmarkEvidence(document, { ...args, sdkHeaderReceipt });
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
   if (!result.promotionEligible) process.exitCode = 1;
+}
+
+async function readEvidenceJson(path, label) {
+  try {
+    return JSON.parse(await readFile(path, "utf8"));
+  } catch {
+    throw new Error(`${label} must be a readable JSON document.`);
+  }
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] || "").href) {

--- a/scripts/verify-uxp-hybrid-benchmark.mjs
+++ b/scripts/verify-uxp-hybrid-benchmark.mjs
@@ -1,5 +1,9 @@
 import { readFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
+import {
+  canonicalNativeSdkHeaderInventorySha256,
+  verifyNativeSdkHeaderInventory,
+} from "./verify-native-sdk-header-inventory.mjs";
 
 export const REQUIRED_TARGETS = ["win-x64", "mac-x64", "mac-arm64"];
 
@@ -10,8 +14,14 @@ export function verifyHybridBenchmarkEvidence(document, options = {}) {
   if (!document || typeof document !== "object" || Array.isArray(document)) {
     return verdict(errors.concat("Evidence must be a JSON object."), [], minimumSpeedupPercent, maximumMemoryRegressionPercent);
   }
+  if (!sameKeys(document, ["schemaVersion", "workloadId", "configuration", "memoryMeasurement", "sdkHeaderReceiptSha256", "runs"])) {
+    errors.push("Evidence must contain only the documented benchmark receipt fields.");
+  }
   if (document.schemaVersion !== 1) errors.push("schemaVersion must be 1.");
   if (document.workloadId !== "weighted-energy-v1") errors.push("workloadId must be weighted-energy-v1.");
+  if (!/^[a-f0-9]{64}$/.test(String(document.sdkHeaderReceiptSha256 || ""))) {
+    errors.push("sdkHeaderReceiptSha256 must be a canonical SDK header receipt SHA-256 digest.");
+  }
   const expectedConfiguration = { sampleCount: 30, warmupCount: 3, iterations: 4, inputLength: 131072, seed: 1337 };
   if (!sameConfiguration(document.configuration, expectedConfiguration)) {
     errors.push("configuration must match the versioned weighted-energy-v1 benchmark settings.");
@@ -29,6 +39,9 @@ export function verifyHybridBenchmarkEvidence(document, options = {}) {
     if (!run || typeof run !== "object" || Array.isArray(run)) {
       errors.push(`${prefix} must be an object.`);
       continue;
+    }
+    if (!sameKeys(run, ["platform", "arch", "hostVersion", "sdkVersion", "buildMode", "addonLoaded", "addonSha256", "sourceCommit", "checksumMatch", "codeSigned", "notarized", "javascript", "native"])) {
+      errors.push(`${prefix} must contain only the documented benchmark fields.`);
     }
     const target = `${run.platform || ""}-${run.arch || ""}`;
     if (!REQUIRED_TARGETS.includes(target)) errors.push(`${prefix} has unsupported target ${target}.`);
@@ -66,13 +79,36 @@ export function verifyHybridBenchmarkEvidence(document, options = {}) {
   if (commits.size > 1) errors.push("All runs must measure the same sourceCommit.");
   if (commits.size === 0) errors.push("A shared full sourceCommit is required.");
   if (sdkVersions.size > 1) errors.push("All runs must use the same UXP Hybrid SDK version.");
+  validateSdkReceipt(document, options.sdkHeaderReceipt, sdkVersions, errors);
   return verdict(errors, Array.from(targets.keys()).sort(), minimumSpeedupPercent, maximumMemoryRegressionPercent);
+}
+
+function validateSdkReceipt(document, receipt, sdkVersions, errors) {
+  if (!receipt) {
+    errors.push("A verified UXP Hybrid SDK header receipt is required.");
+    return;
+  }
+  try {
+    const summary = verifyNativeSdkHeaderInventory(receipt);
+    if (summary.sdk !== "uxp-hybrid") errors.push("SDK header receipt must identify uxp-hybrid.");
+    if (sdkVersions.size === 1 && receipt.source.sdkVersion !== Array.from(sdkVersions)[0]) {
+      errors.push("SDK header receipt sdkVersion must match all benchmark runs.");
+    }
+    if (document.sdkHeaderReceiptSha256 !== canonicalNativeSdkHeaderInventorySha256(receipt)) {
+      errors.push("sdkHeaderReceiptSha256 does not match the verified SDK header receipt.");
+    }
+  } catch (error) {
+    errors.push(`SDK header receipt is invalid: ${error instanceof Error ? error.message : String(error)}`);
+  }
 }
 
 function validateMetrics(value, label, errors) {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     errors.push(`${label} metrics are required.`);
     return;
+  }
+  if (!sameKeys(value, ["sampleCount", "p50Ms", "p95Ms", "peakWorkingSetBytes"])) {
+    errors.push(`${label} must contain only the documented metric fields.`);
   }
   if (!Number.isInteger(value.sampleCount) || value.sampleCount < 20) errors.push(`${label}.sampleCount must be at least 20.`);
   for (const key of ["p50Ms", "p95Ms", "peakWorkingSetBytes"]) {
@@ -98,6 +134,11 @@ function sameConfiguration(value, expected) {
   return Object.keys(value).length === keys.length && keys.every((key) => value[key] === expected[key]);
 }
 
+function sameKeys(value, expected) {
+  return value && typeof value === "object" && !Array.isArray(value) &&
+    Object.keys(value).length === expected.length && expected.every((key) => Object.prototype.hasOwnProperty.call(value, key));
+}
+
 function versionAtLeast(value, minimum) {
   if (!/^\d+\.\d+\.\d+$/.test(value)) return false;
   const left = value.split(".").map(Number), right = minimum.split(".").map(Number);
@@ -120,27 +161,31 @@ function verdict(errors, targets, minimumSpeedupPercent, maximumMemoryRegression
     errors,
     targets,
     thresholds: { minimumSpeedupPercent, maximumMemoryRegressionPercent },
-    verificationBoundary: "submitted_cross_platform_release_build_evidence"
+    verificationBoundary: "submitted_cross_platform_release_build_and_verified_sdk_receipt_evidence"
   };
 }
 
 function parseArguments(argv) {
-  const result = { input: null, minimumSpeedupPercent: 30, maximumMemoryRegressionPercent: 10 };
+  const result = { input: null, sdkHeaderReceipt: null, minimumSpeedupPercent: 30, maximumMemoryRegressionPercent: 10 };
   for (let index = 0; index < argv.length; index += 1) {
     const value = argv[index];
     if (value === "--input") result.input = argv[++index];
+    else if (value === "--sdk-header-receipt") result.sdkHeaderReceipt = argv[++index];
     else if (value === "--min-speedup-percent") result.minimumSpeedupPercent = Number(argv[++index]);
     else if (value === "--max-memory-regression-percent") result.maximumMemoryRegressionPercent = Number(argv[++index]);
     else throw new Error(`Unknown argument: ${value}`);
   }
-  if (!result.input) throw new Error("--input <evidence.json> is required.");
+  if (!result.input || !result.sdkHeaderReceipt) throw new Error("--input <evidence.json> and --sdk-header-receipt <receipt.json> are required.");
   return result;
 }
 
 async function main() {
   const args = parseArguments(process.argv.slice(2));
-  const document = JSON.parse(await readFile(args.input, "utf8"));
-  const result = verifyHybridBenchmarkEvidence(document, args);
+  const [document, sdkHeaderReceipt] = await Promise.all([
+    readFile(args.input, "utf8").then(JSON.parse),
+    readFile(args.sdkHeaderReceipt, "utf8").then(JSON.parse),
+  ]);
+  const result = verifyHybridBenchmarkEvidence(document, { ...args, sdkHeaderReceipt });
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
   if (!result.promotionEligible) process.exitCode = 1;
 }

--- a/src/resources/premiere-surface-registry.json
+++ b/src/resources/premiere-surface-registry.json
@@ -74,7 +74,8 @@
       "inventoryCommand": "npm run native:sdk-header-inventory",
       "inventoryVerificationCommand": "npm run native:sdk-header-inventory:verify",
       "inventoryDocumentation": "docs/native-sdk-header-inventory.md",
-      "notes": "The downloadable SDK headers are access-controlled. The header receipt and standalone verifier can account for an authorized artifact without copying it; the existing benchmark remains disabled until exact SDK and cross-platform evidence are available."
+      "benchmarkEvidenceCommand": "npm run benchmark:uxp-hybrid:verify",
+      "notes": "The downloadable SDK headers are access-controlled. The header receipt and standalone verifier can account for an authorized artifact without copying it; a candidate benchmark must bind its runs to a matching verified receipt, and remains disabled until exact SDK and cross-platform evidence are available."
     },
     {
       "id": "premiere-cpp-sdk",

--- a/tests/hybrid-benchmark-evidence.test.ts
+++ b/tests/hybrid-benchmark-evidence.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
@@ -55,7 +55,7 @@ function prsdkHeaderReceipt() {
 
 function evidence(headerReceipt = sdkHeaderReceipt()) {
   return {
-    schemaVersion: 1,
+    schemaVersion: 2,
     workloadId: "weighted-energy-v1",
     configuration: { sampleCount: 30, warmupCount: 3, iterations: 4, inputLength: 131072, seed: 1337 },
     memoryMeasurement: "fixture process monitor",
@@ -81,7 +81,30 @@ function evidence(headerReceipt = sdkHeaderReceipt()) {
   };
 }
 
+function legacyEvidence() {
+  const { sdkHeaderReceiptSha256, ...v1 } = evidence();
+  return { ...v1, schemaVersion: 1 };
+}
+
 describe("UXP hybrid benchmark evidence verifier", () => {
+  it("keeps the frozen v1 schema and verifier path available while making receipt binding v2", () => {
+    const v1Schema = JSON.parse(readFileSync("benchmarks/uxp-hybrid/evidence.v1.schema.json", "utf8"));
+    const v2Schema = JSON.parse(readFileSync("benchmarks/uxp-hybrid/evidence.schema.json", "utf8"));
+    expect(v1Schema.$id).toBe("https://premiere-pro-mcp.com/schemas/uxp-hybrid-benchmark-evidence-v1.json");
+    expect(v1Schema.properties.schemaVersion.const).toBe(1);
+    expect(v1Schema.required).not.toContain("sdkHeaderReceiptSha256");
+    expect(v2Schema.$id).toBe("https://premiere-pro-mcp.com/schemas/uxp-hybrid-benchmark-evidence-v2.json");
+    expect(v2Schema.properties.schemaVersion.const).toBe(2);
+    expect(v2Schema.required).toContain("sdkHeaderReceiptSha256");
+    expect(verifyHybridBenchmarkEvidence(legacyEvidence())).toEqual({
+      promotionEligible: true,
+      errors: [],
+      targets: ["mac-arm64", "mac-x64", "win-x64"],
+      thresholds: { minimumSpeedupPercent: 30, maximumMemoryRegressionPercent: 10 },
+      verificationBoundary: "submitted_cross_platform_release_build_evidence",
+    });
+  });
+
   it("requires all release targets, matching output, speed, memory, signing, and one commit", () => {
     const receipt = sdkHeaderReceipt();
     expect(verifyHybridBenchmarkEvidence(evidence(receipt), { sdkHeaderReceipt: receipt })).toEqual({
@@ -148,7 +171,7 @@ describe("UXP hybrid benchmark evidence verifier", () => {
       .toContain("runs[0].native must contain only the documented metric fields.");
   });
 
-  it("requires the local receipt path from the command-line verifier without printing it", () => {
+  it("requires a local receipt path for v2 without printing it while retaining v1 CLI compatibility", () => {
     const directory = mkdtempSync(join(tmpdir(), "premiere-hybrid-benchmark-"));
     const input = join(directory, "evidence.json");
     const receiptPath = join(directory, "receipt.json");
@@ -158,7 +181,14 @@ describe("UXP hybrid benchmark evidence verifier", () => {
       writeFileSync(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`);
       const missingReceipt = spawnSync(process.execPath, ["scripts/verify-uxp-hybrid-benchmark.mjs", "--input", input], { encoding: "utf8" });
       expect(missingReceipt.status).not.toBe(0);
-      expect(missingReceipt.stderr).toContain("--input <evidence.json> and --sdk-header-receipt <receipt.json> are required.");
+      expect(missingReceipt.stdout).toContain("A verified UXP Hybrid SDK header receipt is required.");
+
+      writeFileSync(input, `${JSON.stringify(legacyEvidence(), null, 2)}\n`);
+      const legacy = spawnSync(process.execPath, ["scripts/verify-uxp-hybrid-benchmark.mjs", "--input", input], { encoding: "utf8" });
+      expect(legacy.status).toBe(0);
+      expect(legacy.stdout).toContain('"verificationBoundary": "submitted_cross_platform_release_build_evidence"');
+
+      writeFileSync(input, `${JSON.stringify(evidence(receipt), null, 2)}\n`);
 
       const verified = spawnSync(process.execPath, ["scripts/verify-uxp-hybrid-benchmark.mjs", "--input", input, "--sdk-header-receipt", receiptPath], { encoding: "utf8" });
       expect(verified.status).toBe(0);

--- a/tests/hybrid-benchmark-evidence.test.ts
+++ b/tests/hybrid-benchmark-evidence.test.ts
@@ -34,6 +34,25 @@ function sdkHeaderReceipt(sdkVersion = "UXP Hybrid SDK test fixture") {
   };
 }
 
+function prsdkHeaderReceipt() {
+  return {
+    schemaVersion: 1,
+    source: {
+      sdk: "premiere-prsdk",
+      sdkVersion: "UXP Hybrid SDK test fixture",
+      authorityUrl: "https://developer.adobe.com/premiere-pro/",
+      archiveSha256: "c".repeat(64),
+      inventoryScope: "header_files_only",
+      includeDirectories: ["Headers"],
+    },
+    semantics: NATIVE_SDK_HEADER_INVENTORY_SEMANTICS,
+    stats: { headers: 1, bytes: 7 },
+    headers: [
+      { path: "Headers/PrSDKFixture.h", bytes: 7, sha256: "d".repeat(64) },
+    ],
+  };
+}
+
 function evidence(headerReceipt = sdkHeaderReceipt()) {
   return {
     schemaVersion: 1,
@@ -103,9 +122,30 @@ describe("UXP hybrid benchmark evidence verifier", () => {
         "sdkHeaderReceiptSha256 does not match the verified SDK header receipt.",
       ]));
 
+    const wrongSdkReceipt = prsdkHeaderReceipt();
+    expect(verifyHybridBenchmarkEvidence(value, { sdkHeaderReceipt: wrongSdkReceipt }).errors)
+      .toEqual(expect.arrayContaining([
+        "SDK header receipt must identify uxp-hybrid.",
+        "sdkHeaderReceiptSha256 does not match the verified SDK header receipt.",
+      ]));
+
     const withExtraField = { ...value, privateSdkPath: "C:Headers" };
     expect(verifyHybridBenchmarkEvidence(withExtraField, { sdkHeaderReceipt: receipt }).errors)
       .toContain("Evidence must contain only the documented benchmark receipt fields.");
+
+    const withExtraRunField = {
+      ...value,
+      runs: [{ ...value.runs[0], localAddonPath: "C:Headers" }, ...value.runs.slice(1)],
+    };
+    expect(verifyHybridBenchmarkEvidence(withExtraRunField, { sdkHeaderReceipt: receipt }).errors)
+      .toContain("runs[0] must contain only the documented benchmark fields.");
+
+    const withExtraMetricField = {
+      ...value,
+      runs: [{ ...value.runs[0], native: { ...value.runs[0].native, rawSamples: [60] } }, ...value.runs.slice(1)],
+    };
+    expect(verifyHybridBenchmarkEvidence(withExtraMetricField, { sdkHeaderReceipt: receipt }).errors)
+      .toContain("runs[0].native must contain only the documented metric fields.");
   });
 
   it("requires the local receipt path from the command-line verifier without printing it", () => {
@@ -124,6 +164,12 @@ describe("UXP hybrid benchmark evidence verifier", () => {
       expect(verified.status).toBe(0);
       expect(verified.stdout).toContain('"promotionEligible": true');
       expect(verified.stdout).not.toContain("UxpAddonShared.h");
+
+      const unreadableReceipt = join(directory, "do-not-disclose-this-receipt.json");
+      const unreadable = spawnSync(process.execPath, ["scripts/verify-uxp-hybrid-benchmark.mjs", "--input", input, "--sdk-header-receipt", unreadableReceipt], { encoding: "utf8" });
+      expect(unreadable.status).not.toBe(0);
+      expect(unreadable.stderr).toContain("SDK header receipt must be a readable JSON document.");
+      expect(unreadable.stderr).not.toContain(unreadableReceipt);
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }

--- a/tests/hybrid-benchmark-evidence.test.ts
+++ b/tests/hybrid-benchmark-evidence.test.ts
@@ -1,18 +1,46 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
 import {
   REQUIRED_TARGETS,
   verifyHybridBenchmarkEvidence,
 } from "../scripts/verify-uxp-hybrid-benchmark.mjs";
+import { NATIVE_SDK_HEADER_INVENTORY_SEMANTICS } from "../scripts/native-sdk-header-inventory-contract.mjs";
+import { canonicalNativeSdkHeaderInventorySha256 } from "../scripts/verify-native-sdk-header-inventory.mjs";
 
 const SHA = "a".repeat(40);
 const ADDON_SHA = "b".repeat(64);
 
-function evidence() {
+function sdkHeaderReceipt(sdkVersion = "UXP Hybrid SDK test fixture") {
+  return {
+    schemaVersion: 1,
+    source: {
+      sdk: "uxp-hybrid",
+      sdkVersion,
+      authorityUrl: "https://developer.adobe.com/premiere-pro/uxp/plugins/hybrid-plugins/",
+      archiveSha256: "c".repeat(64),
+      inventoryScope: "header_files_only",
+      includeDirectories: ["src/api", "src/utilities"],
+    },
+    semantics: NATIVE_SDK_HEADER_INVENTORY_SEMANTICS,
+    stats: { headers: 3, bytes: 24 },
+    headers: [
+      { path: "src/api/UxpAddonShared.h", bytes: 7, sha256: "d".repeat(64) },
+      { path: "src/api/UxpAddonTypes.h", bytes: 8, sha256: "e".repeat(64) },
+      { path: "src/utilities/UxpAddon.h", bytes: 9, sha256: "f".repeat(64) },
+    ],
+  };
+}
+
+function evidence(headerReceipt = sdkHeaderReceipt()) {
   return {
     schemaVersion: 1,
     workloadId: "weighted-energy-v1",
     configuration: { sampleCount: 30, warmupCount: 3, iterations: 4, inputLength: 131072, seed: 1337 },
     memoryMeasurement: "fixture process monitor",
+    sdkHeaderReceiptSha256: canonicalNativeSdkHeaderInventorySha256(headerReceipt),
     runs: REQUIRED_TARGETS.map((target) => {
       const [platform, arch] = target.split("-");
       return {
@@ -36,24 +64,68 @@ function evidence() {
 
 describe("UXP hybrid benchmark evidence verifier", () => {
   it("requires all release targets, matching output, speed, memory, signing, and one commit", () => {
-    expect(verifyHybridBenchmarkEvidence(evidence())).toEqual({
+    const receipt = sdkHeaderReceipt();
+    expect(verifyHybridBenchmarkEvidence(evidence(receipt), { sdkHeaderReceipt: receipt })).toEqual({
       promotionEligible: true,
       errors: [],
       targets: ["mac-arm64", "mac-x64", "win-x64"],
       thresholds: { minimumSpeedupPercent: 30, maximumMemoryRegressionPercent: 10 },
-      verificationBoundary: "submitted_cross_platform_release_build_evidence",
+      verificationBoundary: "submitted_cross_platform_release_build_and_verified_sdk_receipt_evidence",
     });
   });
 
   it("fails closed when a target is missing or a percentile misses the threshold", () => {
-    const value = evidence();
+    const receipt = sdkHeaderReceipt();
+    const value = evidence(receipt);
     value.runs.pop();
     value.runs[0].native.p95Ms = 110;
-    const result = verifyHybridBenchmarkEvidence(value);
+    const result = verifyHybridBenchmarkEvidence(value, { sdkHeaderReceipt: receipt });
     expect(result.promotionEligible).toBe(false);
     expect(result.errors).toEqual(expect.arrayContaining([
       expect.stringContaining("p95 speedup"),
       expect.stringContaining("Missing required mac-arm64 evidence"),
     ]));
+  });
+
+  it("requires a structurally verified matching Hybrid receipt and rejects undocumented fields", () => {
+    const receipt = sdkHeaderReceipt();
+    const value = evidence(receipt);
+    expect(verifyHybridBenchmarkEvidence(value).errors).toContain("A verified UXP Hybrid SDK header receipt is required.");
+
+    const mismatchedDigest = { ...value, sdkHeaderReceiptSha256: "0".repeat(64) };
+    expect(verifyHybridBenchmarkEvidence(mismatchedDigest, { sdkHeaderReceipt: receipt }).errors)
+      .toContain("sdkHeaderReceiptSha256 does not match the verified SDK header receipt.");
+
+    const mismatchedVersionReceipt = sdkHeaderReceipt("UXP Hybrid SDK other fixture");
+    expect(verifyHybridBenchmarkEvidence(value, { sdkHeaderReceipt: mismatchedVersionReceipt }).errors)
+      .toEqual(expect.arrayContaining([
+        "SDK header receipt sdkVersion must match all benchmark runs.",
+        "sdkHeaderReceiptSha256 does not match the verified SDK header receipt.",
+      ]));
+
+    const withExtraField = { ...value, privateSdkPath: "C:Headers" };
+    expect(verifyHybridBenchmarkEvidence(withExtraField, { sdkHeaderReceipt: receipt }).errors)
+      .toContain("Evidence must contain only the documented benchmark receipt fields.");
+  });
+
+  it("requires the local receipt path from the command-line verifier without printing it", () => {
+    const directory = mkdtempSync(join(tmpdir(), "premiere-hybrid-benchmark-"));
+    const input = join(directory, "evidence.json");
+    const receiptPath = join(directory, "receipt.json");
+    const receipt = sdkHeaderReceipt();
+    try {
+      writeFileSync(input, `${JSON.stringify(evidence(receipt), null, 2)}\n`);
+      writeFileSync(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`);
+      const missingReceipt = spawnSync(process.execPath, ["scripts/verify-uxp-hybrid-benchmark.mjs", "--input", input], { encoding: "utf8" });
+      expect(missingReceipt.status).not.toBe(0);
+      expect(missingReceipt.stderr).toContain("--input <evidence.json> and --sdk-header-receipt <receipt.json> are required.");
+
+      const verified = spawnSync(process.execPath, ["scripts/verify-uxp-hybrid-benchmark.mjs", "--input", input, "--sdk-header-receipt", receiptPath], { encoding: "utf8" });
+      expect(verified.status).toBe(0);
+      expect(verified.stdout).toContain('"promotionEligible": true');
+      expect(verified.stdout).not.toContain("UxpAddonShared.h");
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/premiere-surface-registry.test.ts
+++ b/tests/premiere-surface-registry.test.ts
@@ -13,6 +13,7 @@ type Surface = {
   inventoryCommand?: string;
   inventoryVerificationCommand?: string;
   inventoryDocumentation?: string;
+  benchmarkEvidenceCommand?: string;
   notes: string;
 };
 
@@ -114,6 +115,10 @@ describe("Premiere API and competitor surface registry", () => {
         inventoryDocumentation: "docs/native-sdk-header-inventory.md",
       });
     }
+    expect(registry.integrationSurfaces.find((surface) => surface.id === "uxp-hybrid-cpp"))
+      .toMatchObject({
+        benchmarkEvidenceCommand: "npm run benchmark:uxp-hybrid:verify",
+      });
   });
 
   it("pins reviewed competitor sources and explicit safe-adoption boundaries", () => {

--- a/tests/release-package.test.ts
+++ b/tests/release-package.test.ts
@@ -12,6 +12,7 @@ describe("npm release package verification", () => {
 
     expect(packageJson.scripts["pack:check"]).toBe("node scripts/verify-npm-package.mjs");
     expect(verifier).toContain("package/docs/premiere-surface-registry.md");
+    expect(verifier).toContain("package/docs/uxp-hybrid-benchmark.md");
     expect(verifier).toContain("package/dist/resources/premiere-surface-registry.json");
     expect(verifier).toContain("installedRegistry.integrationSurfaces");
     expect(verifier).toContain("registry references a missing inventory artifact");

--- a/tests/verify-native-sdk-header-inventory.test.ts
+++ b/tests/verify-native-sdk-header-inventory.test.ts
@@ -4,7 +4,10 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
 import { NATIVE_SDK_HEADER_INVENTORY_SEMANTICS } from "../scripts/native-sdk-header-inventory-contract.mjs";
-import { verifyNativeSdkHeaderInventory } from "../scripts/verify-native-sdk-header-inventory.mjs";
+import {
+  canonicalNativeSdkHeaderInventorySha256,
+  verifyNativeSdkHeaderInventory,
+} from "../scripts/verify-native-sdk-header-inventory.mjs";
 
 const hash = (character: string) => character.repeat(64);
 
@@ -83,6 +86,19 @@ describe("native SDK header receipt verifier", () => {
     expect(() => verifyNativeSdkHeaderInventory(missingExpectedHeader)).toThrow("Missing required UXP Hybrid SDK header");
   });
 
+  it("creates one canonical digest for equivalent verified receipts", () => {
+    const receipt = hybridReceipt();
+    const reordered = {
+      headers: receipt.headers,
+      stats: receipt.stats,
+      semantics: receipt.semantics,
+      source: receipt.source,
+      schemaVersion: receipt.schemaVersion,
+    };
+    expect(canonicalNativeSdkHeaderInventorySha256(receipt)).toMatch(/^[a-f0-9]{64}$/);
+    expect(canonicalNativeSdkHeaderInventorySha256(reordered)).toBe(canonicalNativeSdkHeaderInventorySha256(receipt));
+  });
+
   it("validates JSON through the CLI without printing receipt contents", () => {
     const directory = mkdtempSync(join(tmpdir(), "premiere-native-sdk-receipt-"));
     const input = join(directory, "receipt.json");
@@ -92,6 +108,11 @@ describe("native SDK header receipt verifier", () => {
       expect(result.status).toBe(0);
       expect(result.stdout).toContain("Native SDK header receipt is valid: 3 uxp-hybrid header files, 24 bytes.");
       expect(result.stdout).not.toContain("UxpAddonShared.h");
+
+      const digest = spawnSync(process.execPath, ["scripts/verify-native-sdk-header-inventory.mjs", "--input", input, "--print-canonical-sha256"], { encoding: "utf8" });
+      expect(digest.status).toBe(0);
+      expect(digest.stdout).toContain(`Canonical receipt SHA-256: ${canonicalNativeSdkHeaderInventorySha256(hybridReceipt())}`);
+      expect(digest.stdout).not.toContain("UxpAddonShared.h");
 
       const malformed = clone(hybridReceipt());
       malformed.headers[0].contents = "private SDK header";


### PR DESCRIPTION
## Summary\n- require Hybrid benchmark submissions to bind to a canonical SHA-256 of a locally verified, hash-only UXP Hybrid header receipt\n- reject undocumented benchmark receipt fields and require exact receipt/run SDK-version agreement\n- document and register the local-only receipt verification command without adding a native addon, manifest permission, or MCP tool\n\n## Verification\n- 
pm run check\n- 
px vitest run --maxWorkers=4 (104 files, 2,134 tests)\n- 
pm run test:coverage (96.84% lines, 91.61% branches)\n- 
pm run pack:check\n\n## Boundary\nThis is accounting and verification only. It does not commit access-controlled SDK material, verify private archive bytes, create an addon, or establish a licensed Premiere-host capability.