### PR TITLE
test(native): bind Hybrid entrypoint receipt

### DIFF
--- a/docs/premiere-surface-registry.md
+++ b/docs/premiere-surface-registry.md
@@ -35,8 +35,9 @@ its submitted runs to a matching verified receipt, as described by the
 [Hybrid benchmark gate](uxp-hybrid-benchmark.md); the digest binding is not a
 native-build or host-behavior claim. A temporary development bundle can also
 produce a [Hybrid addon-layout receipt](uxp-hybrid-addon-receipt.md) for the
-three public target paths without disclosing binaries; it is still not binary
-architecture, signing, loading, or runtime proof.
+public root `main.js` entrypoint and three target paths without disclosing
+source or binaries; it is still not binary architecture, signing, loading, or
+runtime proof.
 
 The same registry pins the exact competitor commits reviewed for feature-gap
 work. A competitor feature family becomes an implementation candidate only

--- a/docs/uxp-hybrid-addon-receipt.md
+++ b/docs/uxp-hybrid-addon-receipt.md
@@ -2,8 +2,9 @@
 
 Adobe's public Hybrid build guide requires a temporary Hybrid manifest with
 manifest version 6 or newer, `addon.name`, and
-`requiredPermissions.enableAddon`. It also requires one `.uxpaddon` at each
-of these bundle-relative paths:
+`requiredPermissions.enableAddon`. Its documented bundle structure includes a
+root `main.js` entrypoint and one `.uxpaddon` at each of these bundle-relative
+paths:
 
 ```text
 mac/x64/<addon name>.uxpaddon
@@ -16,10 +17,12 @@ or addon permission. Do not run this procedure against `uxp-plugin/`; use a
 separate, local development bundle after obtaining an authorized Hybrid SDK.
 
 `npm run native:hybrid-addon-receipt` reads that local bundle and an already
-verified Hybrid SDK header receipt. It writes only public-layout relative paths,
-byte counts, SHA-256 digests, minimal manifest facts, and the canonical header
-receipt digest. It does not copy the development manifest, addon binaries,
-SDK headers, archive, absolute paths, signing material, or host responses.
+verified Hybrid SDK header receipt. Its current schema-v2 output records the
+root entrypoint's relative path, byte count, and SHA-256 digest alongside the
+three addon artifacts, minimal manifest facts, and canonical header-receipt
+digest. It does not copy or parse the development entrypoint or manifest, or
+copy addon binaries, SDK headers, archive, absolute paths, signing material,
+or host responses.
 
 ```powershell
 npm run native:hybrid-addon-receipt -- `
@@ -40,14 +43,19 @@ npm run native:hybrid-addon-receipt:verify -- `
   --print-canonical-sha256
 ```
 
+The verifier accepts existing schema-v1 receipts, which intentionally contain
+only the three addon artifacts, and current schema-v2 receipts with exactly one
+root `main.js` entrypoint. It does not invent an entrypoint for v1 receipts.
+New generation always produces v2.
+
 The verifier checks the documented layout and the supplied header-receipt
-identity. It does **not** prove that a binary was compiled with the SDK, has the
-advertised architecture, is signed or notarized, can load in UXP Developer
-Tool, exposes the benchmark adapter, is an MCP capability, or behaves in a
-licensed Premiere host. Those remain separate build, signing, UDT installation,
-and licensed-host gates. It records a valid manifest `host.minVersion` (the
-build guide's example is 25.6); the separate benchmark evidence requires the
-actual Premiere host to be 26.2 or newer.
+identity. It does **not** prove that `main.js` requires an addon, that a binary
+was compiled with the SDK, has the advertised architecture, is signed or
+notarized, can load in UXP Developer Tool, exposes the benchmark adapter, is an
+MCP capability, or behaves in a licensed Premiere host. Those remain separate
+build, signing, UDT installation, and licensed-host gates. It records a valid
+manifest `host.minVersion` (the build guide's example is 25.6); the separate
+benchmark evidence requires the actual Premiere host to be 26.2 or newer.
 
 Official references: [Hybrid Plugins](https://developer.adobe.com/premiere-pro/uxp/plugins/hybrid-plugins/)
 and [Building Hybrid Plugins](https://developer.adobe.com/premiere-pro/uxp/plugins/hybrid-plugins/build).

--- a/docs/uxp-hybrid-benchmark.md
+++ b/docs/uxp-hybrid-benchmark.md
@@ -87,9 +87,10 @@ candidates must use v2 rather than changing a published v1 receipt's meaning.
 
 Before submitting performance evidence, record the candidate development
 bundle with the separate [Hybrid addon-layout receipt](uxp-hybrid-addon-receipt.md).
-That verifies the public three-target paths and binds them to the Hybrid header
-receipt without publishing binaries. It is a preflight accounting artifact, not
-a compile, signing, UDT-load, or host-behavior claim.
+That verifies the public root `main.js` entrypoint and three-target paths and
+binds them to the Hybrid header receipt without publishing source or binaries.
+It is a preflight accounting artifact, not a compile, signing, UDT-load, or
+host-behavior claim.
 
 The native implementation must improve both p50 and p95 by at least 30% on every
 target while keeping peak working-set regression at or below 10%. Verify with:

--- a/scripts/generate-uxp-hybrid-addon-receipt.mjs
+++ b/scripts/generate-uxp-hybrid-addon-receipt.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from "node:url";
 import { relative, resolve, sep } from "node:path";
 import {
   UXP_HYBRID_ADDON_AUTHORITY_URL,
+  UXP_HYBRID_ADDON_ENTRYPOINT_PATH,
   UXP_HYBRID_ADDON_RECEIPT_SCHEMA_VERSION,
   UXP_HYBRID_ADDON_RECEIPT_SEMANTICS,
   UXP_HYBRID_ADDON_TARGETS,
@@ -18,6 +19,7 @@ import {
 import { verifyUxpHybridAddonReceipt } from "./verify-uxp-hybrid-addon-receipt.mjs";
 
 const MAX_ARTIFACT_BYTES = 2 ** 31;
+const MAX_ENTRYPOINT_BYTES = 16 * 1024 * 1024;
 
 function receiptError(message) {
   const error = new Error(message);
@@ -107,6 +109,15 @@ export async function generateUxpHybridAddonReceipt(options) {
   if (sdkSummary.sdk !== "uxp-hybrid") throw receiptError("sdkHeaderReceipt must identify uxp-hybrid");
 
   const manifest = await readDevelopmentManifest(pluginRoot);
+  const entrypointFile = await requiredPluginFile(pluginRoot, resolve(pluginRoot, UXP_HYBRID_ADDON_ENTRYPOINT_PATH), UXP_HYBRID_ADDON_ENTRYPOINT_PATH);
+  if (!Number.isSafeInteger(entrypointFile.size) || entrypointFile.size <= 0 || entrypointFile.size > MAX_ENTRYPOINT_BYTES) {
+    throw receiptError(`${UXP_HYBRID_ADDON_ENTRYPOINT_PATH} must be a non-empty file no larger than ${MAX_ENTRYPOINT_BYTES} bytes`);
+  }
+  const entrypoint = {
+    path: UXP_HYBRID_ADDON_ENTRYPOINT_PATH,
+    bytes: entrypointFile.size,
+    sha256: await sha256File(entrypointFile.path),
+  };
   const artifacts = [];
   for (const target of UXP_HYBRID_ADDON_TARGETS) {
     const relativePath = `${target.pathPrefix}/${manifest.addonName}`;
@@ -126,8 +137,14 @@ export async function generateUxpHybridAddonReceipt(options) {
       authorityUrl: UXP_HYBRID_ADDON_AUTHORITY_URL,
     },
     manifest,
+    entrypoint,
     semantics: UXP_HYBRID_ADDON_RECEIPT_SEMANTICS,
-    stats: { artifacts: artifacts.length, bytes: artifacts.reduce((total, artifact) => total + artifact.bytes, 0) },
+    stats: {
+      artifacts: artifacts.length,
+      addonBytes: artifacts.reduce((total, artifact) => total + artifact.bytes, 0),
+      entrypoints: 1,
+      entrypointBytes: entrypoint.bytes,
+    },
     artifacts,
   };
   verifyUxpHybridAddonReceipt(receipt, { sdkHeaderReceipt: options.sdkHeaderReceipt });
@@ -166,7 +183,7 @@ async function main() {
   });
   const rendered = `${JSON.stringify(receipt, null, 2)}\n`;
   if (options.validateOnly) {
-    process.stdout.write(`Validated ${receipt.stats.artifacts} UXP Hybrid addon artifacts.\n`);
+    process.stdout.write(`Validated ${receipt.stats.artifacts} UXP Hybrid addon artifacts and ${receipt.stats.entrypoints} entrypoint.\n`);
     return;
   }
   const outputPath = resolve(options.outputPath);
@@ -176,11 +193,11 @@ async function main() {
     if (current.replaceAll("\r\n", "\n") !== rendered) {
       throw receiptError("UXP Hybrid addon receipt is stale; rerun without --check after reviewing the local development bundle");
     }
-    process.stdout.write(`UXP Hybrid addon receipt is current: ${receipt.stats.artifacts} artifacts.\n`);
+    process.stdout.write(`UXP Hybrid addon receipt is current: ${receipt.stats.artifacts} artifacts and ${receipt.stats.entrypoints} entrypoint.\n`);
     return;
   }
   await writeFile(outputPath, rendered);
-  process.stdout.write(`Wrote ${receipt.stats.artifacts} UXP Hybrid addon artifacts.\n`);
+  process.stdout.write(`Wrote ${receipt.stats.artifacts} UXP Hybrid addon artifacts and ${receipt.stats.entrypoints} entrypoint.\n`);
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/scripts/uxp-hybrid-addon-receipt-contract.mjs
+++ b/scripts/uxp-hybrid-addon-receipt-contract.mjs
@@ -1,14 +1,21 @@
-export const UXP_HYBRID_ADDON_RECEIPT_SCHEMA_VERSION = 1;
+export const UXP_HYBRID_ADDON_RECEIPT_SCHEMA_VERSION = 2;
+export const UXP_HYBRID_ADDON_RECEIPT_LEGACY_SCHEMA_VERSION = 1;
 export const UXP_HYBRID_ADDON_AUTHORITY_URL = "https://developer.adobe.com/premiere-pro/uxp/plugins/hybrid-plugins/build";
+export const UXP_HYBRID_ADDON_ENTRYPOINT_PATH = "main.js";
 export const UXP_HYBRID_ADDON_TARGETS = Object.freeze([
   Object.freeze({ target: "mac-x64", pathPrefix: "mac/x64" }),
   Object.freeze({ target: "mac-arm64", pathPrefix: "mac/arm64" }),
   Object.freeze({ target: "win-x64", pathPrefix: "win/x64" }),
 ]);
 
-export const UXP_HYBRID_ADDON_RECEIPT_SEMANTICS = Object.freeze({
+export const UXP_HYBRID_ADDON_RECEIPT_LEGACY_SEMANTICS = Object.freeze({
   listed: "Each listed item is a required UXP Hybrid addon artifact observed in a locally supplied development plugin bundle. Paths are relative to that bundle and binary or manifest contents are not copied into this receipt.",
   doesNotEstablish: "This receipt does not establish Adobe entitlement, SDK compilation, binary architecture, code-signing or notarization validity, UDT loading, MCP exposure, or licensed-host behavior.",
+});
+
+export const UXP_HYBRID_ADDON_RECEIPT_SEMANTICS = Object.freeze({
+  listed: "Each listed addon artifact and root main.js entrypoint is observed in a locally supplied development plugin bundle. Paths are relative to that bundle and binary, manifest, or entrypoint contents are not copied or parsed by this receipt.",
+  doesNotEstablish: UXP_HYBRID_ADDON_RECEIPT_LEGACY_SEMANTICS.doesNotEstablish,
 });
 
 export function compareUxpHybridPaths(left, right) {

--- a/scripts/verify-uxp-hybrid-addon-receipt.mjs
+++ b/scripts/verify-uxp-hybrid-addon-receipt.mjs
@@ -6,6 +6,9 @@ import { fileURLToPath } from "node:url";
 import { resolve } from "node:path";
 import {
   UXP_HYBRID_ADDON_AUTHORITY_URL,
+  UXP_HYBRID_ADDON_ENTRYPOINT_PATH,
+  UXP_HYBRID_ADDON_RECEIPT_LEGACY_SCHEMA_VERSION,
+  UXP_HYBRID_ADDON_RECEIPT_LEGACY_SEMANTICS,
   UXP_HYBRID_ADDON_RECEIPT_SCHEMA_VERSION,
   UXP_HYBRID_ADDON_RECEIPT_SEMANTICS,
   UXP_HYBRID_ADDON_TARGETS,
@@ -19,6 +22,7 @@ import {
 const SHA256_PATTERN = /^[a-f0-9]{64}$/;
 const MAX_PATH_LENGTH = 512;
 const MAX_ARTIFACT_BYTES = 2 ** 31;
+const MAX_ENTRYPOINT_BYTES = 16 * 1024 * 1024;
 
 function receiptError(message) {
   const error = new Error(message);
@@ -78,9 +82,13 @@ function expectedArtifactPath(target, name) {
 }
 
 export function verifyUxpHybridAddonReceipt(document, options = {}) {
-  const receipt = record(document, "receipt", ["schemaVersion", "source", "manifest", "semantics", "stats", "artifacts"]);
-  if (receipt.schemaVersion !== UXP_HYBRID_ADDON_RECEIPT_SCHEMA_VERSION) {
-    throw receiptError(`schemaVersion must be ${UXP_HYBRID_ADDON_RECEIPT_SCHEMA_VERSION}`);
+  if (!document || typeof document !== "object" || Array.isArray(document)) throw receiptError("receipt must be an object");
+  const legacy = document.schemaVersion === UXP_HYBRID_ADDON_RECEIPT_LEGACY_SCHEMA_VERSION;
+  const receipt = record(document, "receipt", legacy
+    ? ["schemaVersion", "source", "manifest", "semantics", "stats", "artifacts"]
+    : ["schemaVersion", "source", "manifest", "entrypoint", "semantics", "stats", "artifacts"]);
+  if (!legacy && receipt.schemaVersion !== UXP_HYBRID_ADDON_RECEIPT_SCHEMA_VERSION) {
+    throw receiptError(`schemaVersion must be ${UXP_HYBRID_ADDON_RECEIPT_LEGACY_SCHEMA_VERSION} or ${UXP_HYBRID_ADDON_RECEIPT_SCHEMA_VERSION}`);
   }
 
   const source = record(receipt.source, "source", ["sdk", "sdkVersion", "sdkHeaderReceiptSha256", "authorityUrl"]);
@@ -103,8 +111,25 @@ export function verifyUxpHybridAddonReceipt(document, options = {}) {
   if (manifest.enableAddon !== true) throw receiptError("manifest.enableAddon must be true");
 
   const semantics = record(receipt.semantics, "semantics", ["listed", "doesNotEstablish"]);
-  if (semantics.listed !== UXP_HYBRID_ADDON_RECEIPT_SEMANTICS.listed || semantics.doesNotEstablish !== UXP_HYBRID_ADDON_RECEIPT_SEMANTICS.doesNotEstablish) {
+  const requiredSemantics = legacy ? UXP_HYBRID_ADDON_RECEIPT_LEGACY_SEMANTICS : UXP_HYBRID_ADDON_RECEIPT_SEMANTICS;
+  if (semantics.listed !== requiredSemantics.listed || semantics.doesNotEstablish !== requiredSemantics.doesNotEstablish) {
     throw receiptError("semantics must retain the documented evidence boundary");
+  }
+
+  let entrypoint;
+  if (!legacy) {
+    const value = record(receipt.entrypoint, "entrypoint", ["path", "bytes", "sha256"]);
+    if (value.path !== UXP_HYBRID_ADDON_ENTRYPOINT_PATH) {
+      throw receiptError(`entrypoint.path must be ${UXP_HYBRID_ADDON_ENTRYPOINT_PATH}`);
+    }
+    entrypoint = {
+      path: value.path,
+      bytes: safePositiveInteger(value.bytes, "entrypoint.bytes"),
+      sha256: sha256(value.sha256, "entrypoint.sha256"),
+    };
+    if (entrypoint.bytes > MAX_ENTRYPOINT_BYTES) {
+      throw receiptError(`entrypoint.bytes must be no larger than ${MAX_ENTRYPOINT_BYTES}`);
+    }
   }
 
   if (!Array.isArray(receipt.artifacts) || receipt.artifacts.length !== UXP_HYBRID_ADDON_TARGETS.length) {
@@ -119,10 +144,18 @@ export function verifyUxpHybridAddonReceipt(document, options = {}) {
     return { target: artifact.target, path, bytes: safePositiveInteger(artifact.bytes, `artifacts[${index}].bytes`), sha256: sha256(artifact.sha256, `artifacts[${index}].sha256`) };
   });
 
-  const stats = record(receipt.stats, "stats", ["artifacts", "bytes"]);
+  const stats = record(receipt.stats, "stats", legacy
+    ? ["artifacts", "bytes"]
+    : ["artifacts", "addonBytes", "entrypoints", "entrypointBytes"]);
   if (stats.artifacts !== artifacts.length) throw receiptError("stats.artifacts does not match artifacts");
-  const bytes = artifacts.reduce((total, artifact) => total + artifact.bytes, 0);
-  if (!Number.isSafeInteger(bytes) || stats.bytes !== bytes) throw receiptError("stats.bytes does not match artifacts");
+  const addonBytes = artifacts.reduce((total, artifact) => total + artifact.bytes, 0);
+  if (!Number.isSafeInteger(addonBytes)) throw receiptError("addon artifact bytes exceed the supported total");
+  if (legacy && stats.bytes !== addonBytes) throw receiptError("stats.bytes does not match artifacts");
+  if (!legacy) {
+    if (stats.addonBytes !== addonBytes) throw receiptError("stats.addonBytes does not match artifacts");
+    if (stats.entrypoints !== 1) throw receiptError("stats.entrypoints must be 1");
+    if (stats.entrypointBytes !== entrypoint.bytes) throw receiptError("stats.entrypointBytes does not match entrypoint");
+  }
 
   if (options.sdkHeaderReceipt !== undefined) {
     const summary = verifyNativeSdkHeaderInventory(options.sdkHeaderReceipt);
@@ -135,7 +168,9 @@ export function verifyUxpHybridAddonReceipt(document, options = {}) {
     }
   }
 
-  return Object.freeze({ addonName: name, artifacts: artifacts.length, bytes });
+  return Object.freeze(legacy
+    ? { addonName: name, artifacts: artifacts.length, bytes: addonBytes }
+    : { addonName: name, artifacts: artifacts.length, addonBytes, entrypoints: 1, entrypointBytes: entrypoint.bytes });
 }
 
 export function canonicalUxpHybridAddonReceiptSha256(document) {
@@ -172,7 +207,9 @@ async function main() {
     readJson(options.sdkHeaderReceiptPath, "sdkHeaderReceipt"),
   ]);
   const summary = verifyUxpHybridAddonReceipt(receipt, { sdkHeaderReceipt });
-  process.stdout.write(`UXP Hybrid addon receipt is valid: ${summary.artifacts} addon artifacts, ${summary.bytes} bytes.\n`);
+  const entrypointText = "entrypoints" in summary ? ` and ${summary.entrypoints} entrypoint` : "";
+  const bytes = "addonBytes" in summary ? summary.addonBytes + summary.entrypointBytes : summary.bytes;
+  process.stdout.write(`UXP Hybrid addon receipt is valid: ${summary.artifacts} addon artifacts${entrypointText}, ${bytes} bytes.\n`);
   if (options.printCanonicalSha256) process.stdout.write(`Canonical receipt SHA-256: ${canonicalUxpHybridAddonReceiptSha256(receipt)}\n`);
 }
 

--- a/src/resources/premiere-surface-registry.json
+++ b/src/resources/premiere-surface-registry.json
@@ -78,7 +78,7 @@
       "addonReceiptCommand": "npm run native:hybrid-addon-receipt",
       "addonReceiptVerificationCommand": "npm run native:hybrid-addon-receipt:verify",
       "addonReceiptDocumentation": "docs/uxp-hybrid-addon-receipt.md",
-      "notes": "The downloadable SDK headers are access-controlled. The header receipt and standalone verifier can account for an authorized artifact without copying it; a local addon-layout receipt can additionally account for the public three-target bundle layout without copying binaries. A candidate benchmark must bind its runs to a matching verified SDK receipt, and remains disabled until exact SDK, reproducible builds, and cross-platform evidence are available."
+      "notes": "The downloadable SDK headers are access-controlled. The header receipt and standalone verifier can account for an authorized artifact without copying it; a local addon-layout receipt can additionally account for the public root main.js entrypoint and three-target bundle layout without copying source or binaries. A candidate benchmark must bind its runs to a matching verified SDK receipt, and remains disabled until exact SDK, reproducible builds, and cross-platform evidence are available."
     },
     {
       "id": "premiere-cpp-sdk",

--- a/tests/premiere-surface-registry.test.ts
+++ b/tests/premiere-surface-registry.test.ts
@@ -125,6 +125,8 @@ describe("Premiere API and competitor surface registry", () => {
         addonReceiptVerificationCommand: "npm run native:hybrid-addon-receipt:verify",
         addonReceiptDocumentation: "docs/uxp-hybrid-addon-receipt.md",
       });
+    expect(registry.integrationSurfaces.find((surface) => surface.id === "uxp-hybrid-cpp")?.notes)
+      .toContain("root main.js entrypoint and three-target bundle layout");
   });
 
   it("pins reviewed competitor sources and explicit safe-adoption boundaries", () => {

--- a/tests/uxp-hybrid-addon-receipt.test.ts
+++ b/tests/uxp-hybrid-addon-receipt.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
 import { NATIVE_SDK_HEADER_INVENTORY_SEMANTICS } from "../scripts/native-sdk-header-inventory-contract.mjs";
+import { UXP_HYBRID_ADDON_RECEIPT_LEGACY_SEMANTICS } from "../scripts/uxp-hybrid-addon-receipt-contract.mjs";
 import {
   canonicalUxpHybridAddonReceiptSha256,
   verifyUxpHybridAddonReceipt,
@@ -41,6 +42,7 @@ async function writeDevelopmentBundle(root: string, name = "fixture-addon.uxpadd
     addon: { name },
     requiredPermissions: { enableAddon: true },
   }, null, 2)}\n`);
+  writeFileSync(join(root, "main.js"), "const addon = require(\"fixture-addon.uxpaddon\");\n");
   for (const [path, contents] of [
     [`mac/x64/${name}`, "mac intel fixture"],
     [`mac/arm64/${name}`, "mac arm fixture"],
@@ -57,7 +59,7 @@ function clone<T>(value: T): T {
 }
 
 describe("UXP Hybrid addon receipt", () => {
-  it("hashes only the documented three-target temporary-bundle layout and binds a verified Hybrid header receipt", async () => {
+  it("hashes the documented entrypoint and three-target temporary-bundle layout without copying source or binaries", async () => {
     const directory = mkdtempSync(join(tmpdir(), "premiere-hybrid-addon-receipt-"));
     const bundle = join(directory, "bundle");
     const headers = sdkHeaderReceipt();
@@ -66,20 +68,54 @@ describe("UXP Hybrid addon receipt", () => {
       await writeDevelopmentBundle(bundle);
       const receipt = await generateUxpHybridAddonReceipt({ pluginRoot: bundle, sdkHeaderReceipt: headers });
       expect(receipt).toMatchObject({
-        schemaVersion: 1,
+        schemaVersion: 2,
         source: { sdk: "uxp-hybrid", sdkVersion: "fixture-sdk", sdkHeaderReceiptSha256: expect.stringMatching(/^[a-f0-9]{64}$/) },
         manifest: { manifestVersion: 6, hostApp: "premierepro", hostMinVersion: "25.6.0", addonName: "fixture-addon.uxpaddon", enableAddon: true },
-        stats: { artifacts: 3 },
+        entrypoint: { path: "main.js", bytes: expect.any(Number), sha256: expect.stringMatching(/^[a-f0-9]{64}$/) },
+        stats: { artifacts: 3, entrypoints: 1 },
       });
       expect(receipt.artifacts.map((artifact) => artifact.path)).toEqual([
         "mac/x64/fixture-addon.uxpaddon",
         "mac/arm64/fixture-addon.uxpaddon",
         "win/x64/fixture-addon.uxpaddon",
       ]);
-      expect(verifyUxpHybridAddonReceipt(receipt, { sdkHeaderReceipt: headers })).toEqual({ addonName: "fixture-addon.uxpaddon", artifacts: 3, bytes: receipt.stats.bytes });
+      expect(verifyUxpHybridAddonReceipt(receipt, { sdkHeaderReceipt: headers })).toEqual({
+        addonName: "fixture-addon.uxpaddon",
+        artifacts: 3,
+        addonBytes: receipt.stats.addonBytes,
+        entrypoints: 1,
+        entrypointBytes: receipt.stats.entrypointBytes,
+      });
       expect(canonicalUxpHybridAddonReceiptSha256(receipt)).toMatch(/^[a-f0-9]{64}$/);
       expect(JSON.stringify(receipt)).not.toContain("mac intel fixture");
+      expect(JSON.stringify(receipt)).not.toContain("const addon");
       expect(JSON.stringify(receipt)).not.toContain(bundle);
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("continues to verify schema-v1 receipts without silently assigning them a root entrypoint", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "premiere-hybrid-addon-receipt-v1-"));
+    const bundle = join(directory, "bundle");
+    const headers = sdkHeaderReceipt();
+    try {
+      await mkdir(bundle, { recursive: true });
+      await writeDevelopmentBundle(bundle);
+      const current = await generateUxpHybridAddonReceipt({ pluginRoot: bundle, sdkHeaderReceipt: headers });
+      const legacy = {
+        schemaVersion: 1,
+        source: current.source,
+        manifest: current.manifest,
+        semantics: UXP_HYBRID_ADDON_RECEIPT_LEGACY_SEMANTICS,
+        stats: { artifacts: current.stats.artifacts, bytes: current.stats.addonBytes },
+        artifacts: current.artifacts,
+      };
+      expect(verifyUxpHybridAddonReceipt(legacy, { sdkHeaderReceipt: headers })).toEqual({
+        addonName: "fixture-addon.uxpaddon",
+        artifacts: 3,
+        bytes: legacy.stats.bytes,
+      });
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }
@@ -106,6 +142,10 @@ describe("UXP Hybrid addon receipt", () => {
       await writeDevelopmentBundle(bundle);
       rmSync(join(bundle, "win", "x64", "fixture-addon.uxpaddon"));
       await expect(generateUxpHybridAddonReceipt({ pluginRoot: bundle, sdkHeaderReceipt: headers })).rejects.toThrow("addon artifact win-x64 does not exist");
+
+      await writeDevelopmentBundle(bundle);
+      rmSync(join(bundle, "main.js"));
+      await expect(generateUxpHybridAddonReceipt({ pluginRoot: bundle, sdkHeaderReceipt: headers })).rejects.toThrow("main.js does not exist");
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }
@@ -128,13 +168,17 @@ describe("UXP Hybrid addon receipt", () => {
       wrongPath.artifacts[0].path = "C:bundle/addon.uxpaddon";
       expect(() => verifyUxpHybridAddonReceipt(wrongPath)).toThrow("documented mac-x64 addon path");
 
+      const wrongEntrypoint = clone(receipt);
+      wrongEntrypoint.entrypoint.path = "C:bundle/main.js";
+      expect(() => verifyUxpHybridAddonReceipt(wrongEntrypoint)).toThrow("entrypoint.path must be main.js");
+
       const wrongHeader = clone(headers);
       wrongHeader.source.sdkVersion = "other-sdk";
       expect(() => verifyUxpHybridAddonReceipt(receipt, { sdkHeaderReceipt: wrongHeader })).toThrow("source.sdkVersion must match");
 
       const wrongStats = clone(receipt);
-      wrongStats.stats.bytes += 1;
-      expect(() => verifyUxpHybridAddonReceipt(wrongStats)).toThrow("stats.bytes does not match artifacts");
+      wrongStats.stats.entrypointBytes += 1;
+      expect(() => verifyUxpHybridAddonReceipt(wrongStats)).toThrow("stats.entrypointBytes does not match entrypoint");
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }
@@ -152,17 +196,17 @@ describe("UXP Hybrid addon receipt", () => {
       const args = ["scripts/generate-uxp-hybrid-addon-receipt.mjs", "--plugin-root", bundle, "--sdk-header-receipt", headersPath, "--output", output];
       const generated = spawnSync(process.execPath, args, { encoding: "utf8" });
       expect(generated.status).toBe(0);
-      expect(generated.stdout).toContain("Wrote 3 UXP Hybrid addon artifacts.");
+      expect(generated.stdout).toContain("Wrote 3 UXP Hybrid addon artifacts and 1 entrypoint.");
       expect(generated.stdout).not.toContain(bundle);
       expect(spawnSync(process.execPath, [...args, "--check"], { encoding: "utf8" }).status).toBe(0);
 
       const verified = spawnSync(process.execPath, ["scripts/verify-uxp-hybrid-addon-receipt.mjs", "--input", output, "--sdk-header-receipt", headersPath, "--print-canonical-sha256"], { encoding: "utf8" });
       expect(verified.status).toBe(0);
-      expect(verified.stdout).toContain("UXP Hybrid addon receipt is valid: 3 addon artifacts");
+      expect(verified.stdout).toContain("UXP Hybrid addon receipt is valid: 3 addon artifacts and 1 entrypoint");
       expect(verified.stdout).toContain("Canonical receipt SHA-256:");
       expect(verified.stdout).not.toContain(bundle);
 
-      writeFileSync(join(bundle, "mac", "x64", "fixture-addon.uxpaddon"), "changed");
+      writeFileSync(join(bundle, "main.js"), "changed entrypoint");
       const stale = spawnSync(process.execPath, [...args, "--check"], { encoding: "utf8" });
       expect(stale.status).not.toBe(0);
       expect(stale.stderr).toContain("UXP Hybrid addon receipt is stale");
@@ -172,7 +216,9 @@ describe("UXP Hybrid addon receipt", () => {
       expect(unreadable.status).not.toBe(0);
       expect(unreadable.stderr).toContain("sdkHeaderReceipt must be a readable JSON receipt");
       expect(unreadable.stderr).not.toContain(directory);
-      expect(JSON.parse(readFileSync(output, "utf8")).artifacts).toHaveLength(3);
+      const written = JSON.parse(readFileSync(output, "utf8"));
+      expect(written.artifacts).toHaveLength(3);
+      expect(written.entrypoint).toMatchObject({ path: "main.js" });
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- version the hash-only Hybrid addon-layout receipt to v2 and account for the documented root main.js entrypoint
- preserve schema-v1 verifier compatibility without assigning old receipts an entrypoint
- document and test the content-free boundary; no UXP API, MCP tool, native source, or binary is added

## Validation
- npm run check
- npm run test:coverage
- npm run pack:check

## Boundary
This is local receipt accounting only. It does not parse main.js, prove it requires an addon, compile or inspect a binary, establish architecture or signing/notarization, load through UDT, or validate behavior in a licensed Premiere host.