### PR TITLE
test(native): bind Hybrid benchmarks to local CCX receipts

### DIFF
--- a/benchmarks/uxp-hybrid/evidence.template.json
+++ b/benchmarks/uxp-hybrid/evidence.template.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 2,
+  "schemaVersion": 3,
   "workloadId": "weighted-energy-v1",
   "configuration": {
     "sampleCount": 30,
@@ -10,5 +10,7 @@
   },
   "memoryMeasurement": "Replace with the identical process peak-working-set collection method used on every target",
   "sdkHeaderReceiptSha256": "Replace with the canonical digest printed by native:sdk-header-inventory:verify",
+  "addonReceiptSha256": "Replace with the canonical digest printed by native:hybrid-addon-receipt:verify",
+  "ccxReceiptSha256": "Replace with the canonical digest printed by native:hybrid-ccx-receipt:verify",
   "runs": []
 }

--- a/benchmarks/uxp-hybrid/evidence.v2.schema.json
+++ b/benchmarks/uxp-hybrid/evidence.v2.schema.json
@@ -1,12 +1,12 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://premiere-pro-mcp.com/schemas/uxp-hybrid-benchmark-evidence-v3.json",
-  "title": "Premiere Pro MCP UXP hybrid benchmark evidence v3",
+  "$id": "https://premiere-pro-mcp.com/schemas/uxp-hybrid-benchmark-evidence-v2.json",
+  "title": "Premiere Pro MCP UXP hybrid benchmark evidence v2",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schemaVersion", "workloadId", "configuration", "memoryMeasurement", "sdkHeaderReceiptSha256", "addonReceiptSha256", "ccxReceiptSha256", "runs"],
+  "required": ["schemaVersion", "workloadId", "configuration", "memoryMeasurement", "sdkHeaderReceiptSha256", "runs"],
   "properties": {
-    "schemaVersion": { "const": 3 },
+    "schemaVersion": { "const": 2 },
     "workloadId": { "const": "weighted-energy-v1" },
     "configuration": {
       "type": "object",
@@ -22,8 +22,6 @@
     },
     "memoryMeasurement": { "type": "string", "minLength": 1, "maxLength": 256 },
     "sdkHeaderReceiptSha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
-    "addonReceiptSha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
-    "ccxReceiptSha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
     "runs": {
       "type": "array",
       "minItems": 3,

--- a/docs/premiere-surface-registry.md
+++ b/docs/premiere-surface-registry.md
@@ -31,9 +31,9 @@ its archive hash and relative header hashes without copying access-controlled
 files into this repository. That receipt leaves both C++ surfaces blocked until
 the relevant declaration classification, reproducible native build, and
 licensed-host evidence are supplied. A future Hybrid benchmark must also bind
-its submitted runs to a matching verified receipt, as described by the
-[Hybrid benchmark gate](uxp-hybrid-benchmark.md); the digest binding is not a
-native-build or host-behavior claim. A temporary development bundle can also
+its submitted runs to matching verified SDK, addon-layout, and current local
+CCX receipts, as described by the [Hybrid benchmark gate](uxp-hybrid-benchmark.md);
+the digest binding is not a native-build or host-behavior claim. A temporary development bundle can also
 produce a [Hybrid addon-layout receipt](uxp-hybrid-addon-receipt.md) for the
 public root `main.js` entrypoint and three target paths without disclosing
 source or binaries; it is still not binary architecture, signing, loading, or

--- a/docs/uxp-hybrid-benchmark.md
+++ b/docs/uxp-hybrid-benchmark.md
@@ -68,8 +68,8 @@ diagnostic only and are not accepted as process memory evidence.
 
 ## Promotion criteria
 
-Copy `benchmarks/uxp-hybrid/evidence.template.json` (schema version 2), validate it
-against the adjacent v2 schema, and add one run for each required target: Windows x64,
+Copy `benchmarks/uxp-hybrid/evidence.template.json` (schema version 3), validate it
+against the adjacent v3 schema, and add one run for each required target: Windows x64,
 macOS x64, and macOS arm64. Every run must use the same full source commit, an
 identified SDK version, a Release binary SHA-256, matching output, and stable Premiere
 26.2+.
@@ -81,22 +81,19 @@ repository, and give its local path to the benchmark verifier. The receipt must
 identify `uxp-hybrid`, and its `source.sdkVersion` must exactly match every run's
 `sdkVersion`.
 
-The frozen `evidence.v1.schema.json` and verifier compatibility path remain for
-historical v1 benchmark records. They do not bind a receipt, so new benchmark
-candidates must use v2 rather than changing a published v1 receipt's meaning.
+Before submitting schema-v3 performance evidence, record the candidate
+development bundle with the separate [Hybrid addon-layout receipt](uxp-hybrid-addon-receipt.md),
+then create and verify a [Hybrid CCX archive receipt](uxp-hybrid-ccx-receipt.md).
+The v3 benchmark record commits to all three canonical receipt digests. The
+benchmark verifier re-reads the supplied local `.ccx`, checks its current
+content-free receipt chain, and requires every platform run's `addonSha256` to
+match its corresponding attested binary. It does not publish source, binaries,
+the manifest ID, archive contents, or local paths.
 
-Before submitting performance evidence, record the candidate development
-bundle with the separate [Hybrid addon-layout receipt](uxp-hybrid-addon-receipt.md).
-That verifies the public root `main.js` entrypoint and three-target paths and
-binds them to the Hybrid header receipt without publishing source or binaries.
-It is a preflight accounting artifact, not a compile, signing, UDT-load, or
-host-behavior claim.
-
-When a candidate is later packaged for distribution, use the separate
-[Hybrid CCX archive receipt](uxp-hybrid-ccx-receipt.md) to confirm that the
-local ZIP-format `.ccx` contains byte-identical required files from the current
-addon-layout receipt. That archive check is not evidence that UDT created the
-archive, that Adobe accepts the package, or that it installs or loads.
+The frozen `evidence.v1.schema.json` and `evidence.v2.schema.json` plus their
+verifier paths remain available for historical records. v1 has no receipt
+binding and v2 binds only the SDK header receipt; neither can become a new
+package-bound candidate. New submissions must use v3.
 
 The native implementation must improve both p50 and p95 by at least 30% on every
 target while keeping peak working-set regression at or below 10%. Verify with:
@@ -104,12 +101,17 @@ target while keeping peak working-set regression at or below 10%. Verify with:
 ```powershell
 npm run benchmark:uxp-hybrid:verify -- `
   --input .\path\to\evidence.json `
-  --sdk-header-receipt C:\sdk-evidence\uxp-hybrid-headers.json
+  --sdk-header-receipt C:\sdk-evidence\uxp-hybrid-headers.json `
+  --addon-receipt C:\hybrid-evidence\benchmark-addon-layout.json `
+  --ccx-receipt C:\hybrid-evidence\benchmark-ccx.json `
+  --ccx C:\hybrid-evidence\benchmark-plugin.ccx
 ```
 
 Only a zero exit code and `promotionEligible: true` support a later PR that adds the
 native source, reproducible build files, signed/notarized artifacts, manifest v6, and
-addon permission. This receipt binding verifies only the documented hash-only receipt
-structure and the submitted evidence's SDK identity; it does not verify the private
-archive bytes, establish access entitlement, compile an addon, or prove behavior in a
-licensed Premiere host. This benchmark PR itself is not that promotion.
+addon permission. This receipt binding locally verifies the supplied archive's
+hash-only receipt chain and the submitted evidence's SDK and binary identities;
+it does not establish access entitlement, compile an addon, validate signing or
+notarization, prove UDT or Creative Cloud installation, validate an Adobe portal
+record, or prove behavior in a licensed Premiere host. This benchmark PR itself
+is not that promotion.

--- a/scripts/verify-uxp-hybrid-benchmark.mjs
+++ b/scripts/verify-uxp-hybrid-benchmark.mjs
@@ -4,8 +4,18 @@ import {
   canonicalNativeSdkHeaderInventorySha256,
   verifyNativeSdkHeaderInventory,
 } from "./verify-native-sdk-header-inventory.mjs";
+import {
+  canonicalUxpHybridAddonReceiptSha256,
+  verifyUxpHybridAddonReceipt,
+} from "./verify-uxp-hybrid-addon-receipt.mjs";
+import {
+  buildUxpHybridCcxReceipt,
+  canonicalUxpHybridCcxReceiptSha256,
+  verifyUxpHybridCcxReceipt,
+} from "./uxp-hybrid-ccx-receipt-core.mjs";
 
 export const REQUIRED_TARGETS = ["win-x64", "mac-x64", "mac-arm64"];
+const LOCAL_CCX_ARCHIVE_REQUIRED = "A local CCX archive must be rechecked for schemaVersion 3.";
 
 export function verifyHybridBenchmarkEvidence(document, options = {}) {
   const minimumSpeedupPercent = finiteOption(options.minimumSpeedupPercent, 30, "minimumSpeedupPercent");
@@ -14,17 +24,28 @@ export function verifyHybridBenchmarkEvidence(document, options = {}) {
   if (!document || typeof document !== "object" || Array.isArray(document)) {
     return verdict(errors.concat("Evidence must be a JSON object."), [], minimumSpeedupPercent, maximumMemoryRegressionPercent);
   }
-  const receiptBound = document.schemaVersion === 2;
-  const expectedEvidenceKeys = receiptBound
-    ? ["schemaVersion", "workloadId", "configuration", "memoryMeasurement", "sdkHeaderReceiptSha256", "runs"]
-    : ["schemaVersion", "workloadId", "configuration", "memoryMeasurement", "runs"];
+  const receiptBound = document.schemaVersion === 2 || document.schemaVersion === 3;
+  const packageBound = document.schemaVersion === 3;
+  const expectedEvidenceKeys = packageBound
+    ? ["schemaVersion", "workloadId", "configuration", "memoryMeasurement", "sdkHeaderReceiptSha256", "addonReceiptSha256", "ccxReceiptSha256", "runs"]
+    : receiptBound
+      ? ["schemaVersion", "workloadId", "configuration", "memoryMeasurement", "sdkHeaderReceiptSha256", "runs"]
+      : ["schemaVersion", "workloadId", "configuration", "memoryMeasurement", "runs"];
   if (!sameKeys(document, expectedEvidenceKeys)) {
     errors.push("Evidence must contain only the documented benchmark receipt fields.");
   }
-  if (document.schemaVersion !== 1 && document.schemaVersion !== 2) errors.push("schemaVersion must be 1 or 2.");
+  if (document.schemaVersion !== 1 && document.schemaVersion !== 2 && document.schemaVersion !== 3) {
+    errors.push("schemaVersion must be 1, 2, or 3.");
+  }
   if (document.workloadId !== "weighted-energy-v1") errors.push("workloadId must be weighted-energy-v1.");
   if (receiptBound && !/^[a-f0-9]{64}$/.test(String(document.sdkHeaderReceiptSha256 || ""))) {
     errors.push("sdkHeaderReceiptSha256 must be a canonical SDK header receipt SHA-256 digest.");
+  }
+  if (packageBound && !/^[a-f0-9]{64}$/.test(String(document.addonReceiptSha256 || ""))) {
+    errors.push("addonReceiptSha256 must be a canonical addon-layout receipt SHA-256 digest.");
+  }
+  if (packageBound && !/^[a-f0-9]{64}$/.test(String(document.ccxReceiptSha256 || ""))) {
+    errors.push("ccxReceiptSha256 must be a canonical CCX receipt SHA-256 digest.");
   }
   const expectedConfiguration = { sampleCount: 30, warmupCount: 3, iterations: 4, inputLength: 131072, seed: 1337 };
   if (!sameConfiguration(document.configuration, expectedConfiguration)) {
@@ -83,8 +104,74 @@ export function verifyHybridBenchmarkEvidence(document, options = {}) {
   if (commits.size > 1) errors.push("All runs must measure the same sourceCommit.");
   if (commits.size === 0) errors.push("A shared full sourceCommit is required.");
   if (sdkVersions.size > 1) errors.push("All runs must use the same UXP Hybrid SDK version.");
-  if (receiptBound) validateSdkReceipt(document, options.sdkHeaderReceipt, sdkVersions, errors);
+  if (packageBound) validatePackageReceipts(document, options, sdkVersions, targets, errors);
+  else if (receiptBound) validateSdkReceipt(document, options.sdkHeaderReceipt, sdkVersions, errors);
+  if (packageBound) errors.push(LOCAL_CCX_ARCHIVE_REQUIRED);
   return verdict(errors, Array.from(targets.keys()).sort(), minimumSpeedupPercent, maximumMemoryRegressionPercent, document.schemaVersion);
+}
+
+function validatePackageReceipts(document, options, sdkVersions, targets, errors) {
+  const { sdkHeaderReceipt, addonReceipt, ccxReceipt } = options;
+  if (!sdkHeaderReceipt) errors.push("A verified UXP Hybrid SDK header receipt is required.");
+  if (!addonReceipt) errors.push("A verified current UXP Hybrid addon-layout receipt is required.");
+  if (!ccxReceipt) errors.push("A verified UXP Hybrid CCX receipt is required.");
+  if (!sdkHeaderReceipt || !addonReceipt || !ccxReceipt) return;
+  try {
+    const sdk = verifyNativeSdkHeaderInventory(sdkHeaderReceipt);
+    if (sdk.sdk !== "uxp-hybrid") errors.push("SDK header receipt must identify uxp-hybrid.");
+    if (sdkVersions.size === 1 && sdkHeaderReceipt.source.sdkVersion !== Array.from(sdkVersions)[0]) {
+      errors.push("SDK header receipt sdkVersion must match all benchmark runs.");
+    }
+    if (document.sdkHeaderReceiptSha256 !== canonicalNativeSdkHeaderInventorySha256(sdkHeaderReceipt)) {
+      errors.push("sdkHeaderReceiptSha256 does not match the verified SDK header receipt.");
+    }
+
+    verifyUxpHybridAddonReceipt(addonReceipt, { sdkHeaderReceipt });
+    if (document.addonReceiptSha256 !== canonicalUxpHybridAddonReceiptSha256(addonReceipt)) {
+      errors.push("addonReceiptSha256 does not match the verified addon-layout receipt.");
+    }
+
+    verifyUxpHybridCcxReceipt(ccxReceipt, { addonReceipt, sdkHeaderReceipt });
+    if (document.ccxReceiptSha256 !== canonicalUxpHybridCcxReceiptSha256(ccxReceipt)) {
+      errors.push("ccxReceiptSha256 does not match the verified CCX receipt.");
+    }
+
+    for (const [target, run] of targets) {
+      const artifact = addonReceipt.artifacts.find((entry) => entry.target === target);
+      if (!artifact || run.addonSha256 !== artifact.sha256) {
+        errors.push(`runs for ${target} must match the corresponding addon-layout artifact SHA-256.`);
+      }
+    }
+  } catch (error) {
+    errors.push(`Hybrid package receipt is invalid: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+export async function verifyHybridBenchmarkEvidenceWithLocalCcx(document, options = {}) {
+  const result = verifyHybridBenchmarkEvidence(document, options);
+  if (document?.schemaVersion !== 3) return result;
+  const structuralErrors = result.errors.filter((error) => error !== LOCAL_CCX_ARCHIVE_REQUIRED);
+  if (structuralErrors.length > 0) return result;
+  if (typeof options.ccxPath !== "string" || !options.ccxPath.trim() || options.ccxPath.includes("\0")) {
+    return ineligible({ ...result, errors: structuralErrors }, "A local CCX archive path is required for schemaVersion 3.");
+  }
+  try {
+    const current = await buildUxpHybridCcxReceipt({
+      ccxPath: options.ccxPath,
+      addonReceipt: options.addonReceipt,
+      sdkHeaderReceipt: options.sdkHeaderReceipt,
+    });
+    if (canonicalUxpHybridCcxReceiptSha256(current) !== canonicalUxpHybridCcxReceiptSha256(options.ccxReceipt)) {
+      return ineligible({ ...result, errors: structuralErrors }, "CCX receipt does not match the supplied local archive.");
+    }
+    return { ...result, promotionEligible: true, errors: structuralErrors };
+  } catch (error) {
+    return ineligible({ ...result, errors: structuralErrors }, `CCX archive is invalid: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+function ineligible(result, error) {
+  return { ...result, promotionEligible: false, errors: [...result.errors, error] };
 }
 
 function validateSdkReceipt(document, receipt, sdkVersions, errors) {
@@ -160,23 +247,37 @@ function finiteOption(value, fallback, name) {
 }
 
 function verdict(errors, targets, minimumSpeedupPercent, maximumMemoryRegressionPercent, schemaVersion) {
+  const verificationBoundary = schemaVersion === 3
+    ? "submitted_cross_platform_release_build_and_verified_sdk_addon_ccx_receipt_evidence"
+    : schemaVersion === 2
+      ? "submitted_cross_platform_release_build_and_verified_sdk_receipt_evidence"
+      : "submitted_cross_platform_release_build_evidence";
   return {
     promotionEligible: errors.length === 0,
     errors,
     targets,
     thresholds: { minimumSpeedupPercent, maximumMemoryRegressionPercent },
-    verificationBoundary: schemaVersion === 2
-      ? "submitted_cross_platform_release_build_and_verified_sdk_receipt_evidence"
-      : "submitted_cross_platform_release_build_evidence"
+    verificationBoundary,
   };
 }
 
 function parseArguments(argv) {
-  const result = { input: null, sdkHeaderReceipt: null, minimumSpeedupPercent: 30, maximumMemoryRegressionPercent: 10 };
+  const result = {
+    input: null,
+    sdkHeaderReceipt: null,
+    addonReceipt: null,
+    ccxReceipt: null,
+    ccxPath: null,
+    minimumSpeedupPercent: 30,
+    maximumMemoryRegressionPercent: 10,
+  };
   for (let index = 0; index < argv.length; index += 1) {
     const value = argv[index];
     if (value === "--input") result.input = argv[++index];
     else if (value === "--sdk-header-receipt") result.sdkHeaderReceipt = argv[++index];
+    else if (value === "--addon-receipt") result.addonReceipt = argv[++index];
+    else if (value === "--ccx-receipt") result.ccxReceipt = argv[++index];
+    else if (value === "--ccx") result.ccxPath = argv[++index];
     else if (value === "--min-speedup-percent") result.minimumSpeedupPercent = Number(argv[++index]);
     else if (value === "--max-memory-regression-percent") result.maximumMemoryRegressionPercent = Number(argv[++index]);
     else throw new Error(`Unknown argument: ${value}`);
@@ -187,11 +288,18 @@ function parseArguments(argv) {
 
 async function main() {
   const args = parseArguments(process.argv.slice(2));
-  const document = await readEvidenceJson(args.input, "benchmark evidence");
-  const sdkHeaderReceipt = args.sdkHeaderReceipt
-    ? await readEvidenceJson(args.sdkHeaderReceipt, "SDK header receipt")
-    : undefined;
-  const result = verifyHybridBenchmarkEvidence(document, { ...args, sdkHeaderReceipt });
+  const [document, sdkHeaderReceipt, addonReceipt, ccxReceipt] = await Promise.all([
+    readEvidenceJson(args.input, "benchmark evidence"),
+    args.sdkHeaderReceipt ? readEvidenceJson(args.sdkHeaderReceipt, "SDK header receipt") : undefined,
+    args.addonReceipt ? readEvidenceJson(args.addonReceipt, "addon-layout receipt") : undefined,
+    args.ccxReceipt ? readEvidenceJson(args.ccxReceipt, "CCX receipt") : undefined,
+  ]);
+  const result = await verifyHybridBenchmarkEvidenceWithLocalCcx(document, {
+    ...args,
+    sdkHeaderReceipt,
+    addonReceipt,
+    ccxReceipt,
+  });
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
   if (!result.promotionEligible) process.exitCode = 1;
 }

--- a/src/resources/premiere-surface-registry.json
+++ b/src/resources/premiere-surface-registry.json
@@ -75,13 +75,14 @@
       "inventoryVerificationCommand": "npm run native:sdk-header-inventory:verify",
       "inventoryDocumentation": "docs/native-sdk-header-inventory.md",
       "benchmarkEvidenceCommand": "npm run benchmark:uxp-hybrid:verify",
+      "benchmarkEvidenceSchema": "benchmarks/uxp-hybrid/evidence.schema.json",
       "addonReceiptCommand": "npm run native:hybrid-addon-receipt",
       "addonReceiptVerificationCommand": "npm run native:hybrid-addon-receipt:verify",
       "addonReceiptDocumentation": "docs/uxp-hybrid-addon-receipt.md",
       "ccxReceiptCommand": "npm run native:hybrid-ccx-receipt",
       "ccxReceiptVerificationCommand": "npm run native:hybrid-ccx-receipt:verify",
       "ccxReceiptDocumentation": "docs/uxp-hybrid-ccx-receipt.md",
-      "notes": "The downloadable SDK headers are access-controlled. The header receipt and standalone verifier can account for an authorized artifact without copying it; a local addon-layout receipt can additionally account for the public root main.js entrypoint and three-target bundle layout without copying source or binaries. A local CCX archive receipt can bind that current layout receipt to the byte-identical required files in a local ZIP-format installer, without copying archive contents. A candidate benchmark must bind its runs to a matching verified SDK receipt, and remains disabled until exact SDK, reproducible builds, and cross-platform evidence are available."
+      "notes": "The downloadable SDK headers are access-controlled. The header receipt and standalone verifier can account for an authorized artifact without copying it; a local addon-layout receipt can additionally account for the public root main.js entrypoint and three-target bundle layout without copying source or binaries. A local CCX archive receipt can bind that current layout receipt to the byte-identical required files in a local ZIP-format installer, without copying archive contents. A schema-v3 candidate benchmark must bind its runs to matching verified SDK, addon-layout, and current local CCX receipts, but remains disabled until exact SDK, reproducible builds, signing/notarization, and cross-platform evidence are available."
     },
     {
       "id": "premiere-cpp-sdk",

--- a/tests/hybrid-benchmark-evidence.test.ts
+++ b/tests/hybrid-benchmark-evidence.test.ts
@@ -6,12 +6,30 @@ import { describe, expect, it } from "vitest";
 import {
   REQUIRED_TARGETS,
   verifyHybridBenchmarkEvidence,
+  verifyHybridBenchmarkEvidenceWithLocalCcx,
 } from "../scripts/verify-uxp-hybrid-benchmark.mjs";
 import { NATIVE_SDK_HEADER_INVENTORY_SEMANTICS } from "../scripts/native-sdk-header-inventory-contract.mjs";
 import { canonicalNativeSdkHeaderInventorySha256 } from "../scripts/verify-native-sdk-header-inventory.mjs";
+import {
+  UXP_HYBRID_ADDON_RECEIPT_SEMANTICS,
+} from "../scripts/uxp-hybrid-addon-receipt-contract.mjs";
+import {
+  canonicalUxpHybridAddonReceiptSha256,
+} from "../scripts/verify-uxp-hybrid-addon-receipt.mjs";
+import {
+  UXP_HYBRID_CCX_RECEIPT_SEMANTICS,
+} from "../scripts/uxp-hybrid-ccx-receipt-contract.mjs";
+import {
+  canonicalUxpHybridCcxReceiptSha256,
+} from "../scripts/uxp-hybrid-ccx-receipt-core.mjs";
 
 const SHA = "a".repeat(40);
 const ADDON_SHA = "b".repeat(64);
+const ADDON_SHA_BY_TARGET = Object.freeze({
+  "mac-x64": "b".repeat(64),
+  "mac-arm64": "c".repeat(64),
+  "win-x64": "d".repeat(64),
+});
 
 function sdkHeaderReceipt(sdkVersion = "UXP Hybrid SDK test fixture") {
   return {
@@ -86,16 +104,101 @@ function legacyEvidence() {
   return { ...v1, schemaVersion: 1 };
 }
 
+function addonReceipt(headerReceipt = sdkHeaderReceipt()) {
+  return {
+    schemaVersion: 2,
+    source: {
+      sdk: "uxp-hybrid",
+      sdkVersion: headerReceipt.source.sdkVersion,
+      sdkHeaderReceiptSha256: canonicalNativeSdkHeaderInventorySha256(headerReceipt),
+      authorityUrl: "https://developer.adobe.com/premiere-pro/uxp/plugins/hybrid-plugins/build",
+    },
+    manifest: {
+      manifestVersion: 6,
+      hostApp: "premierepro",
+      hostMinVersion: "26.2.0",
+      addonName: "fixture-addon.uxpaddon",
+      enableAddon: true,
+    },
+    entrypoint: { path: "main.js", bytes: 3, sha256: "e".repeat(64) },
+    semantics: UXP_HYBRID_ADDON_RECEIPT_SEMANTICS,
+    stats: { artifacts: 3, addonBytes: 12, entrypoints: 1, entrypointBytes: 3 },
+    artifacts: [
+      { target: "mac-x64", path: "mac/x64/fixture-addon.uxpaddon", bytes: 3, sha256: ADDON_SHA_BY_TARGET["mac-x64"] },
+      { target: "mac-arm64", path: "mac/arm64/fixture-addon.uxpaddon", bytes: 4, sha256: ADDON_SHA_BY_TARGET["mac-arm64"] },
+      { target: "win-x64", path: "win/x64/fixture-addon.uxpaddon", bytes: 5, sha256: ADDON_SHA_BY_TARGET["win-x64"] },
+    ],
+  };
+}
+
+function ccxReceipt(headerReceipt = sdkHeaderReceipt(), addon = addonReceipt(headerReceipt)) {
+  return {
+    schemaVersion: 1,
+    source: {
+      sdk: "uxp-hybrid",
+      sdkVersion: headerReceipt.source.sdkVersion,
+      sdkHeaderReceiptSha256: canonicalNativeSdkHeaderInventorySha256(headerReceipt),
+      addonReceiptSha256: canonicalUxpHybridAddonReceiptSha256(addon),
+      authorityUrl: "https://developer.adobe.com/premiere-pro/uxp/plugins/distribution/package/",
+    },
+    archive: { format: "zip", bytes: 64, sha256: "f".repeat(64) },
+    manifest: {
+      bytes: 32,
+      sha256: "1".repeat(64),
+      idSha256: "2".repeat(64),
+      idLength: 7,
+      manifestVersion: 6,
+      hostApp: "premierepro",
+      hostMinVersion: "26.2.0",
+      addonName: "fixture-addon.uxpaddon",
+      enableAddon: true,
+    },
+    semantics: UXP_HYBRID_CCX_RECEIPT_SEMANTICS,
+    stats: { artifacts: 3, addonBytes: 12, entrypoints: 1, entrypointBytes: 3 },
+  };
+}
+
+function packageEvidence(headerReceipt = sdkHeaderReceipt(), addon = addonReceipt(headerReceipt), ccx = ccxReceipt(headerReceipt, addon)) {
+  return {
+    ...evidence(headerReceipt),
+    schemaVersion: 3,
+    addonReceiptSha256: canonicalUxpHybridAddonReceiptSha256(addon),
+    ccxReceiptSha256: canonicalUxpHybridCcxReceiptSha256(ccx),
+    runs: REQUIRED_TARGETS.map((target) => {
+      const [platform, arch] = target.split("-");
+      return {
+        platform,
+        arch,
+        hostVersion: "26.3.0",
+        sdkVersion: headerReceipt.source.sdkVersion,
+        buildMode: "Release",
+        addonLoaded: true,
+        addonSha256: ADDON_SHA_BY_TARGET[target],
+        sourceCommit: SHA,
+        checksumMatch: true,
+        codeSigned: platform === "mac",
+        notarized: platform === "mac",
+        javascript: { sampleCount: 30, p50Ms: 100, p95Ms: 140, peakWorkingSetBytes: 1000 },
+        native: { sampleCount: 30, p50Ms: 60, p95Ms: 80, peakWorkingSetBytes: 1050 },
+      };
+    }),
+  };
+}
+
 describe("UXP hybrid benchmark evidence verifier", () => {
-  it("keeps the frozen v1 schema and verifier path available while making receipt binding v2", () => {
+  it("keeps frozen v1/v2 schemas and verifier paths available while making package binding v3", () => {
     const v1Schema = JSON.parse(readFileSync("benchmarks/uxp-hybrid/evidence.v1.schema.json", "utf8"));
-    const v2Schema = JSON.parse(readFileSync("benchmarks/uxp-hybrid/evidence.schema.json", "utf8"));
+    const v2Schema = JSON.parse(readFileSync("benchmarks/uxp-hybrid/evidence.v2.schema.json", "utf8"));
+    const v3Schema = JSON.parse(readFileSync("benchmarks/uxp-hybrid/evidence.schema.json", "utf8"));
     expect(v1Schema.$id).toBe("https://premiere-pro-mcp.com/schemas/uxp-hybrid-benchmark-evidence-v1.json");
     expect(v1Schema.properties.schemaVersion.const).toBe(1);
     expect(v1Schema.required).not.toContain("sdkHeaderReceiptSha256");
     expect(v2Schema.$id).toBe("https://premiere-pro-mcp.com/schemas/uxp-hybrid-benchmark-evidence-v2.json");
     expect(v2Schema.properties.schemaVersion.const).toBe(2);
     expect(v2Schema.required).toContain("sdkHeaderReceiptSha256");
+    expect(v3Schema.$id).toBe("https://premiere-pro-mcp.com/schemas/uxp-hybrid-benchmark-evidence-v3.json");
+    expect(v3Schema.properties.schemaVersion.const).toBe(3);
+    expect(v3Schema.required).toEqual(expect.arrayContaining(["sdkHeaderReceiptSha256", "addonReceiptSha256", "ccxReceiptSha256"]));
     expect(verifyHybridBenchmarkEvidence(legacyEvidence())).toEqual({
       promotionEligible: true,
       errors: [],
@@ -169,6 +272,42 @@ describe("UXP hybrid benchmark evidence verifier", () => {
     };
     expect(verifyHybridBenchmarkEvidence(withExtraMetricField, { sdkHeaderReceipt: receipt }).errors)
       .toContain("runs[0].native must contain only the documented metric fields.");
+  });
+
+  it("binds each target run to a verified current addon-layout and CCX receipt chain", async () => {
+    const headerReceipt = sdkHeaderReceipt();
+    const addon = addonReceipt(headerReceipt);
+    const ccx = ccxReceipt(headerReceipt, addon);
+    const value = packageEvidence(headerReceipt, addon, ccx);
+    expect(verifyHybridBenchmarkEvidence(value, {
+      sdkHeaderReceipt: headerReceipt,
+      addonReceipt: addon,
+      ccxReceipt: ccx,
+    })).toEqual({
+      promotionEligible: false,
+      errors: ["A local CCX archive must be rechecked for schemaVersion 3."],
+      targets: ["mac-arm64", "mac-x64", "win-x64"],
+      thresholds: { minimumSpeedupPercent: 30, maximumMemoryRegressionPercent: 10 },
+      verificationBoundary: "submitted_cross_platform_release_build_and_verified_sdk_addon_ccx_receipt_evidence",
+    });
+
+    const mismatchedArtifact = packageEvidence(headerReceipt, addon, ccx);
+    mismatchedArtifact.runs[0].addonSha256 = "0".repeat(64);
+    expect(verifyHybridBenchmarkEvidence(mismatchedArtifact, {
+      sdkHeaderReceipt: headerReceipt,
+      addonReceipt: addon,
+      ccxReceipt: ccx,
+    }).errors).toContain("runs for win-x64 must match the corresponding addon-layout artifact SHA-256.");
+
+    const withoutArchive = await verifyHybridBenchmarkEvidenceWithLocalCcx(value, {
+      sdkHeaderReceipt: headerReceipt,
+      addonReceipt: addon,
+      ccxReceipt: ccx,
+    });
+    expect(withoutArchive).toMatchObject({
+      promotionEligible: false,
+      errors: ["A local CCX archive path is required for schemaVersion 3."],
+    });
   });
 
   it("requires a local receipt path for v2 without printing it while retaining v1 CLI compatibility", () => {

--- a/tests/premiere-surface-registry.test.ts
+++ b/tests/premiere-surface-registry.test.ts
@@ -14,6 +14,7 @@ type Surface = {
   inventoryVerificationCommand?: string;
   inventoryDocumentation?: string;
   benchmarkEvidenceCommand?: string;
+  benchmarkEvidenceSchema?: string;
   addonReceiptCommand?: string;
   addonReceiptVerificationCommand?: string;
   addonReceiptDocumentation?: string;
@@ -124,6 +125,7 @@ describe("Premiere API and competitor surface registry", () => {
     expect(registry.integrationSurfaces.find((surface) => surface.id === "uxp-hybrid-cpp"))
       .toMatchObject({
         benchmarkEvidenceCommand: "npm run benchmark:uxp-hybrid:verify",
+        benchmarkEvidenceSchema: "benchmarks/uxp-hybrid/evidence.schema.json",
         addonReceiptCommand: "npm run native:hybrid-addon-receipt",
         addonReceiptVerificationCommand: "npm run native:hybrid-addon-receipt:verify",
         addonReceiptDocumentation: "docs/uxp-hybrid-addon-receipt.md",
@@ -135,6 +137,8 @@ describe("Premiere API and competitor surface registry", () => {
       .toContain("root main.js entrypoint and three-target bundle layout");
     expect(registry.integrationSurfaces.find((surface) => surface.id === "uxp-hybrid-cpp")?.notes)
       .toContain("CCX archive receipt can bind that current layout receipt");
+    expect(registry.integrationSurfaces.find((surface) => surface.id === "uxp-hybrid-cpp")?.notes)
+      .toContain("schema-v3 candidate benchmark");
   });
 
   it("pins reviewed competitor sources and explicit safe-adoption boundaries", () => {

--- a/tests/uxp-hybrid-ccx-receipt.test.ts
+++ b/tests/uxp-hybrid-ccx-receipt.test.ts
@@ -12,6 +12,9 @@ import {
   verifyUxpHybridCcxReceipt,
 } from "../scripts/uxp-hybrid-ccx-receipt-core.mjs";
 import { generateUxpHybridAddonReceipt } from "../scripts/generate-uxp-hybrid-addon-receipt.mjs";
+import { canonicalUxpHybridAddonReceiptSha256 } from "../scripts/verify-uxp-hybrid-addon-receipt.mjs";
+import { canonicalNativeSdkHeaderInventorySha256 } from "../scripts/verify-native-sdk-header-inventory.mjs";
+import { verifyHybridBenchmarkEvidenceWithLocalCcx } from "../scripts/verify-uxp-hybrid-benchmark.mjs";
 
 const hash = (value: string) => value.repeat(64);
 
@@ -157,6 +160,60 @@ describe("UXP Hybrid CCX receipt", () => {
       expect(JSON.stringify(receipt)).not.toContain("const addon");
       expect(JSON.stringify(receipt)).not.toContain("mac intel fixture");
       expect(JSON.stringify(receipt)).not.toContain(directory);
+
+      const benchmarkEvidence = {
+        schemaVersion: 3,
+        workloadId: "weighted-energy-v1",
+        configuration: { sampleCount: 30, warmupCount: 3, iterations: 4, inputLength: 131072, seed: 1337 },
+        memoryMeasurement: "fixture process monitor",
+        sdkHeaderReceiptSha256: canonicalNativeSdkHeaderInventorySha256(headers),
+        addonReceiptSha256: canonicalUxpHybridAddonReceiptSha256(addonReceipt),
+        ccxReceiptSha256: canonicalUxpHybridCcxReceiptSha256(receipt),
+        runs: addonReceipt.artifacts.map((artifact) => {
+          const [platform, arch] = artifact.target.split("-");
+          return {
+            platform,
+            arch,
+            hostVersion: "26.3.0",
+            sdkVersion: "fixture-sdk",
+            buildMode: "Release",
+            addonLoaded: true,
+            addonSha256: artifact.sha256,
+            sourceCommit: "a".repeat(40),
+            checksumMatch: true,
+            codeSigned: platform === "mac",
+            notarized: platform === "mac",
+            javascript: { sampleCount: 30, p50Ms: 100, p95Ms: 140, peakWorkingSetBytes: 1000 },
+            native: { sampleCount: 30, p50Ms: 60, p95Ms: 80, peakWorkingSetBytes: 1050 },
+          };
+        }),
+      };
+      await expect(verifyHybridBenchmarkEvidenceWithLocalCcx(benchmarkEvidence, {
+        ccxPath: archive,
+        addonReceipt,
+        sdkHeaderReceipt: headers,
+        ccxReceipt: receipt,
+      })).resolves.toMatchObject({ promotionEligible: true, errors: [] });
+
+      const evidencePath = join(directory, "benchmark-evidence.json");
+      const headersPath = join(directory, "headers.json");
+      const addonPath = join(directory, "addon-receipt.json");
+      const ccxReceiptPath = join(directory, "ccx-receipt.json");
+      writeFileSync(evidencePath, `${JSON.stringify(benchmarkEvidence, null, 2)}\n`);
+      writeFileSync(headersPath, `${JSON.stringify(headers, null, 2)}\n`);
+      writeFileSync(addonPath, `${JSON.stringify(addonReceipt, null, 2)}\n`);
+      writeFileSync(ccxReceiptPath, `${JSON.stringify(receipt, null, 2)}\n`);
+      const benchmarkVerified = spawnSync(process.execPath, [
+        "scripts/verify-uxp-hybrid-benchmark.mjs",
+        "--input", evidencePath,
+        "--sdk-header-receipt", headersPath,
+        "--addon-receipt", addonPath,
+        "--ccx-receipt", ccxReceiptPath,
+        "--ccx", archive,
+      ], { encoding: "utf8" });
+      expect(benchmarkVerified.status).toBe(0);
+      expect(benchmarkVerified.stdout).toContain('"promotionEligible": true');
+      expect(benchmarkVerified.stdout).not.toContain(directory);
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- add schema-v3 Hybrid benchmark evidence while preserving frozen v1/v2 schemas and verifier compatibility
- require a hash-only SDK header, schema-v2 addon-layout, and CCX receipt chain; the CLI rechecks a supplied local CCX and binds each platform run SHA to its attested artifact
- document/register the bounded proof and add structural, local-archive, CLI, and regression coverage

## Validation
- npm run check
- npm run test:coverage
- npm run pack:check

## Boundary
This is fail-closed local accounting only. It does not add a native addon or claim SDK entitlement, compilation, signing/notarization validity, UDT/Creative Cloud installation, Adobe portal acceptance, MCP exposure, or licensed-host behavior.