### PR TITLE
feat(native): harden CCX receipt archive accounting

### DIFF
--- a/docs/premiere-surface-registry.md
+++ b/docs/premiere-surface-registry.md
@@ -38,9 +38,10 @@ produce a [Hybrid addon-layout receipt](uxp-hybrid-addon-receipt.md) for the
 public root `main.js` entrypoint and three target paths without disclosing
 source or binaries; it is still not binary architecture, signing, loading, or
 runtime proof. A subsequent [Hybrid CCX archive receipt](uxp-hybrid-ccx-receipt.md)
-can bind those public layout facts to the matching files in a local `.ccx` ZIP
-without disclosing archive contents. It is not UDT, portal, installation, or
-host-runtime proof.
+can bind those public layout facts to the matching files and a content-free safe
+ZIP entry-name-set digest in a local `.ccx` ZIP without disclosing archive
+contents or entry names. It is not UDT, portal, installation, or host-runtime
+proof.
 
 The same registry pins the exact competitor commits reviewed for feature-gap
 work. A competitor feature family becomes an implementation candidate only

--- a/docs/uxp-hybrid-benchmark.md
+++ b/docs/uxp-hybrid-benchmark.md
@@ -86,9 +86,10 @@ development bundle with the separate [Hybrid addon-layout receipt](uxp-hybrid-ad
 then create and verify a [Hybrid CCX archive receipt](uxp-hybrid-ccx-receipt.md).
 The v3 benchmark record commits to all three canonical receipt digests. The
 benchmark verifier re-reads the supplied local `.ccx`, checks its current
-content-free receipt chain, and requires every platform run's `addonSha256` to
-match its corresponding attested binary. It does not publish source, binaries,
-the manifest ID, archive contents, or local paths.
+content-free receipt chain including schema-v2 whole-archive ZIP hygiene, and
+requires every platform run's `addonSha256` to match its corresponding attested
+binary. It does not publish source, binaries, the manifest ID, archive contents,
+entry names, or local paths.
 
 The frozen `evidence.v1.schema.json` and `evidence.v2.schema.json` plus their
 verifier paths remain available for historical records. v1 has no receipt

--- a/docs/uxp-hybrid-ccx-receipt.md
+++ b/docs/uxp-hybrid-ccx-receipt.md
@@ -20,11 +20,14 @@ mac/arm64/<addon name>.uxpaddon
 win/x64/<addon name>.uxpaddon
 ```
 
-The resulting receipt records only the CCX byte count and SHA-256, a SHA-256
-commitment and length for the manifest's nonempty `id`, minimal manifest facts,
-the canonical addon-layout receipt digest, and aggregate file totals. It does
-not copy the archive, manifest, ID, entrypoint, binaries, SDK headers, absolute
-paths, or signing material.
+The current schema-v2 receipt records only the CCX byte count and SHA-256, a
+SHA-256 commitment and length for the manifest's nonempty `id`, minimal
+manifest facts, the canonical addon-layout receipt digest, aggregate ZIP
+entry/file/directory totals, and a one-way digest of the complete safe
+entry-name set. It does not copy the archive, entry names, manifest, ID,
+entrypoint, binaries, SDK headers, absolute paths, or signing material. The
+standalone verifier retains schema-v1 receipt compatibility for historical
+records; new receipts use schema v2.
 
 ```powershell
 npm run native:hybrid-ccx-receipt -- `
@@ -36,9 +39,10 @@ npm run native:hybrid-ccx-receipt -- `
 
 Use `--validate-only` to examine a local archive without writing a receipt, or
 `--check` to compare a regenerated receipt to a reviewed local file. The
-standalone verifier re-reads the archive and fails if its required files, ZIP
-identity, manifest facts, header provenance, or addon-layout receipt binding
-changed:
+standalone verifier re-reads the archive and fails if any ZIP entry is unsafe,
+duplicated, encrypted, or uses unsupported compression, or if its required
+files, ZIP identity, manifest facts, header provenance, addon-layout receipt
+binding, or complete entry-name-set digest changed:
 
 ```powershell
 npm run native:hybrid-ccx-receipt:verify -- `

--- a/scripts/read-zip-archive.mjs
+++ b/scripts/read-zip-archive.mjs
@@ -71,13 +71,46 @@ function readCentralDirectory(buffer, expectedEntries) {
     const localOffset = buffer.readUInt32LE(offset + 42);
     const next = offset + 46 + nameBytes + extraBytes + commentBytes;
     if (next > buffer.length || disk !== 0) throw archiveError("CCX archive central directory entry is invalid");
-    const name = buffer.subarray(offset + 46, offset + 46 + nameBytes).toString("utf8");
-    if (!name || name.includes("\0")) throw archiveError("CCX archive contains an invalid ZIP entry name");
+    const rawName = buffer.subarray(offset + 46, offset + 46 + nameBytes);
+    const name = rawName.toString("utf8");
+    if (!name || !rawName.equals(Buffer.from(name, "utf8"))) {
+      throw archiveError("CCX archive contains an invalid ZIP entry name");
+    }
     entries.push(Object.freeze({ name, flags, method, compressedBytes, uncompressedBytes, localOffset }));
     offset = next;
   }
   if (entries.length !== expectedEntries) throw archiveError("CCX archive central directory count is inconsistent");
   return entries;
+}
+
+function validateArchiveEntries(entries) {
+  const names = new Set();
+  let directories = 0;
+  for (const entry of entries) {
+    if (entry.flags & 0x1 || entry.flags & 0x40) throw archiveError("CCX archive entries must not be encrypted");
+    if (entry.method !== 0 && entry.method !== 8) {
+      throw archiveError("CCX archive entries must use stored or deflate compression");
+    }
+    const { name } = entry;
+    if (name.length > 1024 || /[\0-\x1f\x7f]/.test(name) || name.includes("\\") || name.startsWith("/") || /^[A-Za-z]:/.test(name)) {
+      throw archiveError("CCX archive contains an unsafe ZIP entry name");
+    }
+    const isDirectory = name.endsWith("/");
+    const segments = name.split("/");
+    if (isDirectory) segments.pop();
+    if (segments.length === 0 || segments.some((segment) => !segment || segment === "." || segment === ".." || /^[A-Za-z]:$/.test(segment))) {
+      throw archiveError("CCX archive contains an unsafe ZIP entry name");
+    }
+    if (names.has(name)) throw archiveError("CCX archive contains duplicate ZIP entry names");
+    names.add(name);
+    if (isDirectory) directories += 1;
+  }
+  return Object.freeze({
+    entries: entries.length,
+    files: entries.length - directories,
+    directories,
+    pathSetSha256: createHash("sha256").update(JSON.stringify(Array.from(names).sort())).digest("hex"),
+  });
 }
 
 function pathPrefix(name, expectedPath) {
@@ -162,7 +195,12 @@ export async function inspectZipArchive(archivePath, expectedPaths) {
     const tail = await readExactly(handle, tailBytes, archive.size - tailBytes, "CCX archive end record");
     const end = findEndOfCentralDirectory(tail, archive.size);
     const directory = await readExactly(handle, end.directoryBytes, end.directoryOffset, "CCX archive central directory");
-    return Object.freeze({ bytes: archive.size, selected: selectRequiredEntries(readCentralDirectory(directory, end.entries), expectedPaths) });
+    const entries = readCentralDirectory(directory, end.entries);
+    return Object.freeze({
+      bytes: archive.size,
+      summary: validateArchiveEntries(entries),
+      selected: selectRequiredEntries(entries, expectedPaths),
+    });
   } finally {
     await handle.close();
   }

--- a/scripts/uxp-hybrid-ccx-receipt-contract.mjs
+++ b/scripts/uxp-hybrid-ccx-receipt-contract.mjs
@@ -1,9 +1,15 @@
-export const UXP_HYBRID_CCX_RECEIPT_SCHEMA_VERSION = 1;
+export const UXP_HYBRID_CCX_RECEIPT_LEGACY_SCHEMA_VERSION = 1;
+export const UXP_HYBRID_CCX_RECEIPT_SCHEMA_VERSION = 2;
 export const UXP_HYBRID_CCX_AUTHORITY_URL = "https://developer.adobe.com/premiere-pro/uxp/plugins/distribution/package/";
 
 export const UXP_HYBRID_CCX_RECEIPT_SEMANTICS = Object.freeze({
-  listed: "This receipt records the SHA-256 identity of a locally supplied CCX ZIP archive and confirms that its manifest facts, root main.js entrypoint, and required UXP Hybrid addon artifacts exactly match a supplied schema-v2 addon-layout receipt. It does not copy archive, manifest, entrypoint, or binary contents into the receipt.",
+  listed: "This receipt records the SHA-256 identity of a locally supplied CCX ZIP archive, a one-way digest of its complete safe ZIP entry-name set, and confirms that its manifest facts, root main.js entrypoint, and required UXP Hybrid addon artifacts exactly match a supplied schema-v2 addon-layout receipt. It does not copy archive, entry names, manifest, entrypoint, or binary contents into the receipt.",
   doesNotEstablish: "This receipt does not establish that UXP Developer Tool created the archive, that a manifest ID matches an Adobe Developer Distribution portal record, SDK compilation, binary architecture, code-signing or notarization validity, installation, UDT loading, MCP exposure, or licensed-host behavior.",
+});
+
+export const UXP_HYBRID_CCX_RECEIPT_LEGACY_SEMANTICS = Object.freeze({
+  listed: "This receipt records the SHA-256 identity of a locally supplied CCX ZIP archive and confirms that its manifest facts, root main.js entrypoint, and required UXP Hybrid addon artifacts exactly match a supplied schema-v2 addon-layout receipt. It does not copy archive, manifest, entrypoint, or binary contents into the receipt.",
+  doesNotEstablish: UXP_HYBRID_CCX_RECEIPT_SEMANTICS.doesNotEstablish,
 });
 
 export function compareUxpHybridCcxPaths(left, right) {

--- a/scripts/uxp-hybrid-ccx-receipt-core.mjs
+++ b/scripts/uxp-hybrid-ccx-receipt-core.mjs
@@ -13,6 +13,8 @@ import {
 } from "./uxp-hybrid-addon-receipt-contract.mjs";
 import {
   UXP_HYBRID_CCX_AUTHORITY_URL,
+  UXP_HYBRID_CCX_RECEIPT_LEGACY_SCHEMA_VERSION,
+  UXP_HYBRID_CCX_RECEIPT_LEGACY_SEMANTICS,
   UXP_HYBRID_CCX_RECEIPT_SCHEMA_VERSION,
   UXP_HYBRID_CCX_RECEIPT_SEMANTICS,
   compareUxpHybridCcxPaths,
@@ -66,6 +68,13 @@ function sha256(value, label) {
 function positiveInteger(value, label, maximum) {
   if (!Number.isSafeInteger(value) || value <= 0 || value > maximum) {
     throw receiptError(`${label} must be a positive safe integer no larger than ${maximum}`);
+  }
+  return value;
+}
+
+function nonNegativeInteger(value, label, maximum) {
+  if (!Number.isSafeInteger(value) || value < 0 || value > maximum) {
+    throw receiptError(`${label} must be a non-negative safe integer no larger than ${maximum}`);
   }
   return value;
 }
@@ -178,10 +187,23 @@ function verifyArchiveReceiptAgainstAddon(receipt, addonReceipt, sdkHeaderReceip
   return addon;
 }
 
+function validateArchiveContents(value) {
+  const contents = record(value, "contents", ["entries", "files", "directories", "pathSetSha256"]);
+  const entries = positiveInteger(contents.entries, "contents.entries", 100_000);
+  const files = nonNegativeInteger(contents.files, "contents.files", entries);
+  const directories = nonNegativeInteger(contents.directories, "contents.directories", entries);
+  if (files + directories !== entries) throw receiptError("contents file and directory totals must match entries");
+  sha256(contents.pathSetSha256, "contents.pathSetSha256");
+  return Object.freeze({ entries, files, directories, pathSetSha256: contents.pathSetSha256 });
+}
+
 export function verifyUxpHybridCcxReceipt(document, options = {}) {
-  const receipt = record(document, "receipt", ["schemaVersion", "source", "archive", "manifest", "semantics", "stats"]);
-  if (receipt.schemaVersion !== UXP_HYBRID_CCX_RECEIPT_SCHEMA_VERSION) {
-    throw receiptError(`schemaVersion must be ${UXP_HYBRID_CCX_RECEIPT_SCHEMA_VERSION}`);
+  const legacy = document?.schemaVersion === UXP_HYBRID_CCX_RECEIPT_LEGACY_SCHEMA_VERSION;
+  const receipt = record(document, "receipt", legacy
+    ? ["schemaVersion", "source", "archive", "manifest", "semantics", "stats"]
+    : ["schemaVersion", "source", "archive", "contents", "manifest", "semantics", "stats"]);
+  if (!legacy && receipt.schemaVersion !== UXP_HYBRID_CCX_RECEIPT_SCHEMA_VERSION) {
+    throw receiptError(`schemaVersion must be ${UXP_HYBRID_CCX_RECEIPT_LEGACY_SCHEMA_VERSION} or ${UXP_HYBRID_CCX_RECEIPT_SCHEMA_VERSION}`);
   }
   const source = record(receipt.source, "source", ["sdk", "sdkVersion", "sdkHeaderReceiptSha256", "addonReceiptSha256", "authorityUrl"]);
   if (source.sdk !== "uxp-hybrid") throw receiptError("source.sdk must be uxp-hybrid");
@@ -199,8 +221,11 @@ export function verifyUxpHybridCcxReceipt(document, options = {}) {
 
   validateManifestFacts(receipt.manifest, "manifest", true);
 
+  if (!legacy) validateArchiveContents(receipt.contents);
+
   const semantics = record(receipt.semantics, "semantics", ["listed", "doesNotEstablish"]);
-  if (semantics.listed !== UXP_HYBRID_CCX_RECEIPT_SEMANTICS.listed || semantics.doesNotEstablish !== UXP_HYBRID_CCX_RECEIPT_SEMANTICS.doesNotEstablish) {
+  const requiredSemantics = legacy ? UXP_HYBRID_CCX_RECEIPT_LEGACY_SEMANTICS : UXP_HYBRID_CCX_RECEIPT_SEMANTICS;
+  if (semantics.listed !== requiredSemantics.listed || semantics.doesNotEstablish !== requiredSemantics.doesNotEstablish) {
     throw receiptError("semantics must retain the documented evidence boundary");
   }
 
@@ -255,6 +280,7 @@ export async function buildUxpHybridCcxReceipt(options) {
       authorityUrl: UXP_HYBRID_CCX_AUTHORITY_URL,
     },
     archive: { format: "zip", bytes: archive.bytes, sha256: await sha256File(options.ccxPath) },
+    contents: archive.summary,
     manifest,
     semantics: UXP_HYBRID_CCX_RECEIPT_SEMANTICS,
     stats: {

--- a/scripts/verify-uxp-hybrid-ccx-receipt.mjs
+++ b/scripts/verify-uxp-hybrid-ccx-receipt.mjs
@@ -8,6 +8,7 @@ import {
   canonicalUxpHybridCcxReceiptSha256,
   verifyUxpHybridCcxReceipt,
 } from "./uxp-hybrid-ccx-receipt-core.mjs";
+import { UXP_HYBRID_CCX_RECEIPT_LEGACY_SEMANTICS } from "./uxp-hybrid-ccx-receipt-contract.mjs";
 
 function receiptError(message) {
   const error = new Error(message);
@@ -48,7 +49,14 @@ async function main() {
   ]);
   verifyUxpHybridCcxReceipt(receipt, { addonReceipt, sdkHeaderReceipt });
   const current = await buildUxpHybridCcxReceipt({ ccxPath: resolve(options.ccxPath), addonReceipt, sdkHeaderReceipt });
-  if (canonicalUxpHybridCcxReceiptSha256(receipt) !== canonicalUxpHybridCcxReceiptSha256(current)) {
+  const expected = receipt.schemaVersion === 1
+    ? (() => {
+      const { contents, ...legacy } = current;
+      void contents;
+      return { ...legacy, schemaVersion: 1, semantics: UXP_HYBRID_CCX_RECEIPT_LEGACY_SEMANTICS };
+    })()
+    : current;
+  if (canonicalUxpHybridCcxReceiptSha256(receipt) !== canonicalUxpHybridCcxReceiptSha256(expected)) {
     throw receiptError("UXP Hybrid CCX receipt does not match the supplied local archive");
   }
   process.stdout.write(`UXP Hybrid CCX receipt is valid: ${receipt.stats.artifacts} addon artifacts and ${receipt.stats.entrypoints} entrypoint.\n`);

--- a/src/resources/premiere-surface-registry.json
+++ b/src/resources/premiere-surface-registry.json
@@ -82,7 +82,8 @@
       "ccxReceiptCommand": "npm run native:hybrid-ccx-receipt",
       "ccxReceiptVerificationCommand": "npm run native:hybrid-ccx-receipt:verify",
       "ccxReceiptDocumentation": "docs/uxp-hybrid-ccx-receipt.md",
-      "notes": "The downloadable SDK headers are access-controlled. The header receipt and standalone verifier can account for an authorized artifact without copying it; a local addon-layout receipt can additionally account for the public root main.js entrypoint and three-target bundle layout without copying source or binaries. A local CCX archive receipt can bind that current layout receipt to the byte-identical required files in a local ZIP-format installer, without copying archive contents. A schema-v3 candidate benchmark must bind its runs to matching verified SDK, addon-layout, and current local CCX receipts, but remains disabled until exact SDK, reproducible builds, signing/notarization, and cross-platform evidence are available."
+      "ccxReceiptSchemaVersion": 2,
+      "notes": "The downloadable SDK headers are access-controlled. The header receipt and standalone verifier can account for an authorized artifact without copying it; a local addon-layout receipt can additionally account for the public root main.js entrypoint and three-target bundle layout without copying source or binaries. A schema-v2 local CCX archive receipt can bind that current layout receipt to the byte-identical required files and a full safe ZIP entry-name-set digest without copying archive contents or entry names. A schema-v3 candidate benchmark must bind its runs to matching verified SDK, addon-layout, and current local CCX receipts, but remains disabled until exact SDK, reproducible builds, signing/notarization, and cross-platform evidence are available."
     },
     {
       "id": "premiere-cpp-sdk",

--- a/tests/hybrid-benchmark-evidence.test.ts
+++ b/tests/hybrid-benchmark-evidence.test.ts
@@ -17,7 +17,7 @@ import {
   canonicalUxpHybridAddonReceiptSha256,
 } from "../scripts/verify-uxp-hybrid-addon-receipt.mjs";
 import {
-  UXP_HYBRID_CCX_RECEIPT_SEMANTICS,
+  UXP_HYBRID_CCX_RECEIPT_LEGACY_SEMANTICS,
 } from "../scripts/uxp-hybrid-ccx-receipt-contract.mjs";
 import {
   canonicalUxpHybridCcxReceiptSha256,
@@ -153,7 +153,7 @@ function ccxReceipt(headerReceipt = sdkHeaderReceipt(), addon = addonReceipt(hea
       addonName: "fixture-addon.uxpaddon",
       enableAddon: true,
     },
-    semantics: UXP_HYBRID_CCX_RECEIPT_SEMANTICS,
+    semantics: UXP_HYBRID_CCX_RECEIPT_LEGACY_SEMANTICS,
     stats: { artifacts: 3, addonBytes: 12, entrypoints: 1, entrypointBytes: 3 },
   };
 }

--- a/tests/premiere-surface-registry.test.ts
+++ b/tests/premiere-surface-registry.test.ts
@@ -21,6 +21,7 @@ type Surface = {
   ccxReceiptCommand?: string;
   ccxReceiptVerificationCommand?: string;
   ccxReceiptDocumentation?: string;
+  ccxReceiptSchemaVersion?: number;
   notes: string;
 };
 
@@ -132,11 +133,12 @@ describe("Premiere API and competitor surface registry", () => {
         ccxReceiptCommand: "npm run native:hybrid-ccx-receipt",
         ccxReceiptVerificationCommand: "npm run native:hybrid-ccx-receipt:verify",
         ccxReceiptDocumentation: "docs/uxp-hybrid-ccx-receipt.md",
+        ccxReceiptSchemaVersion: 2,
       });
     expect(registry.integrationSurfaces.find((surface) => surface.id === "uxp-hybrid-cpp")?.notes)
       .toContain("root main.js entrypoint and three-target bundle layout");
     expect(registry.integrationSurfaces.find((surface) => surface.id === "uxp-hybrid-cpp")?.notes)
-      .toContain("CCX archive receipt can bind that current layout receipt");
+      .toContain("schema-v2 local CCX archive receipt can bind that current layout receipt");
     expect(registry.integrationSurfaces.find((surface) => surface.id === "uxp-hybrid-cpp")?.notes)
       .toContain("schema-v3 candidate benchmark");
   });

--- a/tests/uxp-hybrid-ccx-receipt.test.ts
+++ b/tests/uxp-hybrid-ccx-receipt.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { deflateRawSync } from "node:zlib";
 import { describe, expect, it } from "vitest";
 import { NATIVE_SDK_HEADER_INVENTORY_SEMANTICS } from "../scripts/native-sdk-header-inventory-contract.mjs";
+import { UXP_HYBRID_CCX_RECEIPT_LEGACY_SEMANTICS } from "../scripts/uxp-hybrid-ccx-receipt-contract.mjs";
 import {
   buildUxpHybridCcxReceipt,
   canonicalUxpHybridCcxReceiptSha256,
@@ -70,18 +71,19 @@ function crc32(buffer: Buffer) {
   return (value ^ 0xffff_ffff) >>> 0;
 }
 
-function createZip(entries: Array<{ path: string; contents: Buffer }>, prefix = "", deflate = true, localNameOverride?: string) {
+function createZip(entries: Array<{ path: string; contents: Buffer }>, prefix = "", deflate = true, localNameOverride?: string, options: { flags?: number; method?: number } = {}) {
   const locals: Buffer[] = [];
   const centrals: Buffer[] = [];
   let localOffset = 0;
   for (const entry of entries) {
     const name = Buffer.from(`${prefix}${entry.path}`, "utf8");
-    const compressed = deflate ? deflateRawSync(entry.contents) : entry.contents;
-    const method = deflate ? 8 : 0;
+    const method = options.method ?? (deflate ? 8 : 0);
+    const compressed = method === 8 ? deflateRawSync(entry.contents) : entry.contents;
+    const flags = 0x800 | (options.flags ?? 0);
     const local = Buffer.alloc(30);
     local.writeUInt32LE(0x04034b50, 0);
     local.writeUInt16LE(20, 4);
-    local.writeUInt16LE(0x800, 6);
+    local.writeUInt16LE(flags, 6);
     local.writeUInt16LE(method, 8);
     local.writeUInt32LE(crc32(entry.contents), 14);
     local.writeUInt32LE(compressed.length, 18);
@@ -95,7 +97,7 @@ function createZip(entries: Array<{ path: string; contents: Buffer }>, prefix = 
     central.writeUInt32LE(0x02014b50, 0);
     central.writeUInt16LE(20, 4);
     central.writeUInt16LE(20, 6);
-    central.writeUInt16LE(0x800, 8);
+    central.writeUInt16LE(flags, 8);
     central.writeUInt16LE(method, 10);
     central.writeUInt32LE(crc32(entry.contents), 16);
     central.writeUInt32LE(compressed.length, 20);
@@ -115,7 +117,7 @@ function createZip(entries: Array<{ path: string; contents: Buffer }>, prefix = 
   return Buffer.concat([...locals, central, end]);
 }
 
-function writeCcx(bundle: string, archive: string, options: { prefix?: string; deflate?: boolean; main?: string; manifest?: Record<string, unknown>; duplicateMain?: boolean; localMainName?: string } = {}) {
+function writeCcx(bundle: string, archive: string, options: { prefix?: string; deflate?: boolean; main?: string; manifest?: Record<string, unknown>; duplicateMain?: boolean; localMainName?: string; extra?: Array<{ path: string; contents: Buffer }>; zipFlags?: number; compressionMethod?: number } = {}) {
   const name = "fixture-addon.uxpaddon";
   const manifest = { ...JSON.parse(readFileSync(join(bundle, "manifest.json"), "utf8")), ...(options.manifest ?? {}) };
   const entries = [
@@ -125,8 +127,12 @@ function writeCcx(bundle: string, archive: string, options: { prefix?: string; d
     { path: `mac/arm64/${name}`, contents: readFileSync(join(bundle, "mac", "arm64", name)) },
     { path: `win/x64/${name}`, contents: readFileSync(join(bundle, "win", "x64", name)) },
   ];
+  entries.push(...(options.extra ?? []));
   if (options.duplicateMain) entries.push({ path: "main.js", contents: Buffer.from("duplicate") });
-  writeFileSync(archive, createZip(entries, options.prefix ?? "", options.deflate ?? true, options.localMainName));
+  writeFileSync(archive, createZip(entries, options.prefix ?? "", options.deflate ?? true, options.localMainName, {
+    flags: options.zipFlags,
+    method: options.compressionMethod,
+  }));
 }
 
 describe("UXP Hybrid CCX receipt", () => {
@@ -143,9 +149,10 @@ describe("UXP Hybrid CCX receipt", () => {
       const receipt = await buildUxpHybridCcxReceipt({ ccxPath: archive, addonReceipt, sdkHeaderReceipt: headers });
 
       expect(receipt).toMatchObject({
-        schemaVersion: 1,
+        schemaVersion: 2,
         source: { sdk: "uxp-hybrid", addonReceiptSha256: expect.stringMatching(/^[a-f0-9]{64}$/) },
         archive: { format: "zip", bytes: expect.any(Number), sha256: expect.stringMatching(/^[a-f0-9]{64}$/) },
+        contents: { entries: 5, files: 5, directories: 0, pathSetSha256: expect.stringMatching(/^[a-f0-9]{64}$/) },
         manifest: { idLength: "fixture-hybrid-plugin".length, idSha256: expect.stringMatching(/^[a-f0-9]{64}$/), addonName: "fixture-addon.uxpaddon" },
         stats: { artifacts: 3, entrypoints: 1 },
       });
@@ -155,8 +162,44 @@ describe("UXP Hybrid CCX receipt", () => {
         entrypoints: 1,
         entrypointBytes: addonReceipt.stats.entrypointBytes,
       });
+      const { contents: ignoredContents, ...legacyReceipt } = receipt;
+      expect(ignoredContents).toBeDefined();
+      expect(verifyUxpHybridCcxReceipt({
+        ...legacyReceipt,
+        schemaVersion: 1,
+        semantics: UXP_HYBRID_CCX_RECEIPT_LEGACY_SEMANTICS,
+      }, { addonReceipt, sdkHeaderReceipt: headers })).toEqual({
+        artifacts: 3,
+        addonBytes: addonReceipt.stats.addonBytes,
+        entrypoints: 1,
+        entrypointBytes: addonReceipt.stats.entrypointBytes,
+      });
+      const legacyPath = join(directory, "legacy-ccx-receipt.json");
+      const legacyHeadersPath = join(directory, "legacy-headers.json");
+      const legacyAddonPath = join(directory, "legacy-addon-receipt.json");
+      writeFileSync(legacyPath, `${JSON.stringify({
+        ...legacyReceipt,
+        schemaVersion: 1,
+        semantics: UXP_HYBRID_CCX_RECEIPT_LEGACY_SEMANTICS,
+      }, null, 2)}\n`);
+      writeFileSync(legacyHeadersPath, `${JSON.stringify(headers, null, 2)}\n`);
+      writeFileSync(legacyAddonPath, `${JSON.stringify(addonReceipt, null, 2)}\n`);
+      const legacyVerified = spawnSync(process.execPath, [
+        "scripts/verify-uxp-hybrid-ccx-receipt.mjs",
+        "--input", legacyPath,
+        "--ccx", archive,
+        "--addon-receipt", legacyAddonPath,
+        "--sdk-header-receipt", legacyHeadersPath,
+      ], { encoding: "utf8" });
+      expect(legacyVerified.status).toBe(0);
+      expect(legacyVerified.stdout).toContain("UXP Hybrid CCX receipt is valid");
+      expect(() => verifyUxpHybridCcxReceipt({
+        ...receipt,
+        contents: { ...receipt.contents, files: receipt.contents.files - 1 },
+      })).toThrow("contents file and directory totals must match entries");
       expect(canonicalUxpHybridCcxReceiptSha256(receipt)).toMatch(/^[a-f0-9]{64}$/);
       expect(JSON.stringify(receipt)).not.toContain("fixture-hybrid-plugin");
+      expect(JSON.stringify(receipt)).not.toContain("mac/x64");
       expect(JSON.stringify(receipt)).not.toContain("const addon");
       expect(JSON.stringify(receipt)).not.toContain("mac intel fixture");
       expect(JSON.stringify(receipt)).not.toContain(directory);
@@ -219,7 +262,7 @@ describe("UXP Hybrid CCX receipt", () => {
     }
   });
 
-  it("fails closed for a missing manifest ID, duplicate or inconsistent entrypoint, or content that differs from the addon receipt", async () => {
+  it("fails closed for malformed manifest, ZIP, entrypoint, and addon content", async () => {
     const directory = mkdtempSync(join(tmpdir(), "premiere-hybrid-ccx-receipt-invalid-"));
     const bundle = join(directory, "bundle");
     const archive = join(directory, "fixture.ccx");
@@ -233,13 +276,22 @@ describe("UXP Hybrid CCX receipt", () => {
       await expect(buildUxpHybridCcxReceipt({ ccxPath: archive, addonReceipt, sdkHeaderReceipt: headers })).rejects.toThrow("manifest.json id must be a non-empty string");
 
       writeCcx(bundle, archive, { duplicateMain: true });
-      await expect(buildUxpHybridCcxReceipt({ ccxPath: archive, addonReceipt, sdkHeaderReceipt: headers })).rejects.toThrow("exactly one main.js entry");
+      await expect(buildUxpHybridCcxReceipt({ ccxPath: archive, addonReceipt, sdkHeaderReceipt: headers })).rejects.toThrow("duplicate ZIP entry names");
 
       writeCcx(bundle, archive, { localMainName: "renamed-main.js" });
       await expect(buildUxpHybridCcxReceipt({ ccxPath: archive, addonReceipt, sdkHeaderReceipt: headers })).rejects.toThrow("local entry name is inconsistent");
 
       writeCcx(bundle, archive, { main: "changed entrypoint" });
       await expect(buildUxpHybridCcxReceipt({ ccxPath: archive, addonReceipt, sdkHeaderReceipt: headers })).rejects.toThrow("CCX archive main.js must match the addon-layout receipt");
+
+      writeCcx(bundle, archive, { extra: [{ path: "C:Headers", contents: Buffer.from("unsafe") }] });
+      await expect(buildUxpHybridCcxReceipt({ ccxPath: archive, addonReceipt, sdkHeaderReceipt: headers })).rejects.toThrow("unsafe ZIP entry name");
+
+      writeCcx(bundle, archive, { zipFlags: 0x1 });
+      await expect(buildUxpHybridCcxReceipt({ ccxPath: archive, addonReceipt, sdkHeaderReceipt: headers })).rejects.toThrow("entries must not be encrypted");
+
+      writeCcx(bundle, archive, { compressionMethod: 12 });
+      await expect(buildUxpHybridCcxReceipt({ ccxPath: archive, addonReceipt, sdkHeaderReceipt: headers })).rejects.toThrow("stored or deflate compression");
     } finally {
       rmSync(directory, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- emit a schema-v2 CCX receipt that commits to a validated whole-archive ZIP entry-name set without storing names or archive contents
- reject unsafe, duplicate, encrypted, and unsupported-compression entries before required-file binding
- retain schema-v1 receipt verification for historical records while requiring v2 for newly generated receipt chains

## Validation
- `npm run check`
- `npm run test:coverage` (95.07% statements, 91.42% branches, 96.57% functions, 96.75% lines)
- `npm run pack:check`

## Evidence boundary
This adds local archive-structure/accounting evidence only. It does not establish UDT creation, portal acceptance, SDK compilation, signing, installation, MCP exposure, or licensed-host behavior.