### PR TITLE
fix(mcp): add Claude Desktop legacy protocol fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ through `2025-11-25`. Modern clients receive discovery, validated routing header
 cache hints, subscription-stream support, and the formal Premiere extension
 capability. See the [complete MCP capability and boundary report](docs/mcp-2026-07-28-capabilities.md).
 
+If an MCP client cannot complete its `server/discover` probe, set
+`PREMIERE_MCP_PROTOCOL_MODE=legacy` in that client's server environment and restart
+the client. This uses the SDK's base stdio transport and the legacy initialization
+handshake only; leave it unset (or `auto`) for modern MCP capabilities.
+
 ---
 
 ## For editors evaluating an AI workflow

--- a/claude-desktop/manifest.json
+++ b/claude-desktop/manifest.json
@@ -24,7 +24,8 @@
       "command": "node",
       "args": ["${__dirname}/server/dist/index.js"],
       "env": {
-        "PREMIERE_UXP_TOKEN": "${user_config.premiere_uxp_token}"
+        "PREMIERE_UXP_TOKEN": "${user_config.premiere_uxp_token}",
+        "PREMIERE_MCP_PROTOCOL_MODE": "${user_config.premiere_mcp_protocol_mode}"
       }
     }
   },
@@ -35,6 +36,12 @@
       "description": "Shared secret used to authenticate the local Premiere UXP bridge. Use the same value in the Premiere panel (minimum 16 characters).",
       "sensitive": true,
       "required": true
+    },
+    "premiere_mcp_protocol_mode": {
+      "type": "string",
+      "title": "MCP protocol mode",
+      "description": "Leave blank or use auto for modern MCP negotiation. Set legacy only if Claude Desktop support directs you to bypass server/discover negotiation.",
+      "required": false
     }
   },
   "tools_generated": true,

--- a/docs/mcp-2026-07-28-capabilities.md
+++ b/docs/mcp-2026-07-28-capabilities.md
@@ -11,7 +11,7 @@ This repository targets the current Model Context Protocol revision, `2026-07-28
 | Stateless protocol core | Implemented | HTTP uses `createMcpHandler`; every modern request receives a fresh MCP server instance and can land on any process instance. |
 | `server/discover` | Implemented | HTTP and stdio use the v2 serving entries and advertise `2026-07-28`; modern clients can probe before selecting an era. |
 | Per-request `_meta` envelope | Implemented | Validated and exposed by the SDK on modern calls; no hidden MCP session state is required. |
-| Dual-era serving | Implemented | One factory serves modern and legacy clients over both Streamable HTTP and stdio. |
+| Dual-era serving | Implemented | One factory serves modern and legacy clients over both Streamable HTTP and stdio. For a stdio client that cannot complete `server/discover`, the explicit `PREMIERE_MCP_PROTOCOL_MODE=legacy` fallback serves the legacy initialization handshake only. |
 | `MCP-Protocol-Version`, `Mcp-Method`, and `Mcp-Name` routing headers | Implemented | The modern HTTP entry validates required headers and agreement with the JSON-RPC body before dispatch. |
 | `Mcp-Param-*` schema headers | Available | The v2 entry validates parameters declared with `x-mcp-header`; no current Premiere tool duplicates an argument into a routing header. |
 | Cacheable list/read results | Implemented | `tools/list` is private for 30 seconds; `prompts/list` is public for 5 minutes; `resources/list` is private for 1 minute; live `resources/read` results are private and uncached. |

--- a/scripts/validate-distribution.mjs
+++ b/scripts/validate-distribution.mjs
@@ -76,6 +76,16 @@ export function validateClaudeManifest(manifest, packageJson) {
       "${user_config.premiere_uxp_token}",
     "Claude bundle must map the configured Premiere UXP token into the server environment",
   );
+  const protocolModeConfig = manifest.user_config?.premiere_mcp_protocol_mode;
+  assert(
+    protocolModeConfig?.type === "string" && protocolModeConfig?.required === false,
+    "Claude bundle must expose an optional MCP protocol-mode fallback configuration",
+  );
+  assert(
+    manifest.server?.mcp_config?.env?.PREMIERE_MCP_PROTOCOL_MODE ===
+      "${user_config.premiere_mcp_protocol_mode}",
+    "Claude bundle must map the configured MCP protocol mode into the server environment",
+  );
   assert(
     Array.isArray(manifest.compatibility?.platforms) &&
       manifest.compatibility.platforms.length === 2 &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { serveStdio } from "@modelcontextprotocol/server/stdio";
+import { StdioServerTransport, serveStdio } from "@modelcontextprotocol/server/stdio";
 import { createServer } from "./server.js";
 import { cleanupTempDir, getTempDir } from "./bridge/file-bridge.js";
 import { getTelemetry } from "./telemetry.js";
@@ -27,6 +27,14 @@ function debugLog(message: string): void {
   if (debugEnabled) {
     console.error(`[premiere-pro-mcp] ${message}`);
   }
+}
+
+type McpProtocolMode = "auto" | "legacy";
+
+function readMcpProtocolMode(value = process.env.PREMIERE_MCP_PROTOCOL_MODE): McpProtocolMode {
+  if (value === undefined || value === "" || value === "auto") return "auto";
+  if (value === "legacy") return "legacy";
+  throw new Error("PREMIERE_MCP_PROTOCOL_MODE must be either auto or legacy.");
 }
 
 function isLoopbackPortInUse(error: unknown): boolean {
@@ -147,6 +155,7 @@ Environment variables:
   PREMIERE_MCP_CAPABILITIES  Comma-separated authority profile
   PREMIERE_MCP_TOOL_PACKS    Comma-separated discovery packs: full, essential, inspection, delivery, captions
   PREMIERE_MCP_DEBUG    Set to 1/true to enable verbose stderr diagnostics
+  PREMIERE_MCP_PROTOCOL_MODE  auto (default) or legacy; use legacy only when a client cannot complete modern MCP negotiation
   PREMIERE_UXP_TOKEN    Enable the authenticated local UXP bridge (minimum 16 characters)
   PREMIERE_UXP_PORT     UXP loopback WebSocket port (default: 7777)
 
@@ -253,6 +262,7 @@ if (cepActions.length === 1) {
 
 async function main() {
   process.env.PREMIERE_MCP_TRANSPORT = "stdio";
+  const protocolMode = readMcpProtocolMode();
   const telemetry = getTelemetry();
   const bridgeOptions = {
     tempDir: process.env.PREMIERE_TEMP_DIR,
@@ -289,13 +299,26 @@ async function main() {
     }
   }
 
-  const serverHandle = serveStdio(
-    () => createServer(bridgeOptions, { uxpBridge, telemetry }),
-    {
-      onerror: (error) => console.error("[premiere-pro-mcp] MCP stdio error:", error),
-    },
-  );
-  debugLog("Server connected and ready");
+  const serverHandle = protocolMode === "legacy"
+    ? await (async () => {
+      const server = createServer(bridgeOptions, { uxpBridge, telemetry });
+      const transport = new StdioServerTransport();
+      await server.connect(transport);
+      debugLog("Server connected in legacy MCP mode");
+      return {
+        close: async () => {
+          await server.close();
+          await transport.close();
+        },
+      };
+    })()
+    : serveStdio(
+      () => createServer(bridgeOptions, { uxpBridge, telemetry }),
+      {
+        onerror: (error) => console.error("[premiere-pro-mcp] MCP stdio error:", error),
+      },
+    );
+  if (protocolMode === "auto") debugLog("Server connected and ready");
 
   const shutdown = async () => {
     if (uxpBridge) await uxpBridge.stop();

--- a/tests/codex-plugin.test.ts
+++ b/tests/codex-plugin.test.ts
@@ -129,8 +129,13 @@ describe("Claude distributions", () => {
       sensitive: true,
       required: true,
     });
+    expect(manifest.user_config.premiere_mcp_protocol_mode).toMatchObject({
+      type: "string",
+      required: false,
+    });
     expect(manifest.server.mcp_config.env).toEqual({
       PREMIERE_UXP_TOKEN: "${user_config.premiere_uxp_token}",
+      PREMIERE_MCP_PROTOCOL_MODE: "${user_config.premiere_mcp_protocol_mode}",
     });
   });
 });

--- a/tests/entrypoints-unit.test.ts
+++ b/tests/entrypoints-unit.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   cleanup: vi.fn(),
   connect: vi.fn(async () => {}),
   serveStdio: vi.fn(),
+  stdioServerTransport: vi.fn(),
   closeMcp: vi.fn(async () => {}),
   handleRequest: vi.fn(async (_req: any, res: any) => { res.statusCode = 204; }),
   closeTransport: vi.fn(async () => {}),
@@ -70,6 +71,10 @@ vi.mock("@modelcontextprotocol/node", () => ({
 }));
 vi.mock("@modelcontextprotocol/server/stdio", () => ({
   serveStdio: (...args: any[]) => mocks.serveStdio(...args),
+  StdioServerTransport: class {
+    constructor() { mocks.stdioServerTransport(); }
+    close = mocks.closeTransport;
+  },
 }));
 vi.mock("../src/http-security.js", () => ({ applyHttpSecurityHeaders: vi.fn() }));
 vi.mock("../src/http-admission.js", async (original) => {
@@ -268,6 +273,33 @@ describe("stdio CLI entry point", () => {
     await vi.waitFor(() => expect(mocks.connect).toHaveBeenCalledOnce());
     expect(mocks.cleanup).toHaveBeenCalledWith({ tempDir: "C:\\custom-temp", timeoutMs: 4321 });
     expect(process.env.PREMIERE_MCP_TRANSPORT).toBe("stdio");
+  });
+
+  it("offers an explicit legacy stdio fallback for clients that cannot negotiate server/discover", async () => {
+    process.argv = [process.execPath, "index.js"];
+    process.env.PREMIERE_MCP_PROTOCOL_MODE = "legacy";
+
+    await import("../src/index.js");
+
+    await vi.waitFor(() => expect(mocks.connect).toHaveBeenCalledOnce());
+    expect(mocks.stdioServerTransport).toHaveBeenCalledOnce();
+    expect(mocks.serveStdio).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown MCP protocol mode before opening stdio", async () => {
+    process.argv = [process.execPath, "index.js"];
+    process.env.PREMIERE_MCP_PROTOCOL_MODE = "unsupported";
+    const error = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+
+    await import("../src/index.js");
+
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(1));
+    expect(mocks.serveStdio).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith(
+      "[premiere-pro-mcp] Fatal error:",
+      expect.objectContaining({ message: "PREMIERE_MCP_PROTOCOL_MODE must be either auto or legacy." }),
+    );
   });
 
   it("starts the authenticated UXP bridge and emits debug readiness details", async () => {


### PR DESCRIPTION
## Summary
- Adds `PREMIERE_MCP_PROTOCOL_MODE=legacy` as an explicit, opt-in fallback for stdio clients that cannot complete a `server/discover` probe.
- Legacy mode connects the MCP server to the SDK's base `StdioServerTransport`, retaining the classic initialization handshake and intentionally disabling modern-only negotiation features.
- Exposes the fallback through the Claude Desktop MCPB configuration and documents the boundary.

Closes #347.

## Validation
- `npx vitest run tests/entrypoints-unit.test.ts tests/codex-plugin.test.ts`
- `node scripts/validate-distribution.mjs --claude`
- `npm run build`
- Wrapped/in-place SDK stdio client smoke test with a UXP token: connected and listed 417 tools in both auto and legacy modes.

## Evidence boundary
This validates bundled-server behavior with the SDK client transport. It does not validate a licensed Premiere host or an installed Claude Desktop client on macOS.