### PR TITLE
fix(landing): remediate fast-uri and qs advisories

### DIFF
--- a/landing/package-lock.json
+++ b/landing/package-lock.json
@@ -6955,9 +6955,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {
@@ -6968,8 +6968,7 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ],
-      "license": "BSD-3-Clause"
+      ]
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -10001,11 +10000,10 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "es-define-property": "^1.0.1",
         "side-channel": "^1.1.1"


### PR DESCRIPTION
## Summary\n- update transitive fast-uri from 3.1.5 to 3.1.7, clearing Dependabot alerts #113 through #116\n- update transitive qs from 6.15.3 to 6.16.0, clearing the remaining npm audit finding\n- keep the remediation limited to landing/package-lock.json\n\n## Validation\n- npm --prefix landing audit --json (0 vulnerabilities)\n- npm --prefix landing ci\n- npm --prefix landing run build\n- git diff --check