### PR TITLE
Add in-panel global updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,19 @@ premiere-pro-mcp --update
 client configuration and projects untouched. Restart Premiere and your MCP
 client afterward, then run `verify_premiere_connection` before editing.
 
+**From the MCP for Adobe Premiere Pro panel (Windows global npm install):**
+
+The **MCP updates** card compares the installed global server and connector
+with npm `latest`. Choose **Update after quit**, review the confirmation, then
+quit Premiere normally. A per-user helper waits for Premiere to exit; it never
+force-quits the app, then installs the published npm package and refreshes its
+matching connector. This also supports older global installs that predate the
+`--update` command.
+When you reopen Premiere, the panel reports the result and reminds you to
+restart your MCP client and verify the connection. This flow never changes a
+project or MCP client configuration. It deliberately will not update a Git
+checkout, a custom npm prefix, or a Claude Desktop `.mcpb` bundle.
+
 **Installed from a Git clone:**
 
 ```bash

--- a/cep-plugin/index.html
+++ b/cep-plugin/index.html
@@ -80,11 +80,11 @@
 
     <section class="update-section" aria-live="polite">
       <div class="update-copy">
-        <span class="section-label">Connector updates</span>
+        <span class="section-label">MCP updates</span>
         <strong id="updateTitle">Version 1.14.7</strong>
-        <span id="updateDetail">Checking for updates…</span>
+        <span id="updateDetail">Checking the global MCP server and connector release…</span>
       </div>
-      <button id="btnUpdate" class="button button-update" onclick="handleUpdateClick()" type="button" disabled>
+      <button id="btnUpdate" class="button button-update" onclick="handleUpdateClick()" type="button" aria-describedby="updateDetail" disabled>
         Check again
       </button>
     </section>

--- a/cep-plugin/main.js
+++ b/cep-plugin/main.js
@@ -1,4 +1,4 @@
-/* MCP Bridge - CEP Plugin Main Script
+/* MCP for Adobe Premiere Pro - CEP Plugin Main Script
  * Polls a temp directory for command files (.jsx), executes them
  * in Premiere Pro's ExtendScript engine, and writes results back. */
 
@@ -109,6 +109,70 @@ function defaultBridgeDirectory() {
 }
 tempDir = defaultBridgeDirectory();
 var latestUpdate = null;
+var UPDATE_STATUS_STORAGE_KEY = "mcp_bridge_desktop_update_status_path";
+var MAX_UPDATE_RESPONSE_BYTES = 64 * 1024;
+
+function getPerUserGlobalInstall() {
+  try {
+    var nodeProcess = nodeRequire("process");
+    var appData = nodeProcess && nodeProcess.env && nodeProcess.env.APPDATA;
+    if (typeof appData !== "string" || !appData.trim()) return null;
+    var npmDirectory = path.resolve(appData, "npm");
+    var commandPath = path.resolve(npmDirectory, "premiere-pro-mcp.cmd");
+    var packagePath = path.resolve(npmDirectory, "node_modules", "premiere-pro-mcp", "package.json");
+    var relative = path.relative(npmDirectory, commandPath);
+    var packageRelative = path.relative(npmDirectory, packagePath);
+    if (
+      !relative ||
+      !packageRelative ||
+      relative.indexOf(".." + path.sep) === 0 ||
+      packageRelative.indexOf(".." + path.sep) === 0 ||
+      path.isAbsolute(relative) ||
+      path.isAbsolute(packageRelative) ||
+      !fs.existsSync(commandPath) ||
+      !fs.existsSync(packagePath)
+    ) return null;
+    var packageMetadata = JSON.parse(fs.readFileSync(packagePath, "utf-8"));
+    var serverVersion = MCPBridgeUpdater.normalizeVersion(packageMetadata && packageMetadata.version);
+    if (!serverVersion) return null;
+    return { commandPath: commandPath, serverVersion: serverVersion };
+  } catch (e) {
+    return null;
+  }
+}
+
+function getPerUserGlobalCommand() {
+  var install = getPerUserGlobalInstall();
+  return install ? install.commandPath : null;
+}
+
+function saveUpdateStatusPath(statusPath) {
+  try {
+    localStorage.setItem(UPDATE_STATUS_STORAGE_KEY, statusPath);
+  } catch (e) {}
+}
+
+function readScheduledUpdateStatus() {
+  var statusPath = "";
+  try {
+    statusPath = localStorage.getItem(UPDATE_STATUS_STORAGE_KEY) || "";
+  } catch (e) {
+    return null;
+  }
+  if (!statusPath || !path.isAbsolute(statusPath) || !fs.existsSync(statusPath)) return null;
+  try {
+    var status = JSON.parse(fs.readFileSync(statusPath, "utf-8"));
+    var validStates = ["waiting_for_premiere", "updating", "complete", "failed"];
+    if (
+      !status ||
+      status.schemaVersion !== "premiere-pro-mcp.desktop-update.v1" ||
+      validStates.indexOf(status.state) === -1
+    ) return null;
+    return status;
+  } catch (e) {
+    return null;
+  }
+}
 
 function ensureDir(dir) {
   try {
@@ -355,8 +419,70 @@ function setUpdateUI(title, detail, buttonText, disabled) {
   button.disabled = !!disabled;
 }
 
+function updateInstructionUrl() {
+  return MCPBridgeUpdater.RELEASES_URL;
+}
+
+function openTrustedUpdateInstructions() {
+  var url = updateInstructionUrl();
+  if (!MCPBridgeUpdater.isTrustedDownloadUrl(url)) {
+    showUpdateCheckError("The update instructions link was not trusted.");
+    return;
+  }
+  try {
+    var childProcess = nodeRequire("child_process");
+    var command =
+      os.platform() === "win32"
+        ? ["cmd.exe", ["/d", "/s", "/c", "start", "", url]]
+        : ["open", [url]];
+    var child = childProcess.spawn(command[0], command[1], {
+      detached: true,
+      stdio: "ignore",
+    });
+    child.unref();
+  } catch (e) {
+    showUpdateCheckError("Could not open the update instructions. Try again.");
+  }
+}
+
+function restoreScheduledUpdateStatus() {
+  var status = readScheduledUpdateStatus();
+  if (!status) return false;
+
+  if (status.state === "complete") {
+    setUpdateUI(
+      "Update complete",
+      "Restart your MCP client, then use Verify Premiere connection before editing.",
+      "Check again",
+      false
+    );
+    return true;
+  }
+  if (status.state === "failed") {
+    setUpdateUI(
+      "Update needs attention",
+      "Nothing was changed in your projects. Check the update command or retry after Premiere closes.",
+      "Check again",
+      false
+    );
+    return true;
+  }
+
+  setUpdateUI(
+    "Update scheduled",
+    status.state === "updating"
+      ? "The global MCP server and connector are being updated. Keep Premiere closed."
+      : "Quit Premiere Pro. The updater will begin after it fully closes.",
+    "Scheduled",
+    true
+  );
+  return true;
+}
+
 function checkForUpdates() {
   latestUpdate = null;
+  var globalInstall = os.platform() === "win32" ? getPerUserGlobalInstall() : null;
+  var responseTooLarge = false;
   setUpdateUI(
     "Version " + MCPBridgeUpdater.CURRENT_VERSION,
     "Checking for updates…",
@@ -365,10 +491,10 @@ function checkForUpdates() {
   );
 
   var request = https.get(
-    MCPBridgeUpdater.LATEST_RELEASE_API,
+    MCPBridgeUpdater.LATEST_PACKAGE_API,
     {
       headers: {
-        Accept: "application/vnd.github+json",
+        Accept: "application/vnd.npm.install-v1+json",
         "User-Agent": "premiere-pro-mcp-connector/" + MCPBridgeUpdater.CURRENT_VERSION,
       },
     },
@@ -376,46 +502,71 @@ function checkForUpdates() {
       var body = "";
       response.setEncoding("utf8");
       response.on("data", function (chunk) {
-        if (body.length < 1024 * 1024) body += chunk;
+        if (body.length + chunk.length > MAX_UPDATE_RESPONSE_BYTES) {
+          responseTooLarge = true;
+          request.destroy(new Error("npm registry update record was unexpectedly large."));
+          return;
+        }
+        body += chunk;
       });
       response.on("end", function () {
+        if (responseTooLarge) return;
         if (response.statusCode !== 200) {
-          showUpdateCheckError("Could not check GitHub (HTTP " + response.statusCode + ").");
+          showUpdateCheckError("Could not check npm (HTTP " + response.statusCode + ").");
           return;
         }
         try {
-          var release = JSON.parse(body);
-          var latestVersion = MCPBridgeUpdater.normalizeVersion(
-            release.tag_name || release.name
+          var update = MCPBridgeUpdater.updateStateFromPackageRecord(
+            MCPBridgeUpdater.CURRENT_VERSION,
+            JSON.parse(body)
           );
-          if (!latestVersion) throw new Error("Release has no version");
+          var serverUpdateAvailable = Boolean(
+            globalInstall &&
+            MCPBridgeUpdater.compareVersions(update.latestVersion, globalInstall.serverVersion) > 0
+          );
+          var needsUpdate = update.updateAvailable || serverUpdateAvailable;
 
-          if (
-            MCPBridgeUpdater.compareVersions(
-              latestVersion,
-              MCPBridgeUpdater.CURRENT_VERSION
-            ) > 0
-          ) {
+          if (needsUpdate) {
             latestUpdate = {
-              version: latestVersion,
-              url: MCPBridgeUpdater.chooseDownloadUrl(release),
+              version: update.latestVersion,
             };
-            setUpdateUI(
-              "Version " + latestVersion + " is available",
-              "Download it, then close Premiere and run the installer.",
-              "Download update",
-              false
-            );
+            if (os.platform() === "win32" && globalInstall) {
+              var versionSummary =
+                "Server " + globalInstall.serverVersion + ", connector " + MCPBridgeUpdater.CURRENT_VERSION + ". ";
+              setUpdateUI(
+                "Version " + update.latestVersion + " is available",
+                versionSummary + "Update both together after you close Premiere.",
+                "Update after quit",
+                false
+              );
+            } else if (os.platform() === "win32") {
+              setUpdateUI(
+                "Version " + update.latestVersion + " is available",
+                "A global npm install was not found. This panel will not modify a source checkout.",
+                "Open instructions",
+                false
+              );
+            } else {
+              setUpdateUI(
+                "Version " + update.latestVersion + " is available",
+                "Open the matching release, then update your local server using the documented install path.",
+                "Open instructions",
+                false
+              );
+            }
           } else {
+            var currentDetail = globalInstall
+              ? "Server " + globalInstall.serverVersion + " and connector " + MCPBridgeUpdater.CURRENT_VERSION + " are current."
+              : "Your connector release is current. This check does not alter your projects or MCP client configuration.";
             setUpdateUI(
               "Version " + MCPBridgeUpdater.CURRENT_VERSION,
-              "You have the latest connector.",
+              currentDetail,
               "Check again",
               false
             );
           }
         } catch (e) {
-          showUpdateCheckError("GitHub returned an unreadable release.");
+          showUpdateCheckError("npm returned an unreadable package record.");
         }
       });
     }
@@ -424,7 +575,9 @@ function checkForUpdates() {
     request.destroy(new Error("Update check timed out"));
   });
   request.on("error", function () {
-    showUpdateCheckError("Unable to check while offline.");
+    showUpdateCheckError(
+      responseTooLarge ? "npm returned an unexpectedly large package record." : "Unable to check while offline."
+    );
   });
 }
 
@@ -442,25 +595,46 @@ function handleUpdateClick() {
     checkForUpdates();
     return;
   }
-  if (!MCPBridgeUpdater.isTrustedDownloadUrl(latestUpdate.url)) {
-    showUpdateCheckError("The update link was not trusted.");
+
+  if (os.platform() !== "win32") {
+    openTrustedUpdateInstructions();
     return;
   }
+
+  var cliPath = getPerUserGlobalCommand();
+  if (!cliPath) {
+    openTrustedUpdateInstructions();
+    return;
+  }
+
+  var confirmation =
+    "Update Premiere MCP to " + latestUpdate.version + " after Premiere Pro fully closes?\n\n" +
+    "This updates only the per-user global MCP server and its connector. " +
+    "It does not change your projects or MCP client configuration, and it will not force Premiere to close.";
+  if (typeof window.confirm === "function" && !window.confirm(confirmation)) return;
+
   try {
     var childProcess = nodeRequire("child_process");
-    var command =
-      os.platform() === "win32"
-        ? ["cmd.exe", ["/d", "/s", "/c", "start", "", latestUpdate.url]]
-        : ["open", [latestUpdate.url]];
-    var child = childProcess.spawn(command[0], command[1], {
-      detached: true,
-      stdio: "ignore",
+    var nodeCrypto = nodeRequire("crypto");
+    var scheduled = MCPBridgeUpdater.scheduleWindowsGlobalUpdate({
+      cliPath: cliPath,
+      runtime: {
+        fs: fs,
+        path: path,
+        os: os,
+        childProcess: childProcess,
+        crypto: nodeCrypto,
+      },
     });
-    child.unref();
-    document.getElementById("updateDetail").textContent =
-      "Download opened. Close Premiere before installing.";
+    saveUpdateStatusPath(scheduled.statusPath);
+    setUpdateUI(
+      "Update scheduled",
+      "Quit Premiere Pro. The updater will refresh the global server and connector after it fully closes.",
+      "Scheduled",
+      true
+    );
   } catch (e) {
-    showUpdateCheckError("Could not open the download. Try again.");
+    showUpdateCheckError("Could not schedule the local update. No files were changed.");
   }
 }
 
@@ -488,5 +662,5 @@ function handleUpdateClick() {
   startBridgeHeartbeat();
   log("Auto-starting bridge...");
   setTimeout(startBridge, 500);
-  setTimeout(checkForUpdates, 1200);
+  if (!restoreScheduledUpdateStatus()) setTimeout(checkForUpdates, 1200);
 })();

--- a/cep-plugin/updater.cjs
+++ b/cep-plugin/updater.cjs
@@ -8,6 +8,8 @@
   "use strict";
 
   var CURRENT_VERSION = "1.14.7";
+  var PACKAGE_NAME = "premiere-pro-mcp";
+  var LATEST_PACKAGE_API = "https://registry.npmjs.org/" + PACKAGE_NAME;
   var LATEST_RELEASE_API =
     "https://api.github.com/repos/leancoderkavy/premiere-pro-mcp/releases/latest";
   var RELEASES_URL =
@@ -31,6 +33,32 @@
       if (aPart < bPart) return -1;
     }
     return 0;
+  }
+
+  function latestPackageVersion(record) {
+    if (!record || typeof record !== "object") {
+      throw new Error("The npm registry returned an invalid package record.");
+    }
+    var tags = record["dist-tags"];
+    var latest = tags && tags.latest;
+    var version = normalizeVersion(latest);
+    if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
+      throw new Error("The npm registry did not provide a valid latest version.");
+    }
+    return version;
+  }
+
+  function updateStateFromPackageRecord(currentVersion, record) {
+    var current = normalizeVersion(currentVersion);
+    if (!current || !/^\d+\.\d+\.\d+$/.test(current)) {
+      throw new Error("The installed connector version is invalid.");
+    }
+    var latest = latestPackageVersion(record);
+    return {
+      currentVersion: current,
+      latestVersion: latest,
+      updateAvailable: compareVersions(latest, current) > 0,
+    };
   }
 
   function chooseDownloadUrl(release) {
@@ -62,13 +90,115 @@
     );
   }
 
+  function powerShellLiteral(value) {
+    return "'" + String(value).replace(/'/g, "''") + "'";
+  }
+
+  function randomSuffix(runtime) {
+    if (runtime.crypto && typeof runtime.crypto.randomBytes === "function") {
+      return runtime.crypto.randomBytes(12).toString("hex");
+    }
+    return String(new Date().getTime()) + "-" + String(Math.random()).slice(2);
+  }
+
+  /**
+   * The CEP panel cannot replace its own files safely while Premiere is running.
+   * This small, detached helper waits for Premiere to close, then invokes the
+   * already-installed per-user npm command. It does not receive project data,
+   * MCP configuration, or credentials, and it never force-quits Premiere.
+   */
+  function buildWindowsGlobalUpdateScript(cliPath, statusPath, scriptPath) {
+    return [
+      "$ErrorActionPreference = 'Stop'",
+      "$cliPath = " + powerShellLiteral(cliPath),
+      "$statusPath = " + powerShellLiteral(statusPath),
+      "$scriptPath = " + powerShellLiteral(scriptPath),
+      "function Write-UpdateStatus([string]$state) {",
+      "  $payload = @{ schemaVersion = 'premiere-pro-mcp.desktop-update.v1'; state = $state; updatedAt = [DateTime]::UtcNow.ToString('o') } | ConvertTo-Json -Compress",
+      "  [System.IO.File]::WriteAllText($statusPath, $payload, [System.Text.UTF8Encoding]::new($false))",
+      "}",
+      "try {",
+      "  Write-UpdateStatus 'waiting_for_premiere'",
+      "  $premiereProcesses = @('Adobe Premiere Pro', 'Adobe Premiere Pro Beta')",
+      "  while (Get-Process -Name $premiereProcesses -ErrorAction SilentlyContinue) { Start-Sleep -Seconds 2 }",
+      "  Write-UpdateStatus 'updating'",
+      "  $npmCommand = (Get-Command npm.cmd -ErrorAction Stop).Source",
+      "  & $npmCommand install --global 'premiere-pro-mcp@latest'",
+      "  if ($LASTEXITCODE -ne 0) { throw 'npm could not install the latest Premiere MCP package.' }",
+      "  & $cliPath --install-cep",
+      "  if ($LASTEXITCODE -ne 0) { throw 'The refreshed Premiere MCP package could not install its connector.' }",
+      "  Write-UpdateStatus 'complete'",
+      "} catch {",
+      "  Write-UpdateStatus 'failed'",
+      "  exit 1",
+      "} finally {",
+      "  Remove-Item -LiteralPath $scriptPath -Force -ErrorAction SilentlyContinue",
+      "}",
+      "",
+    ].join("\r\n");
+  }
+
+  function scheduleWindowsGlobalUpdate(options) {
+    if (!options || !options.runtime) throw new Error("A local updater runtime is required.");
+    var runtime = options.runtime;
+    var fs = runtime.fs;
+    var path = runtime.path;
+    var os = runtime.os;
+    var childProcess = runtime.childProcess;
+    if (!fs || !path || !os || !childProcess) {
+      throw new Error("The local updater runtime is unavailable.");
+    }
+
+    var cliPath = String(options.cliPath || "");
+    if (!cliPath || typeof path.isAbsolute !== "function" || !path.isAbsolute(cliPath)) {
+      throw new Error("The per-user Premiere MCP command could not be resolved.");
+    }
+    if (typeof fs.existsSync === "function" && !fs.existsSync(cliPath)) {
+      throw new Error("The per-user Premiere MCP command is not installed.");
+    }
+
+    var updateDirectory = String(options.updateDirectory || os.tmpdir());
+    if (!updateDirectory || typeof path.isAbsolute !== "function" || !path.isAbsolute(updateDirectory)) {
+      throw new Error("The local update directory is unavailable.");
+    }
+    if (typeof fs.mkdirSync === "function") fs.mkdirSync(updateDirectory, { recursive: true, mode: 0o700 });
+
+    var suffix = randomSuffix(runtime);
+    var statusPath = path.join(updateDirectory, "premiere-pro-mcp-update-" + suffix + ".json");
+    var scriptPath = path.join(updateDirectory, "premiere-pro-mcp-update-" + suffix + ".ps1");
+    var script = buildWindowsGlobalUpdateScript(cliPath, statusPath, scriptPath);
+    fs.writeFileSync(scriptPath, script, { encoding: "utf8", mode: 0o600, flag: "wx" });
+
+    try {
+      var child = childProcess.spawn(
+        "powershell.exe",
+        ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", scriptPath],
+        { detached: true, windowsHide: true, stdio: "ignore" }
+      );
+      if (!child || typeof child.unref !== "function") {
+        throw new Error("The local updater could not be started.");
+      }
+      child.unref();
+      return { statusPath: statusPath };
+    } catch (error) {
+      try { fs.unlinkSync(scriptPath); } catch (cleanupError) {}
+      throw error;
+    }
+  }
+
   return {
     CURRENT_VERSION: CURRENT_VERSION,
+    PACKAGE_NAME: PACKAGE_NAME,
+    LATEST_PACKAGE_API: LATEST_PACKAGE_API,
     LATEST_RELEASE_API: LATEST_RELEASE_API,
     RELEASES_URL: RELEASES_URL,
     normalizeVersion: normalizeVersion,
     compareVersions: compareVersions,
+    latestPackageVersion: latestPackageVersion,
+    updateStateFromPackageRecord: updateStateFromPackageRecord,
     chooseDownloadUrl: chooseDownloadUrl,
     isTrustedDownloadUrl: isTrustedDownloadUrl,
+    buildWindowsGlobalUpdateScript: buildWindowsGlobalUpdateScript,
+    scheduleWindowsGlobalUpdate: scheduleWindowsGlobalUpdate,
   };
 });

--- a/docs/distribution-readiness.md
+++ b/docs/distribution-readiness.md
@@ -43,11 +43,20 @@ For a global npm installation, users can run `premiere-pro-mcp --check-update`
 to see the current npm `latest` version. After fully quitting Premiere,
 `premiere-pro-mcp --update` installs that published package and refreshes the
 per-user CEP connector. It does not alter MCP client configuration or project
-files. Source users can run `npm run check-update:source` and then
-`npm run update:source`; the source path refuses dirty or locally-ahead
-checkouts and uses a fast-forward-only update before rebuilding and refreshing
-the connector. Claude Desktop `.mcpb` bundles remain user-installed extension
-packages and must be replaced from the matching release asset.
+files. On Windows, a global npm installation can instead select **Update after
+quit** in the MCP for Adobe Premiere Pro panel. The panel shows the global server and connector
+versions, requires confirmation, and launches a detached per-user helper. That
+helper waits for Premiere to close without forcing it, invokes the same
+published npm installation and connector-refresh path, and records only a
+bounded completion state for the panel's next launch. This keeps upgrades
+working for older global versions that do not expose `--update`. It never
+changes a project, MCP client
+configuration, source checkout, or custom npm-prefix install. Source users can
+run `npm run check-update:source` and then `npm run update:source`; the source
+path refuses dirty or locally-ahead checkouts and uses a fast-forward-only
+update before rebuilding and refreshing the connector. Claude Desktop `.mcpb`
+bundles remain user-installed extension packages and must be replaced from the
+matching release asset.
 
 ## Connector removal
 

--- a/tests/cep-install.test.ts
+++ b/tests/cep-install.test.ts
@@ -56,7 +56,14 @@ describe("CEP installation metadata", () => {
     expect(workflow).toContain("release:");
     expect(workflow).toContain("artifacts/MCPBridgeCEP.zxp");
     expect(panel).toContain('src="updater.cjs"');
-    expect(panelLogic).toContain("Download update");
+    expect(panel).toContain("MCP updates");
+    expect(panel).toContain('aria-describedby="updateDetail"');
+    expect(panelLogic).toContain("Update after quit");
+    expect(panelLogic).toContain("scheduleWindowsGlobalUpdate");
+    expect(panelLogic).toContain("window.confirm");
+    expect(panelLogic).toContain("getPerUserGlobalInstall");
+    expect(panelLogic).toContain("LATEST_PACKAGE_API");
+    expect(panelLogic).toContain("This panel will not modify a source checkout.");
     expect(panelLogic).toContain("writeResponseFile(resFilePath, response)");
     expect(panelLogic).toContain("fs.renameSync(stagedPath, filePath)");
     expect(panelLogic).toContain('"bridge-heartbeat.json"');

--- a/tests/cep-updater.test.ts
+++ b/tests/cep-updater.test.ts
@@ -1,6 +1,6 @@
 import { createRequire } from "node:module";
-import { join } from "node:path";
-import { describe, expect, it } from "vitest";
+import { join, win32 } from "node:path";
+import { describe, expect, it, vi } from "vitest";
 
 const require = createRequire(import.meta.url);
 const updater = require(join(process.cwd(), "cep-plugin", "updater.cjs"));
@@ -34,5 +34,76 @@ describe("CEP connector updater", () => {
   it("rejects untrusted download hosts", () => {
     expect(updater.isTrustedDownloadUrl("https://github.com/example/file.zxp")).toBe(true);
     expect(updater.isTrustedDownloadUrl("https://evil.example/file.zxp")).toBe(false);
+  });
+
+  it("reads the latest global package version from the npm registry record", () => {
+    const update = updater.updateStateFromPackageRecord("1.14.7", {
+      "dist-tags": { latest: "v1.14.8" },
+    });
+
+    expect(updater.LATEST_PACKAGE_API).toBe("https://registry.npmjs.org/premiere-pro-mcp");
+    expect(update).toEqual({
+      currentVersion: "1.14.7",
+      latestVersion: "1.14.8",
+      updateAvailable: true,
+    });
+    expect(() => updater.latestPackageVersion({ "dist-tags": { latest: "nightly" } }))
+      .toThrow("valid latest version");
+  });
+
+  it("creates a detached Windows updater that waits for Premiere instead of closing it", () => {
+    const scriptPath = "C:\\Temp\\premiere-pro-mcp-update-abc.ps1";
+    const statusPath = "C:\\Temp\\premiere-pro-mcp-update-abc.json";
+    const cliPath = "C:\\Users\\editor\\AppData\\Roaming\\npm\\premiere-pro-mcp.cmd";
+    const script = updater.buildWindowsGlobalUpdateScript(cliPath, statusPath, scriptPath);
+
+    expect(script).toContain("while (Get-Process -Name $premiereProcesses");
+    expect(script).toContain("Start-Sleep -Seconds 2");
+    expect(script).toContain("Get-Command npm.cmd");
+    expect(script).toContain("& $npmCommand install --global 'premiere-pro-mcp@latest'");
+    expect(script).toContain("& $cliPath --install-cep");
+    expect(script).toContain("premiere-pro-mcp.desktop-update.v1");
+    expect(script).not.toContain("Stop-Process");
+  });
+
+  it("schedules only an existing absolute per-user command and cleans up if launch fails", () => {
+    const writes = new Map<string, string>();
+    const unref = vi.fn();
+    const spawn = vi.fn(() => ({ unref }));
+    const runtime = {
+      fs: {
+        existsSync: vi.fn(() => true),
+        mkdirSync: vi.fn(),
+        writeFileSync: vi.fn((file: string, value: string) => writes.set(file, value)),
+        unlinkSync: vi.fn(),
+      },
+      path: win32,
+      os: { tmpdir: () => "C:\\Temp" },
+      childProcess: { spawn },
+      crypto: { randomBytes: () => Buffer.from("abcdef", "hex") },
+    };
+    const cliPath = "C:\\Users\\editor\\AppData\\Roaming\\npm\\premiere-pro-mcp.cmd";
+    const scheduled = updater.scheduleWindowsGlobalUpdate({ cliPath, runtime });
+
+    expect(scheduled.statusPath).toBe("C:\\Temp\\premiere-pro-mcp-update-abcdef.json");
+    expect(writes.get("C:\\Temp\\premiere-pro-mcp-update-abcdef.ps1"))
+      .toContain("& $npmCommand install --global 'premiere-pro-mcp@latest'");
+    expect(spawn).toHaveBeenCalledWith(
+      "powershell.exe",
+      ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "C:\\Temp\\premiere-pro-mcp-update-abcdef.ps1"],
+      { detached: true, windowsHide: true, stdio: "ignore" },
+    );
+    expect(unref).toHaveBeenCalledOnce();
+
+    expect(() => updater.scheduleWindowsGlobalUpdate({ cliPath: "relative.cmd", runtime }))
+      .toThrow("could not be resolved");
+
+    const failingRuntime = {
+      ...runtime,
+      childProcess: { spawn: vi.fn(() => { throw new Error("launch failed"); }) },
+    };
+    expect(() => updater.scheduleWindowsGlobalUpdate({ cliPath, runtime: failingRuntime }))
+      .toThrow("launch failed");
+    expect(runtime.fs.unlinkSync).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary\n- add a confirmation-gated Windows panel flow that checks the global server and CEP connector against npm latest\n- schedule a detached, per-user helper that waits for Premiere to close without forcing it, upgrades the global npm package, and installs the matching connector\n- keep source checkouts, custom npm prefixes, MCP client configuration, and projects out of scope\n\n## Verification\n- 
pm run check (131 files, 2,440 tests)\n- 
pm run pack:check\n- generated PowerShell helper syntax parsed successfully\n- installed the branch CEP connector locally and verified that a real Premiere instance answered erify_premiere_connection through the CEP bridge\n\n## Evidence boundary\n- Desktop UI automation could not expose Premiere's panel in this environment, so the click/confirmation surface was covered by automated tests and the installed connector was verified through the live read-only MCP bridge.\n- The background helper was not allowed to run through a real update because that would modify the active global installation; its scheduling and wait-for-Premiere behavior are covered by focused tests and PowerShell parsing.