### PR TITLE
docs: refresh README release highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,31 @@ The AI handles the entire workflow through 328 core tools spanning the supported
 
 ### Latest release: 1.14.7
 
-- **Guarded UXP editing:** compatible hosts can use verified sequence ranges,
-  display formats, playhead, marker, transition, caption, silence-cut, and split-edit workflows.
-- **Review-first evidence:** local delivery checks, sampled media analysis, and
-  editorial context packs remain bounded and avoid unapproved provider writes.
-- **Narrowed host behavior:** unsupported sequence pixel-aspect ratios and
-  partial UXP transition writes fail closed; other mutations retain their
-  documented verified or explicitly `committed_unverified` outcome.
+- **New UXP inspection:** compatible hosts can inspect source-proxy readiness
+  (with an explicit opt-in before an attached proxy path is disclosed) and the
+  endpoint displacement of one animated PointF effect parameter. Both are
+  read-only, bounded inspections—not proof of proxy compatibility or rendered
+  appearance.
+- **Desktop protocol fallback:** if a client cannot negotiate the modern
+  server mode over stdio, set `PREMIERE_MCP_PROTOCOL_MODE=legacy` in that
+  client's server environment and restart it. `auto` remains the default; see
+  [current protocol support](#current-mcp-protocol-support) for the boundary.
+- **Guarded UXP editing from 1.14.6:** compatible hosts can use verified
+  sequence ranges, display formats, playhead, marker batches, transitions,
+  caption-track inventory, silence-cut stringouts, beat-grid markers, and
+  atomic split-edit workflows.
+- **Review and delivery evidence from 1.14.6:** editorial context packs,
+  local delivery conformance, sampled video scopes and motion analysis, Warp
+  Stabilizer status inspection, and shot-match plans remain bounded and avoid
+  unapproved provider writes.
+- **Fail-closed outcomes:** unsupported sequence pixel-aspect ratios, partial
+  UXP transition writes, unavailable media-timing readback, and incomplete
+  delivery probes reject rather than reporting success. Other mutations retain
+  their documented verified or explicitly `committed_unverified` outcome.
 - **Explicit boundary:** the hosted endpoint remains an operator-managed MCP
   service; unauthenticated callers are rejected and it does not pair users to
-  local Premiere processes.
+  local Premiere processes. See the generated [supported action catalog](docs/supported-actions.md)
+  for individual capability and verification contracts.
 
 See the [v1.14.7 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.14.7)
 for complete details. Live installation in Premiere Pro still requires host verification.


### PR DESCRIPTION
## What does this PR do?

Refreshes the README's 1.14.7 release highlights from the merged work of the last seven days. It now calls out the new bounded UXP inspections, the desktop legacy-protocol fallback, concrete 1.14.6 guarded editing and review/delivery workflows, specific fail-closed cases, and the canonical action catalog.

## Related Issue

N/A

## Type of Change

- [x] Documentation

## New Tools Added (if any)

None.

**Total tool count after this PR:** unchanged (328 core; 417 with a connected UXP bridge)

## Validation

- [x] `npm run build`
- [x] `npm run docs:supported-actions:check`
- [x] `npm run docs:quickstart:check`
- [x] `npm test` (2,437 tests across 131 files)
- [x] `git diff --check`
- [x] No Premiere host test claimed; this PR changes documentation only.