### PR TITLE
feat: add previewable doctor repair plans

### DIFF
--- a/docs/ai-editorial-workflows.md
+++ b/docs/ai-editorial-workflows.md
@@ -121,6 +121,12 @@ structural acceptance only. Verify playback or exported frames before delivery.
 There is no supported raw-caption, translation, or transcription invocation in
 this MCP server.
 
+Local installation recovery is separate from editorial work. Use
+`premiere-pro-mcp --doctor --plan-fixes` to review privacy-safe local repair
+guidance before starting a workflow. It cannot establish a Premiere connection;
+see [previewable doctor repair plans](doctor-repair-plans.md) for the explicit
+connector-backup and post-repair boundary.
+
 ## Adobe and provider boundaries
 
 `get_advanced_feature_support` now reports an explicit access mode:

--- a/docs/doctor-repair-plans.md
+++ b/docs/doctor-repair-plans.md
@@ -1,0 +1,50 @@
+# Previewable local doctor repair plans
+
+## Status
+
+`premiere-pro-mcp --doctor` reports local installation/configuration facts only.
+It does not inspect a project, send an MCP request, open Premiere, read a
+token, or prove that a host connection works.
+
+Every component now includes a stable diagnostic code, such as
+`CEP_CONNECTOR_MISSING`, `NODE_RUNTIME_UNSUPPORTED`, or
+`PREMIERE_HOST_NOT_CHECKED`. Codes are safe to include in a support request;
+the report excludes paths, tokens, environment values, prompts, project data,
+and tool arguments/results.
+
+## Preview first
+
+```powershell
+premiere-pro-mcp --doctor --plan-fixes
+```
+
+This emits a no-write JSON repair plan. The plan can recommend one of four
+actions:
+
+- install the missing local CEP connector;
+- install a supported Node.js runtime;
+- configure UXP only if that backend is desired;
+- run a safe client-to-Premiere connection check.
+
+Only a missing CEP connector on Windows or macOS is eligible for local
+automation. Node installation, UXP setup, and live connection checks remain
+manual because they require authority outside the local package or a live host.
+
+## Apply an eligible connector repair
+
+Fully quit Premiere Pro, then make that closure explicit:
+
+```powershell
+premiere-pro-mcp --doctor --apply-fixes --confirm-premiere-closed
+```
+
+Without `--confirm-premiere-closed`, `--apply-fixes` makes no changes and
+returns `withheld`. With confirmation, the command can move an incomplete
+local connector directory to a timestamped backup, run the existing connector
+installer, and rerun the local doctor check. The backup is retained; this flow
+does not delete it automatically.
+
+The result distinguishes `applied`, `withheld`, `manual_required`, and `failed`.
+It never reports Premiere open, an MCP client connected, a selected project, or
+an editing/rendering outcome. After an `applied` local check, restart Premiere
+and run the safe connection check from the MCP client before editing.

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -14,7 +14,9 @@ export type ReadinessBoundary =
 export type ReadinessState = "ready" | "needs_attention" | "not_checked";
 
 export interface ReadinessComponent {
-  id: "mcp_process" | "premiere_connector" | "premiere_host" | "active_project" | "active_sequence" | "uxp_bridge";
+  id: "mcp_process" | "node_runtime" | "premiere_connector" | "premiere_host" | "active_project" | "active_sequence" | "uxp_bridge";
+  /** Stable, privacy-safe category for support and repair routing. */
+  code: string;
   label: string;
   boundary: ReadinessBoundary;
   state: ReadinessState;
@@ -35,6 +37,26 @@ export interface LocalDoctorReport {
     includes: string[];
     excludes: string[];
   };
+}
+
+export interface DoctorRepairAction {
+  id: "install_cep_connector" | "upgrade_node_runtime" | "configure_uxp_connection" | "verify_live_connection";
+  diagnosticCode: string;
+  title: string;
+  canApplyLocally: boolean;
+  requiresPremiereClosed: boolean;
+  createsBackup: boolean;
+  instruction: string;
+  verification: string;
+}
+
+export interface DoctorRepairPlan {
+  schemaVersion: "premiere-pro-mcp.doctor-repair-plan.v1";
+  generatedAt: string;
+  overall: "ready" | "needs_attention";
+  actions: DoctorRepairAction[];
+  privacy: { excludes: string[] };
+  verificationBoundary: string;
 }
 
 export interface FirstRunReport {
@@ -100,6 +122,7 @@ function installedComponent(installed: boolean): ReadinessComponent {
   return installed
     ? {
         id: "premiere_connector",
+        code: "CEP_CONNECTOR_READY",
         label: "Premiere Connector",
         boundary: "installed",
         state: "ready",
@@ -107,6 +130,7 @@ function installedComponent(installed: boolean): ReadinessComponent {
       }
     : {
         id: "premiere_connector",
+        code: "CEP_CONNECTOR_MISSING",
         label: "Premiere Connector",
         boundary: "installed",
         state: "needs_attention",
@@ -118,6 +142,14 @@ function installedComponent(installed: boolean): ReadinessComponent {
 function nodeMajor(nodeVersion: string): number | null {
   const match = /^v?(\d+)/.exec(nodeVersion);
   return match ? Number(match[1]) : null;
+}
+
+function nodeRuntimeReady(nodeVersion: string): boolean {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)/.exec(nodeVersion);
+  if (!match) return false;
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  return major > 20 || (major === 20 && minor >= 19);
 }
 
 function cepManifestPath(platform: NodeJS.Platform, environment: NodeJS.ProcessEnv): string | null {
@@ -147,14 +179,27 @@ export function collectLocalDoctor(options: LocalDoctorOptions = {}): LocalDocto
   const components: ReadinessComponent[] = [
     {
       id: "mcp_process",
+      code: "MCP_SERVER_LOCAL",
       label: "MCP server",
       boundary: "installed",
       state: "ready",
       message: "This copy of Premiere MCP can run on this computer.",
     },
+    {
+      id: "node_runtime",
+      code: nodeRuntimeReady(nodeVersion) ? "NODE_RUNTIME_SUPPORTED" : "NODE_RUNTIME_UNSUPPORTED",
+      label: "Node.js runtime",
+      boundary: "installed",
+      state: nodeRuntimeReady(nodeVersion) ? "ready" : "needs_attention",
+      message: nodeRuntimeReady(nodeVersion)
+        ? "The local Node.js runtime meets Premiere MCP's supported minimum."
+        : "The local Node.js runtime is below the supported Node.js 20.19 minimum or could not be identified.",
+      ...(nodeRuntimeReady(nodeVersion) ? {} : { repair: "Install a supported Node.js runtime, then run the local check again." }),
+    },
     installedComponent(connectorInstalled),
     {
       id: "uxp_bridge",
+      code: uxpConfigured ? "UXP_CONNECTION_CONFIGURED" : "UXP_CONNECTION_NOT_CONFIGURED",
       label: "UXP connection",
       boundary: "configured",
       state: uxpConfigured ? "ready" : "not_checked",
@@ -164,6 +209,7 @@ export function collectLocalDoctor(options: LocalDoctorOptions = {}): LocalDocto
     },
     {
       id: "premiere_host",
+      code: "PREMIERE_HOST_NOT_CHECKED",
       label: "Live Premiere check",
       boundary: "live_verified",
       state: "not_checked",
@@ -179,12 +225,86 @@ export function collectLocalDoctor(options: LocalDoctorOptions = {}): LocalDocto
       platform,
       nodeMajor: nodeMajor(nodeVersion),
     },
-    overall: connectorInstalled ? "ready" : "needs_attention",
+    overall: connectorInstalled && nodeRuntimeReady(nodeVersion) ? "ready" : "needs_attention",
     components,
     privacy: {
       includes: ["component readiness", "operating system", "Node.js major version"],
       excludes: PRIVACY_EXCLUSIONS,
     },
+  };
+}
+
+/**
+ * Build a no-write repair plan from local readiness facts. It intentionally
+ * cannot inspect or repair a running Premiere host, a project, a sequence, or
+ * any secret-bearing configuration.
+ */
+export function createDoctorRepairPlan(report: LocalDoctorReport): DoctorRepairPlan {
+  const actions: DoctorRepairAction[] = [];
+  const runtime = report.components.find((component) => component.id === "node_runtime");
+  const connector = report.components.find((component) => component.id === "premiere_connector");
+  const uxp = report.components.find((component) => component.id === "uxp_bridge");
+  const host = report.components.find((component) => component.id === "premiere_host");
+
+  if (runtime?.state === "needs_attention") {
+    actions.push({
+      id: "upgrade_node_runtime",
+      diagnosticCode: runtime.code,
+      title: "Install a supported Node.js runtime",
+      canApplyLocally: false,
+      requiresPremiereClosed: false,
+      createsBackup: false,
+      instruction: "Install Node.js 20.19 or later using your approved system package process, then rerun premiere-pro-mcp --doctor.",
+      verification: "A new local doctor report must show NODE_RUNTIME_SUPPORTED. This does not verify Premiere.",
+    });
+  }
+  if (connector?.state === "needs_attention") {
+    const canApplyLocally = report.runtime.platform === "win32" || report.runtime.platform === "darwin";
+    actions.push({
+      id: "install_cep_connector",
+      diagnosticCode: connector.code,
+      title: "Install the local Premiere Connector",
+      canApplyLocally,
+      requiresPremiereClosed: true,
+      createsBackup: true,
+      instruction: canApplyLocally
+        ? "Fully quit Premiere Pro. --apply-fixes can back up an incomplete local connector directory, run the existing connector installer, and rerun the local check."
+        : "Install the Premiere Connector on a supported Windows or macOS computer, then rerun the local check.",
+      verification: "A new local doctor report can verify installed connector files only; it cannot verify that Premiere is open or connected.",
+    });
+  }
+  if (uxp?.state === "not_checked") {
+    actions.push({
+      id: "configure_uxp_connection",
+      diagnosticCode: uxp.code,
+      title: "Configure UXP only when you choose that backend",
+      canApplyLocally: false,
+      requiresPremiereClosed: false,
+      createsBackup: false,
+      instruction: "Set up the authenticated local UXP bridge through the documented client and panel flow. Do not paste a token into a support bundle or repair plan.",
+      verification: "A local check can report only that a token is configured, never the token value or a live host connection.",
+    });
+  }
+  if (host?.state === "not_checked") {
+    actions.push({
+      id: "verify_live_connection",
+      diagnosticCode: host.code,
+      title: "Run a safe live connection check",
+      canApplyLocally: false,
+      requiresPremiereClosed: false,
+      createsBackup: false,
+      instruction: "Open Premiere Pro and use your MCP client's safe connection check before editing.",
+      verification: "This is the first step that can establish a client-to-host connection; it still does not verify playback or render quality.",
+    });
+  }
+
+  return {
+    schemaVersion: "premiere-pro-mcp.doctor-repair-plan.v1",
+    generatedAt: report.generatedAt,
+    overall: report.overall,
+    actions,
+    privacy: { excludes: [...report.privacy.excludes] },
+    verificationBoundary: "This no-write plan contains local readiness guidance only. It does not expose paths, tokens, project data, or host state, and it cannot claim a repair or live Premiere connection.",
   };
 }
 
@@ -195,6 +315,7 @@ export function buildFirstRunReport(
 ): FirstRunReport {
   const mcpProcess: ReadinessComponent = {
     id: "mcp_process",
+    code: "MCP_SERVER_CONNECTED",
     label: "AI assistant connection",
     boundary: "connected",
     state: "ready",
@@ -215,6 +336,7 @@ export function buildFirstRunReport(
         mcpProcess,
         {
           id: "premiere_connector",
+          code: "PREMIERE_CONNECTOR_UNREACHABLE",
           label: "Premiere Connector",
           boundary: "connected",
           state: "needs_attention",
@@ -223,6 +345,7 @@ export function buildFirstRunReport(
         },
         {
           id: "active_project",
+          code: "ACTIVE_PROJECT_NOT_CHECKED",
           label: "Active project",
           boundary: "live_verified",
           state: "not_checked",
@@ -230,6 +353,7 @@ export function buildFirstRunReport(
         },
         {
           id: "active_sequence",
+          code: "ACTIVE_SEQUENCE_NOT_CHECKED",
           label: "Active sequence",
           boundary: "live_verified",
           state: "not_checked",
@@ -247,6 +371,7 @@ export function buildFirstRunReport(
     mcpProcess,
     {
       id: "premiere_connector",
+      code: "PREMIERE_CONNECTOR_CONNECTED",
       label: "Premiere Connector",
       boundary: "connected",
       state: "ready",
@@ -254,6 +379,7 @@ export function buildFirstRunReport(
     },
     {
       id: "active_project",
+      code: projectOpen ? "ACTIVE_PROJECT_OPEN" : "ACTIVE_PROJECT_MISSING",
       label: "Active project",
       boundary: "live_verified",
       state: projectOpen ? "ready" : "needs_attention",
@@ -264,6 +390,7 @@ export function buildFirstRunReport(
     },
     {
       id: "active_sequence",
+      code: sequenceOpen ? "ACTIVE_SEQUENCE_OPEN" : "ACTIVE_SEQUENCE_MISSING",
       label: "Active sequence",
       boundary: "live_verified",
       state: sequenceOpen ? "ready" : "needs_attention",

--- a/src/doctor-repairs.ts
+++ b/src/doctor-repairs.ts
@@ -1,0 +1,156 @@
+import { existsSync, renameSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import {
+  collectLocalDoctor,
+  type DoctorRepairPlan,
+  type LocalDoctorReport,
+} from "./diagnostics.js";
+
+export interface DoctorRepairApplyOptions {
+  projectRoot: string;
+  confirmPremiereClosed?: boolean;
+  platform?: NodeJS.Platform;
+  environment?: NodeJS.ProcessEnv;
+  now?: () => Date;
+  exists?: (value: string) => boolean;
+  rename?: (from: string, to: string) => void;
+  runInstaller?: (platform: NodeJS.Platform, projectRoot: string) => void;
+  collect?: () => LocalDoctorReport;
+}
+
+export interface DoctorRepairResult {
+  schemaVersion: "premiere-pro-mcp.doctor-repair-result.v1";
+  applied: boolean;
+  actions: Array<{
+    id: string;
+    status: "applied" | "withheld" | "manual_required" | "failed";
+    backupCreated: boolean;
+    message: string;
+  }>;
+  doctor: LocalDoctorReport;
+  verificationBoundary: string;
+}
+
+function connectorDirectory(platform: NodeJS.Platform, environment: NodeJS.ProcessEnv): string | undefined {
+  if (platform === "win32" && environment.APPDATA) {
+    return path.join(environment.APPDATA, "Adobe", "CEP", "extensions", "MCPBridgeCEP");
+  }
+  if (platform === "darwin" && environment.HOME) {
+    return path.join(environment.HOME, "Library", "Application Support", "Adobe", "CEP", "extensions", "MCPBridgeCEP");
+  }
+  return undefined;
+}
+
+function defaultRunInstaller(platform: NodeJS.Platform, projectRoot: string): void {
+  if (platform === "win32") {
+    execFileSync("powershell.exe", [
+      "-NoProfile",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-File",
+      path.join(projectRoot, "scripts", "install-cep.ps1"),
+    ], { stdio: "inherit", cwd: projectRoot, windowsHide: true });
+    return;
+  }
+  if (platform === "darwin") {
+    execFileSync("bash", [path.join(projectRoot, "scripts", "install-cep.sh"), "--copy"], {
+      stdio: "inherit",
+      cwd: projectRoot,
+    });
+    return;
+  }
+  throw new Error(`Connector repair is unsupported on ${platform}`);
+}
+
+/**
+ * Apply only the plan's explicitly local connector repair. Existing connector
+ * content is moved aside first and never deleted by this helper. It cannot
+ * prove Premiere is closed, so that fact remains an explicit CLI confirmation.
+ */
+export function applyDoctorRepairPlan(
+  plan: DoctorRepairPlan,
+  options: DoctorRepairApplyOptions,
+): DoctorRepairResult {
+  const platform = options.platform ?? process.platform;
+  const environment = options.environment ?? process.env;
+  const now = options.now ?? (() => new Date());
+  const exists = options.exists ?? existsSync;
+  const rename = options.rename ?? renameSync;
+  const runInstaller = options.runInstaller ?? defaultRunInstaller;
+  const collect = options.collect ?? (() => collectLocalDoctor({ platform, environment }));
+  const actions: DoctorRepairResult["actions"] = [];
+  let applied = false;
+
+  for (const action of plan.actions) {
+    if (action.id !== "install_cep_connector") {
+      actions.push({
+        id: action.id,
+        status: "manual_required",
+        backupCreated: false,
+        message: action.instruction,
+      });
+      continue;
+    }
+    if (!action.canApplyLocally) {
+      actions.push({ id: action.id, status: "manual_required", backupCreated: false, message: action.instruction });
+      continue;
+    }
+    if (action.requiresPremiereClosed && options.confirmPremiereClosed !== true) {
+      actions.push({
+        id: action.id,
+        status: "withheld",
+        backupCreated: false,
+        message: "No local files were changed because Premiere closure was not explicitly confirmed. Fully quit Premiere, then rerun with --confirm-premiere-closed.",
+      });
+      continue;
+    }
+    const destination = connectorDirectory(platform, environment);
+    if (!destination) {
+      actions.push({ id: action.id, status: "manual_required", backupCreated: false, message: action.instruction });
+      continue;
+    }
+    let backupCreated = false;
+    try {
+      if (exists(destination)) {
+        const backup = `${destination}.backup-${now().toISOString().replace(/[^0-9]/g, "")}`;
+        rename(destination, backup);
+        backupCreated = true;
+      }
+      runInstaller(platform, options.projectRoot);
+      const after = collect();
+      const connector = after.components.find((component) => component.id === "premiere_connector");
+      if (connector?.state !== "ready") {
+        actions.push({
+          id: action.id,
+          status: "failed",
+          backupCreated,
+          message: "The installer finished without a ready local connector report. The retained backup was not deleted; inspect it before retrying.",
+        });
+        continue;
+      }
+      applied = true;
+      actions.push({
+        id: action.id,
+        status: "applied",
+        backupCreated,
+        message: "The connector installer completed and a fresh local check found connector files. Restart Premiere and run a safe connection check before editing.",
+      });
+    } catch {
+      actions.push({
+        id: action.id,
+        status: "failed",
+        backupCreated,
+        message: "Connector repair failed. Any backup was retained and was not deleted; run the existing connector diagnostics for local detail before retrying.",
+      });
+    }
+  }
+
+  return {
+    schemaVersion: "premiere-pro-mcp.doctor-repair-result.v1",
+    applied,
+    actions,
+    doctor: collect(),
+    verificationBoundary: "A successful local repair verifies only current local readiness components. It does not prove that Premiere is open, a client is connected, a project is selected, or an edit/render works.",
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,9 +11,11 @@ import path from "path";
 import { UxpWebSocketBridge } from "./bridge/uxp-websocket-bridge.js";
 import {
   collectLocalDoctor,
+  createDoctorRepairPlan,
   createSupportBundle,
   renderDoctorHuman,
 } from "./diagnostics.js";
+import { applyDoctorRepairPlan } from "./doctor-repairs.js";
 import { compareVersions, fetchLatestNpmVersion } from "./update.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -143,6 +145,9 @@ Usage:
   premiere-pro-mcp --diagnose-cep  Check the CEP install, debug keys, and Premiere signature logs
   premiere-pro-mcp --doctor        Check local install/configuration without reading a project
   premiere-pro-mcp --doctor --json Print the same local check as machine-readable JSON
+  premiere-pro-mcp --doctor --plan-fixes Show a no-write, privacy-safe local repair plan
+  premiere-pro-mcp --doctor --apply-fixes Apply only safe planned local fixes; requires explicit Premiere-closed confirmation where needed
+  premiere-pro-mcp --doctor --apply-fixes --confirm-premiere-closed Confirm Premiere is fully closed before a connector repair
   premiere-pro-mcp --support-bundle  Print a privacy-safe, machine-readable support bundle
   premiere-pro-mcp --check-update    Check npm for a newer released local server
   premiere-pro-mcp --update          Update an npm global install and refresh the CEP connector
@@ -182,7 +187,27 @@ if (args.includes("--version") || args.includes("-v")) {
   process.exit(0);
 }
 
+const doctorPlanRequested = args.includes("--plan-fixes");
+const doctorApplyRequested = args.includes("--apply-fixes");
+const premiereClosedConfirmed = args.includes("--confirm-premiere-closed");
+if ((doctorPlanRequested || doctorApplyRequested) && !args.includes("--doctor")) {
+  console.error("--plan-fixes and --apply-fixes require --doctor.");
+  process.exit(1);
+}
+if (doctorPlanRequested && doctorApplyRequested) {
+  console.error("Use either --plan-fixes or --apply-fixes, not both.");
+  process.exit(1);
+}
+if (premiereClosedConfirmed && !doctorApplyRequested) {
+  console.error("--confirm-premiere-closed is only valid with --doctor --apply-fixes.");
+  process.exit(1);
+}
+
 if (args.includes("--doctor") || args.includes("--support-bundle")) {
+  if (args.includes("--support-bundle") && (doctorPlanRequested || doctorApplyRequested)) {
+    console.error("--support-bundle cannot be combined with --plan-fixes or --apply-fixes.");
+    process.exit(1);
+  }
   const pkg = await import("../package.json", { with: { type: "json" } }).catch(
     () => ({ default: { version: "unknown" } }),
   );
@@ -193,9 +218,20 @@ if (args.includes("--doctor") || args.includes("--support-bundle")) {
     console.log(JSON.stringify(createSupportBundle({ version: pkg.default.version }), null, 2));
   } else {
     const report = collectLocalDoctor();
-    console.log(args.includes("--json")
-      ? JSON.stringify(report, null, 2)
-      : renderDoctorHuman(report));
+    if (doctorPlanRequested) {
+      console.log(JSON.stringify(createDoctorRepairPlan(report), null, 2));
+    } else if (doctorApplyRequested) {
+      const result = applyDoctorRepairPlan(createDoctorRepairPlan(report), {
+        projectRoot,
+        confirmPremiereClosed: premiereClosedConfirmed,
+      });
+      console.log(JSON.stringify(result, null, 2));
+      if (result.actions.some((action) => action.status === "failed")) process.exit(1);
+    } else {
+      console.log(args.includes("--json")
+        ? JSON.stringify(report, null, 2)
+        : renderDoctorHuman(report));
+    }
   }
   process.exit(0);
 }

--- a/tests/diagnostics.test.ts
+++ b/tests/diagnostics.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildFirstRunReport,
   collectLocalDoctor,
+  createDoctorRepairPlan,
   createSupportBundle,
   renderDoctorHuman,
 } from "../src/diagnostics.js";
@@ -19,9 +20,30 @@ describe("non-technical diagnostics", () => {
     expect(report.overall).toBe("ready");
     expect(report.runtime).toEqual({ platform: "win32", nodeMajor: 22 });
     expect(report.components).toEqual(expect.arrayContaining([
-      expect.objectContaining({ id: "premiere_connector", boundary: "installed", state: "ready" }),
-      expect.objectContaining({ id: "premiere_host", boundary: "live_verified", state: "not_checked" }),
+      expect.objectContaining({ id: "premiere_connector", code: "CEP_CONNECTOR_READY", boundary: "installed", state: "ready" }),
+      expect.objectContaining({ id: "premiere_host", code: "PREMIERE_HOST_NOT_CHECKED", boundary: "live_verified", state: "not_checked" }),
     ]));
+  });
+
+  it("creates a privacy-safe, no-write repair plan with stable diagnostic codes", () => {
+    const report = collectLocalDoctor({
+      platform: "win32",
+      nodeVersion: "v22.12.0",
+      environment: { APPDATA: "C:\\Users\\Example\\AppData" },
+      exists: () => false,
+      now: () => new Date("2026-09-04T00:00:00.000Z"),
+    });
+    const plan = createDoctorRepairPlan(report);
+    expect(plan).toMatchObject({
+      schemaVersion: "premiere-pro-mcp.doctor-repair-plan.v1",
+      actions: expect.arrayContaining([
+        expect.objectContaining({ id: "install_cep_connector", diagnosticCode: "CEP_CONNECTOR_MISSING", canApplyLocally: true, createsBackup: true }),
+        expect.objectContaining({ id: "verify_live_connection", diagnosticCode: "PREMIERE_HOST_NOT_CHECKED", canApplyLocally: false }),
+      ]),
+    });
+    const serialized = JSON.stringify(plan);
+    expect(serialized).not.toContain("C:\\Users\\Example");
+    expect(serialized).not.toContain("APPDATA");
   });
 
   it("proves the complete first-run lane with booleans only", () => {
@@ -84,6 +106,7 @@ describe("non-technical diagnostics", () => {
     expect(report.overall).toBe("needs_attention");
     expect(report.runtime.nodeMajor).toBeNull();
     expect(report.components).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "node_runtime", code: "NODE_RUNTIME_UNSUPPORTED", state: "needs_attention" }),
       expect.objectContaining({ id: "premiere_connector", state: "needs_attention", repair: expect.any(String) }),
       expect.objectContaining({ id: "uxp_bridge", state: "not_checked" }),
     ]));

--- a/tests/doctor-repairs.test.ts
+++ b/tests/doctor-repairs.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+import { applyDoctorRepairPlan } from "../src/doctor-repairs.js";
+import { collectLocalDoctor, createDoctorRepairPlan } from "../src/diagnostics.js";
+
+function missingConnectorReport() {
+  return collectLocalDoctor({
+    platform: "win32",
+    nodeVersion: "v22.12.0",
+    environment: { APPDATA: "C:\\Users\\Example\\AppData" },
+    exists: () => false,
+    now: () => new Date("2026-09-04T00:00:00.000Z"),
+  });
+}
+
+describe("doctor repair application", () => {
+  it("withholds a connector write until Premiere closure is explicitly confirmed", () => {
+    const runInstaller = vi.fn();
+    const result = applyDoctorRepairPlan(createDoctorRepairPlan(missingConnectorReport()), {
+      projectRoot: "D:\\fixture",
+      platform: "win32",
+      environment: { APPDATA: "C:\\Users\\Example\\AppData" },
+      runInstaller,
+      collect: missingConnectorReport,
+    });
+
+    expect(runInstaller).not.toHaveBeenCalled();
+    expect(result.actions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: "install_cep_connector", status: "withheld", backupCreated: false }),
+    ]));
+    expect(JSON.stringify(result)).not.toContain("C:\\Users\\Example");
+  });
+
+  it("backs up an incomplete connector before an explicit installer run and rechecks local readiness", () => {
+    const rename = vi.fn();
+    const runInstaller = vi.fn();
+    const readyReport = collectLocalDoctor({
+      platform: "win32",
+      nodeVersion: "v22.12.0",
+      environment: { APPDATA: "C:\\Users\\Example\\AppData" },
+      exists: () => true,
+      now: () => new Date("2026-09-04T00:00:01.000Z"),
+    });
+    const result = applyDoctorRepairPlan(createDoctorRepairPlan(missingConnectorReport()), {
+      projectRoot: "D:\\fixture",
+      platform: "win32",
+      environment: { APPDATA: "C:\\Users\\Example\\AppData" },
+      confirmPremiereClosed: true,
+      exists: () => true,
+      rename,
+      runInstaller,
+      collect: () => readyReport,
+      now: () => new Date("2026-09-04T00:00:01.000Z"),
+    });
+
+    expect(rename).toHaveBeenCalledOnce();
+    expect(runInstaller).toHaveBeenCalledWith("win32", "D:\\fixture");
+    expect(result).toMatchObject({
+      applied: true,
+      actions: expect.arrayContaining([
+        expect.objectContaining({ id: "install_cep_connector", status: "applied", backupCreated: true }),
+      ]),
+    });
+    expect(JSON.stringify(result)).not.toContain("C:\\Users\\Example");
+  });
+});

--- a/tests/entrypoints-unit.test.ts
+++ b/tests/entrypoints-unit.test.ts
@@ -213,6 +213,24 @@ describe("stdio CLI entry point", () => {
     });
   });
 
+  it("prints a no-write doctor repair plan and applies no writes without the closure confirmation", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    let loaded = await importCli(["--doctor", "--plan-fixes"]);
+    await expect(loaded.promise).rejects.toThrow("EXIT:0");
+    expect(JSON.parse(String(log.mock.calls[0][0]))).toMatchObject({
+      schemaVersion: "premiere-pro-mcp.doctor-repair-plan.v1",
+    });
+
+    vi.resetModules();
+    log.mockClear();
+    loaded = await importCli(["--doctor", "--apply-fixes"]);
+    await expect(loaded.promise).rejects.toThrow("EXIT:0");
+    expect(JSON.parse(String(log.mock.calls[0][0]))).toMatchObject({
+      schemaVersion: "premiere-pro-mcp.doctor-repair-result.v1",
+    });
+    expect(JSON.parse(String(log.mock.calls[0][0])).applied).toBe(false);
+  });
+
   it("checks for a newer release and updates a global npm installation", async () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
     mocks.fetchLatestNpmVersion.mockResolvedValueOnce("1.14.8");


### PR DESCRIPTION
Adds no-write doctor repair-plan previews and a narrowly scoped, explicitly confirmed connector reinstall. Repair application is withheld unless Premiere closure is confirmed, backs up an existing connector instead of deleting it, and never exposes paths or tokens in results. Validated with npm run check (2,441 tests).