### PR TITLE
perf: harden MCP transport scale limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1061,6 +1061,7 @@ user/device authorization are implemented.
 | `MCP_KEEP_ALIVE_TIMEOUT_MS` | Idle keep-alive socket timeout | `5000` |
 | `MCP_MAX_REQUESTS_PER_SOCKET` | Requests permitted on one keep-alive socket | `100` |
 | `MCP_MAX_CONCURRENT_REQUESTS` | In-flight authenticated MCP request ceiling | `8` |
+| `MCP_MAX_CONCURRENT_STREAMS` | Open authenticated SSE stream ceiling; isolated from operation capacity | `32` |
 | `MCP_RATE_LIMIT_PER_MINUTE` | Per-credential token-bucket refill rate | `120` |
 | `MCP_RATE_LIMIT_BURST` | Per-credential short burst allowance | `30` |
 | `MCP_MAX_RATE_LIMIT_KEYS` | In-memory rate-limit identity ceiling | `2048` |

--- a/cep-plugin/main.js
+++ b/cep-plugin/main.js
@@ -276,16 +276,20 @@ function executeScript(script, callback) {
 
 // ---- Command Processing ----
 function processCommands() {
+  if (commandInFlight) return;
   var cmdFiles = listCommandFiles();
-  for (var i = 0; i < cmdFiles.length; i++) {
-    processOneCommand(cmdFiles[i]);
-  }
+  // Premiere's scripting engine is stateful. Starting every discovered command
+  // at once lets overlapping edits race each other and overload the host. The
+  // atomic claim below still prevents duplicate work across the visible and
+  // headless panels, while this panel dispatches strictly one command at a time.
+  if (cmdFiles.length > 0) processOneCommand(cmdFiles[0]);
 }
 
 // Both the visible panel and the headless auto-start instance run this file.
 // A rename is atomic on the same volume, so whichever engine renames first owns
 // the command; the loser's rename throws and it skips the file.
 var ENGINE_ID = Math.random().toString(36).slice(2, 8);
+var commandInFlight = false;
 
 function processOneCommand(cmdFileName) {
   var cmdFilePath = path.join(tempDir, cmdFileName);
@@ -302,6 +306,8 @@ function processOneCommand(cmdFileName) {
     log("Failed to read: " + cmdFileName, "err");
     return;
   }
+
+  commandInFlight = true;
 
   // Derive response filename: cmd_12345.jsx -> res_12345.json
   var id = cmdFileName.replace("cmd_", "").replace(".jsx", "");
@@ -358,6 +364,10 @@ function processOneCommand(cmdFileName) {
     }
 
     writeResponseFile(resFilePath, response);
+    commandInFlight = false;
+    // Continue without waiting for the next poll interval, preserving FIFO
+    // ordering while minimizing queue handoff latency.
+    if (bridgeRunning) processCommands();
   });
 }
 

--- a/src/bridge/file-bridge.ts
+++ b/src/bridge/file-bridge.ts
@@ -38,6 +38,8 @@ export function getDefaultBridgeTempDir(
 const DEFAULT_TEMP_DIR = getDefaultBridgeTempDir();
 const POLL_FALLBACK_MS = 250;
 const DEFAULT_TIMEOUT_MS = 30000;
+export const MAX_QUEUED_BRIDGE_COMMANDS = 32;
+export const MAX_BRIDGE_RESPONSE_BYTES = 1_048_576;
 export const BRIDGE_HEARTBEAT_FILE = "bridge-heartbeat.json";
 export const BRIDGE_HEARTBEAT_STALE_MS = 3_000;
 
@@ -46,6 +48,62 @@ type ResponseListener = () => void;
 interface SharedResponseWatcher {
   watcher?: FSWatcher;
   listeners: Map<string, Set<ResponseListener>>;
+}
+
+interface QueuedBridgeCommand {
+  run: () => Promise<CommandResult>;
+  resolve: (result: CommandResult) => void;
+  reject: (error: unknown) => void;
+}
+
+interface BridgeCommandScheduler {
+  running: boolean;
+  pending: QueuedBridgeCommand[];
+}
+
+// One Premiere scripting engine serves each bridge directory. Serialize command
+// publication per directory so concurrent MCP requests cannot make independent
+// CEP panels issue overlapping host edits. The bounded queue fails fast instead
+// of accumulating unbounded command files and response watchers under load.
+const commandSchedulers = new Map<string, BridgeCommandScheduler>();
+
+function scheduleBridgeCommand(
+  tempDir: string,
+  run: () => Promise<CommandResult>,
+): Promise<CommandResult> {
+  let scheduler = commandSchedulers.get(tempDir);
+  if (!scheduler) {
+    scheduler = { running: false, pending: [] };
+    commandSchedulers.set(tempDir, scheduler);
+  }
+
+  if (scheduler.running && scheduler.pending.length >= MAX_QUEUED_BRIDGE_COMMANDS) {
+    return Promise.resolve({
+      success: false,
+      error: `Bridge command queue is full (${MAX_QUEUED_BRIDGE_COMMANDS} waiting); retry after an active command finishes`,
+    });
+  }
+
+  return new Promise<CommandResult>((resolve, reject) => {
+    scheduler!.pending.push({ run, resolve, reject });
+    runNextBridgeCommand(tempDir, scheduler!);
+  });
+}
+
+function runNextBridgeCommand(tempDir: string, scheduler: BridgeCommandScheduler): void {
+  if (scheduler.running) return;
+  const next = scheduler.pending.shift();
+  if (!next) {
+    commandSchedulers.delete(tempDir);
+    return;
+  }
+  scheduler.running = true;
+  void next.run()
+    .then(next.resolve, next.reject)
+    .finally(() => {
+      scheduler.running = false;
+      runNextBridgeCommand(tempDir, scheduler);
+    });
 }
 
 // CEP commands can be issued concurrently, especially when an MCP client
@@ -261,6 +319,15 @@ export async function sendCommand(
   script: string,
   options?: BridgeOptions
 ): Promise<CommandResult> {
+  validateScript(script);
+  const tempDir = getTempDir(options);
+  return scheduleBridgeCommand(tempDir, () => sendCommandUnchecked(script, options));
+}
+
+async function sendCommandUnchecked(
+  script: string,
+  options?: BridgeOptions,
+): Promise<CommandResult> {
   const tempDir = getTempDir(options);
   const timeoutMs = options?.timeoutMs || DEFAULT_TIMEOUT_MS;
   ensureDir(tempDir);
@@ -275,9 +342,6 @@ export async function sendCommand(
   const stagedCmdFile = `${cmdFile}.staged`;
   const resFile = join(tempDir, `res_${id}.json`);
   const busyFile = join(tempDir, `busy_${id}.json`);
-
-  // Validate script
-  validateScript(script);
 
   try {
     // Write a complete command before its .jsx name makes it visible to CEP.
@@ -326,6 +390,15 @@ export async function sendRawCommand(
   script: string,
   options?: BridgeOptions
 ): Promise<CommandResult> {
+  validateScript(script, true);
+  const tempDir = getTempDir(options);
+  return scheduleBridgeCommand(tempDir, () => sendRawCommandUnchecked(script, options));
+}
+
+async function sendRawCommandUnchecked(
+  script: string,
+  options?: BridgeOptions,
+): Promise<CommandResult> {
   const tempDir = getTempDir(options);
   const timeoutMs = options?.timeoutMs || DEFAULT_TIMEOUT_MS;
   ensureDir(tempDir);
@@ -341,7 +414,6 @@ export async function sendRawCommand(
   const resFile = join(tempDir, `res_${id}.json`);
   const busyFile = join(tempDir, `busy_${id}.json`);
 
-  validateScript(script, true);
   try {
     writeFileSync(stagedCmdFile, `${ensureHelpers(tempDir, options?.helpers)}
 ${script}`, "utf-8");
@@ -405,6 +477,14 @@ async function pollForResponse(
       if (settled) return;
       if (existsSync(resFile)) {
         try {
+          const responseSize = statSync(resFile).size;
+          if (responseSize > MAX_BRIDGE_RESPONSE_BYTES) {
+            finish({
+              success: false,
+              error: `Bridge response exceeds the ${MAX_BRIDGE_RESPONSE_BYTES}-byte limit`,
+            });
+            return;
+          }
           const raw = readFileSync(resFile, "utf-8");
           const result = JSON.parse(raw) as CommandResult;
           if (typeof result !== "object" || result === null || typeof result.success !== "boolean") {

--- a/src/http-admission.ts
+++ b/src/http-admission.ts
@@ -24,6 +24,7 @@ export interface HttpAdmissionSettings {
   keepAliveTimeoutMs: number;
   maxRequestsPerSocket: number;
   maxConcurrentRequests: number;
+  maxConcurrentStreams: number;
   rateLimitPerMinute: number;
   rateLimitBurst: number;
   maxRateLimitKeys: number;
@@ -32,8 +33,12 @@ export interface HttpAdmissionSettings {
 
 export interface AdmissionMetrics {
   activeRequests: number;
+  activeOperationRequests: number;
+  activeStreamRequests: number;
   trackedRateLimitKeys: number;
 }
+
+export type AdmissionLane = "operation" | "stream";
 
 export type AdmissionDecision =
   | { accepted: true; release: () => void }
@@ -76,6 +81,7 @@ export function readHttpAdmissionSettings(env: NodeJS.ProcessEnv): HttpAdmission
     keepAliveTimeoutMs: readBoundedInteger(env, "MCP_KEEP_ALIVE_TIMEOUT_MS", 5_000, 1_000, 60_000),
     maxRequestsPerSocket: readBoundedInteger(env, "MCP_MAX_REQUESTS_PER_SOCKET", 100, 1, 10_000),
     maxConcurrentRequests: readBoundedInteger(env, "MCP_MAX_CONCURRENT_REQUESTS", 8, 1, 128),
+    maxConcurrentStreams: readBoundedInteger(env, "MCP_MAX_CONCURRENT_STREAMS", 32, 1, 1_024),
     rateLimitPerMinute,
     rateLimitBurst,
     maxRateLimitKeys: readBoundedInteger(env, "MCP_MAX_RATE_LIMIT_KEYS", 2_048, 16, 100_000),
@@ -321,14 +327,15 @@ interface TokenBucket {
  */
 export class HttpAdmissionController {
   private readonly buckets = new Map<string, TokenBucket>();
-  private activeRequests = 0;
+  private activeOperationRequests = 0;
+  private activeStreamRequests = 0;
 
   constructor(
-    private readonly settings: Pick<HttpAdmissionSettings, "maxConcurrentRequests" | "rateLimitPerMinute" | "rateLimitBurst" | "maxRateLimitKeys">,
+    private readonly settings: Pick<HttpAdmissionSettings, "maxConcurrentRequests" | "maxConcurrentStreams" | "rateLimitPerMinute" | "rateLimitBurst" | "maxRateLimitKeys">,
     private readonly clock: () => number = Date.now,
   ) {}
 
-  acquire(identity: string): AdmissionDecision {
+  acquire(identity: string, lane: AdmissionLane = "operation"): AdmissionDecision {
     const now = this.clock();
     this.pruneIdleBuckets(now);
 
@@ -347,25 +354,34 @@ export class HttpAdmissionController {
       return { accepted: false, reason: "rate_limited", statusCode: 429, retryAfterSeconds };
     }
 
-    if (this.activeRequests >= this.settings.maxConcurrentRequests) {
+    const activeRequests = lane === "stream" ? this.activeStreamRequests : this.activeOperationRequests;
+    const maximumRequests = lane === "stream" ? this.settings.maxConcurrentStreams : this.settings.maxConcurrentRequests;
+    if (activeRequests >= maximumRequests) {
       return { accepted: false, reason: "at_capacity", statusCode: 503, retryAfterSeconds: 1 };
     }
 
     bucket.tokens -= 1;
-    this.activeRequests += 1;
+    if (lane === "stream") this.activeStreamRequests += 1;
+    else this.activeOperationRequests += 1;
     let released = false;
     return {
       accepted: true,
       release: () => {
         if (released) return;
         released = true;
-        this.activeRequests = Math.max(0, this.activeRequests - 1);
+        if (lane === "stream") this.activeStreamRequests = Math.max(0, this.activeStreamRequests - 1);
+        else this.activeOperationRequests = Math.max(0, this.activeOperationRequests - 1);
       },
     };
   }
 
   metrics(): AdmissionMetrics {
-    return { activeRequests: this.activeRequests, trackedRateLimitKeys: this.buckets.size };
+    return {
+      activeRequests: this.activeOperationRequests + this.activeStreamRequests,
+      activeOperationRequests: this.activeOperationRequests,
+      activeStreamRequests: this.activeStreamRequests,
+      trackedRateLimitKeys: this.buckets.size,
+    };
   }
 
   private getOrCreateBucket(identity: string, now: number): TokenBucket | undefined {

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -21,8 +21,9 @@
  *                      binds 0.0.0.0 and can drive Premiere.
  *   MCP_OAUTH_*        Alternatively configure an OAuth issuer, JWKS URI,
  *                      audience, public URL, and required scopes for per-user auth.
- *   MCP_MAX_REQUEST_BYTES, MCP_*_TIMEOUT_MS, MCP_RATE_LIMIT_* and
- *   MCP_MAX_CONCURRENT_REQUESTS bound public HTTP resource use. See README.
+ *   MCP_MAX_REQUEST_BYTES, MCP_*_TIMEOUT_MS, MCP_RATE_LIMIT_*,
+ *   MCP_MAX_CONCURRENT_REQUESTS, and MCP_MAX_CONCURRENT_STREAMS bound public
+ *   HTTP resource use. See README.
  */
 
 import http from "node:http";
@@ -37,6 +38,7 @@ import { cleanupTempDir, getTempDir } from "./bridge/file-bridge.js";
 import { getTelemetry } from "./telemetry.js";
 import { applyHttpSecurityHeaders } from "./http-security.js";
 import { OAuthResourceServer } from "./oauth-resource-server.js";
+import { ProjectContextRepository } from "./context/project-context-store.js";
 import {
   HttpAdmissionController,
   MCP_HTTP_METHODS,
@@ -216,8 +218,12 @@ const telemetry = getTelemetry();
 const admission = new HttpAdmissionController(admissionSettings);
 const preAuthAdmission = new HttpAdmissionController(admissionSettings);
 const oauthResourceServer = httpAuth.oauth ? new OAuthResourceServer(httpAuth.oauth) : undefined;
+// Streamable HTTP creates an McpServer for every request. Sharing the repository
+// keeps memory-backed context durable across those request-scoped servers and
+// avoids repeatedly opening the same JSON or SQLite store.
+const projectContextRepository = new ProjectContextRepository();
 const mcpHandler = createMcpHandler(
-  () => createServer(bridgeOptions, { telemetry }),
+  () => createServer(bridgeOptions, { telemetry, contextRepository: projectContextRepository }),
   {
     onerror: (error) => console.error("[premiere-pro-mcp] MCP handler error:", error),
   },
@@ -340,7 +346,10 @@ const httpServer = http.createServer(async (req, res) => {
   const authenticatedIdentity = oauthAuthentication?.authenticated
     ? `oauth:${oauthAuthentication.principal.rateLimitKey}`
     : "credential:shared-operator";
-  const admissionDecision = admission.acquire(authenticatedIdentity);
+  const admissionDecision = admission.acquire(
+    authenticatedIdentity,
+    req.method === "GET" ? "stream" : "operation",
+  );
   if (!admissionDecision.accepted) {
     telemetry.capture("mcp_request_rejected", {
       outcome: admissionDecision.reason,
@@ -435,6 +444,7 @@ async function shutdown(signal: string) {
   console.error(`[premiere-pro-mcp] ${signal} received, shutting down...`);
   httpServer.close();
   await mcpHandler.close();
+  await projectContextRepository.close();
   await telemetry.shutdown();
   process.exit(0);
 }

--- a/src/tools/export.ts
+++ b/src/tools/export.ts
@@ -11,6 +11,7 @@ import { parseEbur128Summary } from "./audio.js";
 const execFileAsync = promisify(execFile);
 const VIDEO_QC_TIMEOUT_MS = 300_000;
 const MAX_FAILURE_DIAGNOSTIC_LENGTH = 4_096;
+export const MAX_CAPTURE_FRAME_BYTES = 8 * 1024 * 1024;
 
 export type ConformanceStatus = "pass" | "fail" | "not_evaluated";
 
@@ -1231,8 +1232,14 @@ export function getExportTools(bridgeOptions: BridgeOptions) {
         }
 
         try {
+          const frameSize = statSync(framePath).size;
+          if (frameSize > MAX_CAPTURE_FRAME_BYTES) {
+            return {
+              success: false,
+              error: `Captured frame exceeds the ${MAX_CAPTURE_FRAME_BYTES}-byte inline response limit`,
+            };
+          }
           const base64 = readFileSync(framePath).toString("base64");
-          try { unlinkSync(framePath); } catch {}
           return {
             success: true,
             data: {
@@ -1243,6 +1250,8 @@ export function getExportTools(bridgeOptions: BridgeOptions) {
           };
         } catch (e) {
           return { success: false, error: `Failed to read captured frame: ${e instanceof Error ? e.message : String(e)}` };
+        } finally {
+          try { unlinkSync(framePath); } catch {}
         }
       },
     },

--- a/src/tools/project-context.ts
+++ b/src/tools/project-context.ts
@@ -22,6 +22,7 @@ const CORE_CONTEXT_KINDS = new Set<ProjectContextKind>(["project", "sequence", "
 const ENRICHMENT_KINDS = new Set<ProjectContextKind>(["transcript", "shot", "audio", "note"]);
 const MAX_CAPTURED_TIMELINE_ITEMS = 2_000;
 const MAX_ENRICHMENTS_PER_CALL = 512;
+export const MAX_CONCURRENT_SOURCE_FINGERPRINTS = 16;
 
 interface SnapshotClip {
   nodeId: string;
@@ -227,10 +228,18 @@ export async function buildContextDocumentFromSnapshot(
     if (clip.sourceId && !uniqueSources.has(clip.sourceId)) uniqueSources.set(clip.sourceId, clip);
   }
 
+  const sourceEntries = [...uniqueSources.entries()];
   const fingerprints = new Map<string, MediaFingerprint>();
-  await Promise.all([...uniqueSources.entries()].map(async ([sourceId, clip]) => {
-    fingerprints.set(sourceId, await fingerprint(clip.mediaPath));
-  }));
+  let nextSourceIndex = 0;
+  await Promise.all(Array.from(
+    { length: Math.min(MAX_CONCURRENT_SOURCE_FINGERPRINTS, sourceEntries.length) },
+    async () => {
+      while (nextSourceIndex < sourceEntries.length) {
+        const [sourceId, clip] = sourceEntries[nextSourceIndex++]!;
+        fingerprints.set(sourceId, await fingerprint(clip.mediaPath));
+      }
+    },
+  ));
 
   const sourceRecords: ProjectContextRecord[] = [...uniqueSources.entries()].map(([sourceId, clip]) => {
     const media = fingerprints.get(sourceId) ?? {};

--- a/tests/bridge/file-bridge-extra-coverage.test.ts
+++ b/tests/bridge/file-bridge-extra-coverage.test.ts
@@ -128,7 +128,7 @@ describe("file bridge fallback and cleanup branches", () => {
     expect(fs.unlink).toHaveBeenCalledWith(expect.stringContaining("busy_1.json"));
   });
 
-  it("skips POSIX ownership checks on Windows", async () => {
+  it("skips POSIX ownership changes on Windows while checking response bounds", async () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("win32");
     fs.exists.mockReturnValue(true);
     fs.read.mockReturnValue('{"success":true}');
@@ -136,7 +136,7 @@ describe("file bridge fallback and cleanup branches", () => {
     await expect(sendCommand("var windows = true;", {
       tempDir: "C:\\Temp\\premiere-bridge",
     })).resolves.toEqual({ success: true });
-    expect(fs.stat).not.toHaveBeenCalled();
+    expect(fs.stat).toHaveBeenCalledWith(expect.stringContaining("res_"));
     expect(fs.chmod).not.toHaveBeenCalled();
   });
 });

--- a/tests/bridge/file-bridge.test.ts
+++ b/tests/bridge/file-bridge.test.ts
@@ -361,6 +361,18 @@ describe("sendCommand", () => {
     expect(fakeWatcher.close).toHaveBeenCalledTimes(2);
   });
 
+  it("fails fast when a bridge directory already has the bounded command backlog", async () => {
+    mockedExistsSync.mockImplementation((path) => !String(path).includes("res_"));
+    const commands = Array.from({ length: 34 }, (_, index) => sendCommand(`queued-${index}`, {
+      tempDir: "/tmp/queue-capacity-bridge",
+    }));
+
+    await expect(commands[33]).resolves.toEqual({
+      success: false,
+      error: "Bridge command queue is full (32 waiting); retry after an active command finishes",
+    });
+  });
+
   it("keeps polling a malformed response without resending the command", async () => {
     mockedExistsSync.mockImplementation((path) => {
       if (String(path).includes("res_")) return true;

--- a/tests/bridge/file-bridge.test.ts
+++ b/tests/bridge/file-bridge.test.ts
@@ -19,6 +19,7 @@ import {
   getTempDir,
   getDefaultBridgeTempDir,
   getBridgeLiveness,
+  MAX_BRIDGE_RESPONSE_BYTES,
   sendCommand,
   sendRawCommand,
   cleanupTempDir,
@@ -149,6 +150,7 @@ describe("sendCommand", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    mockedStatSync.mockReturnValue({ uid: myUid, mode: 0o700 } as unknown as ReturnType<typeof statSync>);
   });
 
   afterEach(() => {
@@ -249,6 +251,21 @@ describe("sendCommand", () => {
     expect(result).toEqual({ success: true, data: { version: "24.0" } });
   });
 
+  it("rejects an oversized bridge response before reading it into memory", async () => {
+    mockedExistsSync.mockReturnValue(true);
+    mockedStatSync.mockReturnValue({
+      uid: myUid,
+      mode: 0o700,
+      size: MAX_BRIDGE_RESPONSE_BYTES + 1,
+    } as unknown as ReturnType<typeof statSync>);
+
+    await expect(sendCommand("test", { tempDir: "/tmp/test-bridge" })).resolves.toEqual({
+      success: false,
+      error: `Bridge response exceeds the ${MAX_BRIDGE_RESPONSE_BYTES}-byte limit`,
+    });
+    expect(mockedReadFileSync).not.toHaveBeenCalled();
+  });
+
   it("uses distinct cryptographic IDs for concurrently-created command files", async () => {
     mockedExistsSync.mockReturnValue(true);
     mockedReadFileSync.mockReturnValue('{"success":true}');
@@ -304,11 +321,11 @@ describe("sendCommand", () => {
     expect(fakeWatcher.close).toHaveBeenCalled();
   });
 
-  it("shares one directory watcher across concurrent bridge commands", async () => {
+  it("serializes concurrent bridge commands before they reach CEP", async () => {
     const readyResponses = new Set<string>();
     let onChange: ((event: string, filename: string) => void) | undefined;
     const fakeWatcher = { on: vi.fn().mockReturnThis(), close: vi.fn() };
-    mockedWatch.mockImplementationOnce(((_path, _options, listener) => {
+    mockedWatch.mockImplementation(((_path, _options, listener) => {
       onChange = listener as (event: string, filename: string) => void;
       return fakeWatcher;
     }) as typeof watch);
@@ -323,20 +340,25 @@ describe("sendCommand", () => {
       sendCommand("second", { tempDir: "/tmp/shared-watch-bridge" }),
     ];
     expect(mockedWatch).toHaveBeenCalledTimes(1);
+    expect(mockedRenameSync).toHaveBeenCalledTimes(1);
 
-    for (const [, commandPath] of mockedRenameSync.mock.calls) {
+    const signalResponse = (commandPath: unknown) => {
       const responsePath = String(commandPath)
         .replace(/cmd_/, "res_")
         .replace(/\.jsx$/, ".json");
       readyResponses.add(responsePath);
       onChange?.("rename", responsePath.split(/[\\/]/).pop()!);
-    }
+    };
+    signalResponse(mockedRenameSync.mock.calls[0]?.[1]);
+    await expect(pending[0]).resolves.toEqual({ success: true, data: { shared: true } });
 
-    await expect(Promise.all(pending)).resolves.toEqual([
-      { success: true, data: { shared: true } },
-      { success: true, data: { shared: true } },
-    ]);
-    expect(fakeWatcher.close).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mockedRenameSync).toHaveBeenCalledTimes(2);
+    expect(mockedWatch).toHaveBeenCalledTimes(2);
+    signalResponse(mockedRenameSync.mock.calls[1]?.[1]);
+
+    await expect(pending[1]).resolves.toEqual({ success: true, data: { shared: true } });
+    expect(fakeWatcher.close).toHaveBeenCalledTimes(2);
   });
 
   it("keeps polling a malformed response without resending the command", async () => {

--- a/tests/http-admission.test.ts
+++ b/tests/http-admission.test.ts
@@ -19,6 +19,7 @@ describe("HTTP admission settings", () => {
     expect(readHttpAdmissionSettings({})).toMatchObject({
       maxRequestBytes: 1_048_576,
       maxConcurrentRequests: 8,
+      maxConcurrentStreams: 32,
       rateLimitPerMinute: 120,
       rateLimitBurst: 30,
     });
@@ -154,7 +155,7 @@ describe("HTTP request classification", () => {
 describe("HTTP admission controller", () => {
   it("bounds concurrent requests and makes release idempotent", () => {
     const controller = new HttpAdmissionController({
-      maxConcurrentRequests: 1, rateLimitPerMinute: 100, rateLimitBurst: 10, maxRateLimitKeys: 16,
+      maxConcurrentRequests: 1, maxConcurrentStreams: 2, rateLimitPerMinute: 100, rateLimitBurst: 10, maxRateLimitKeys: 16,
     });
     const first = controller.acquire("credential:a");
     expect(first.accepted).toBe(true);
@@ -171,7 +172,7 @@ describe("HTTP admission controller", () => {
   it("enforces a bounded token bucket with Retry-After", () => {
     let now = 0;
     const controller = new HttpAdmissionController({
-      maxConcurrentRequests: 5, rateLimitPerMinute: 60, rateLimitBurst: 2, maxRateLimitKeys: 16,
+      maxConcurrentRequests: 5, maxConcurrentStreams: 5, rateLimitPerMinute: 60, rateLimitBurst: 2, maxRateLimitKeys: 16,
     }, () => now);
     const first = controller.acquire("credential:a");
     const second = controller.acquire("credential:a");
@@ -185,7 +186,7 @@ describe("HTTP admission controller", () => {
   it("bounds tracked identities and prunes stale buckets", () => {
     let now = 0;
     const controller = new HttpAdmissionController({
-      maxConcurrentRequests: 2, rateLimitPerMinute: 60, rateLimitBurst: 1, maxRateLimitKeys: 1,
+      maxConcurrentRequests: 2, maxConcurrentStreams: 2, rateLimitPerMinute: 60, rateLimitBurst: 1, maxRateLimitKeys: 1,
     }, () => now);
     const first = controller.acquire("credential:a");
     if (first.accepted) first.release();
@@ -195,5 +196,27 @@ describe("HTTP admission controller", () => {
     expect(second.accepted).toBe(true);
     expect(controller.metrics().trackedRateLimitKeys).toBe(1);
     if (second.accepted) second.release();
+  });
+
+  it("reserves SSE capacity without consuming operation capacity", () => {
+    const controller = new HttpAdmissionController({
+      maxConcurrentRequests: 1, maxConcurrentStreams: 2, rateLimitPerMinute: 100, rateLimitBurst: 10, maxRateLimitKeys: 16,
+    });
+    const operation = controller.acquire("credential:a", "operation");
+    const firstStream = controller.acquire("credential:a", "stream");
+    const secondStream = controller.acquire("credential:b", "stream");
+    expect(operation.accepted).toBe(true);
+    expect(firstStream.accepted).toBe(true);
+    expect(secondStream.accepted).toBe(true);
+    expect(controller.acquire("credential:b", "operation")).toMatchObject({ accepted: false, reason: "at_capacity" });
+    expect(controller.acquire("credential:c", "stream")).toMatchObject({ accepted: false, reason: "at_capacity" });
+    expect(controller.metrics()).toMatchObject({
+      activeRequests: 3,
+      activeOperationRequests: 1,
+      activeStreamRequests: 2,
+    });
+    if (operation.accepted) operation.release();
+    if (firstStream.accepted) firstStream.release();
+    if (secondStream.accepted) secondStream.release();
   });
 });

--- a/tests/project-context.test.ts
+++ b/tests/project-context.test.ts
@@ -14,6 +14,7 @@ import {
   buildContextDocumentFromSnapshot,
   enrichContextDocument,
   getProjectContextTools,
+  MAX_CONCURRENT_SOURCE_FINGERPRINTS,
   type PremiereContextSnapshot,
 } from "../src/tools/project-context.js";
 
@@ -90,6 +91,26 @@ describe("project context index", () => {
     expect(changedSource.document.sourceRevision).not.toBe(first.document.sourceRevision);
     expect(changedSource.document.records.some((record) => record.kind === "transcript")).toBe(false);
     expect(changedSource.invalidatedRecords).toBe(1);
+  });
+
+  it("bounds concurrent source fingerprint work during a large capture", async () => {
+    const largeSnapshot = snapshot();
+    largeSnapshot.sequence.clips = Array.from({ length: MAX_CONCURRENT_SOURCE_FINGERPRINTS * 3 }, (_, index) => ({
+      ...largeSnapshot.sequence.clips[0]!,
+      nodeId: `timeline-${index}`,
+      sourceId: `source-${index}`,
+      mediaPath: `D:/Media/source-${index}.mov`,
+    }));
+    let active = 0;
+    let peak = 0;
+    await buildContextDocumentFromSnapshot(largeSnapshot, undefined, async () => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      active -= 1;
+      return {};
+    });
+    expect(peak).toBe(MAX_CONCURRENT_SOURCE_FINGERPRINTS);
   });
 
   it("ranks bounded transcript and audio evidence while preserving revision provenance", async () => {

--- a/tests/tools/audio-edit-export-coverage.test.ts
+++ b/tests/tools/audio-edit-export-coverage.test.ts
@@ -31,6 +31,7 @@ import { confirmationToken, getEditPlanTools, validateEditPlan } from "../../src
 import {
   getExportTools,
   inspectExportPresetFile,
+  MAX_CAPTURE_FRAME_BYTES,
   verifyDeliveryFile,
 } from "../../src/tools/export.js";
 
@@ -283,6 +284,14 @@ describe("export verification and host-result coverage", () => {
       data: { captured: true, mimeType: "image/png", base64: Buffer.from("png bytes").toString("base64") },
     });
     expect(existsSync(frame)).toBe(false);
+
+    const oversizedFrame = temporaryPath("oversized-frame.png", "x".repeat(MAX_CAPTURE_FRAME_BYTES + 1));
+    mockedSendCommand.mockResolvedValueOnce({ success: true, data: { outputPath: oversizedFrame } });
+    await expect(tools.capture_frame.handler({})).resolves.toMatchObject({
+      success: false,
+      error: expect.stringContaining("inline response limit"),
+    });
+    expect(existsSync(oversizedFrame)).toBe(false);
 
     mockedSendCommand.mockResolvedValueOnce({ success: true, data: { outputPath: temporaryDirectory() } });
     await expect(tools.capture_frame.handler({})).resolves.toMatchObject({


### PR DESCRIPTION
## Summary
- Serialize CEP bridge command publication with a bounded queue and one-command CEP dispatch.
- Reserve separate authenticated SSE capacity, while retaining bounded operation capacity and rate limits.
- Reuse one context repository for stateless HTTP server instances and bound large bridge/frame reads.
- Limit concurrent project-context source fingerprints and cover the scale guards with regression tests.

## Validation
- npm test -- tests/bridge/file-bridge.test.ts tests/bridge/file-bridge-extra-coverage.test.ts tests/bridge/bridge-edge-coverage.test.ts tests/http-admission.test.ts tests/project-context.test.ts tests/tools/audio-edit-export-coverage.test.ts tests/entrypoints-unit.test.ts --reporter=default --silent (141 passed)
- npm run build
- npm run lint
- npm run pack:check

No licensed Premiere host was available for runtime validation.