### PR TITLE
Prepare Adobe and MCP Registry recognition

### DIFF
--- a/docs/marketing/adobe-video-partner-brief.md
+++ b/docs/marketing/adobe-video-partner-brief.md
@@ -1,0 +1,69 @@
+# Adobe Video Partner brief
+
+**Status:** prepared for an owner-operated Adobe Video Partner application.
+This document is not an application, endorsement, Marketplace listing, or
+claim of Adobe affiliation.
+
+## Suggested application summary
+
+MCP for Adobe Premiere Pro is a free, MIT-licensed local integration that lets
+compatible AI clients use structured, capability-aware Premiere workflows. It
+is designed for reviewable work: start with a read-only connection check,
+inspect supported project state, preview meaningful changes where available,
+and return explicit results or limitations. The recommended setup keeps the AI
+client, server, connector, and Premiere host on the editor's computer.
+
+The project complements Adobe's evolving native AI experiences. It does not
+claim to replace them, to be affiliated with Adobe, or to provide unattended
+editing, universal host compatibility, or a hosted relay into a customer's
+desktop Premiere process.
+
+## Links for the application owner
+
+- Adobe Video Partner Program: <https://www.adobevideopartner.com/>
+- Product site: <https://premiere-pro-mcp.com/>
+- Source and support: <https://github.com/leancoderkavy/premiere-pro-mcp>
+- Current release: <https://github.com/leancoderkavy/premiere-pro-mcp/releases/latest>
+- [Installation and local-first boundary](../../README.md)
+- [Capability and support boundary](../supported-actions.md)
+- [Marketplace release checklist](../adobe-marketplace-release-checklist.md)
+- [Design-partner pilot controls](../industry/security-and-design-partner-pilot.md)
+
+## Evidence the owner should attach or link
+
+1. A current release build and the Marketplace-targeted connector package only
+   when it has passed the channel-specific validation.
+2. Three real, redacted licensed-host walkthroughs: read-only connection
+   verification, a review-first workflow, and a returned verification or
+   limitation. Label simulations and illustrations as such.
+3. The exact host version, operating system, artifact hash, workflow boundary,
+   and observed result for every claimed demonstration.
+4. Current privacy, security, and support pages, plus the reviewer instructions
+   needed to install and test the local connector.
+
+## Conversation goals
+
+- Ask for feedback on UXP integration and distribution expectations.
+- Offer a narrowly scoped design-partner evaluation using synthetic or
+  facility-approved fixtures, not production media by default.
+- Invite review of one repeatable workflow—Project Intake, review planning, or
+  delivery preflight—rather than claiming general autonomous editing.
+
+## Do not say
+
+- "Adobe-approved," "Adobe-endorsed," or "Adobe-certified" before Adobe
+  independently grants that status.
+- "Marketplace available" before a public Marketplace URL is live.
+- "Production-proven," "safe for every project," or "works on every Premiere
+  version" without evidence for the specific workflow and host.
+- That local-first architecture changes the privacy terms of a chosen AI client
+  or model provider.
+
+## Owner actions still required
+
+1. Use the Adobe Video Partner Program's current application path and provide
+   the final publisher/contact details.
+2. Verify current Marketplace reviewer requirements in Adobe Developer
+   Distribution; account status and requested materials are time-sensitive.
+3. Approve any public contact, customer reference, screenshot, or demonstration
+   before it is sent or posted.

--- a/docs/marketing/mcp-registry-readiness.md
+++ b/docs/marketing/mcp-registry-readiness.md
@@ -1,17 +1,30 @@
 # MCP Registry readiness
 
-**Status:** prepared for review; not submitted to any registry.
+**Status:** v1.14.8 local and published-npm metadata verified on 2026-09-04; not submitted to the official registry.
 
 The official MCP Registry is a separate public listing. A repository change, an npm package, or a GitHub release does not create a listing. Submission requires a user-authorized registry login and publication action.
 
-Before a future submission:
+The verified v1.14.8 npm artifact exposes
+`mcpName: io.github.leancoderkavy/premiere-pro`, and its checked-in `registry/server.json`
+matches the published package name, version, repository, and local `stdio`
+transport. Run the official validator and the read-only preflight below at the
+moment of submission; their results are readiness evidence, not a publication
+claim.
 
-1. Release a new npm package version containing the required `mcpName` metadata and the matching README marker. The published npm version—not merely this repository checkout—must contain those values.
-2. Generate and inspect the registry manifest from the exact released package.
-3. Confirm the listing describes the published local stdio/server route accurately; do not present the local Premiere bridge as a hosted service.
-4. Validate the manifest and package version before authenticating.
-5. Obtain action-time approval, authenticate, and publish once.
-6. Query the registry for the exact listing name and retain the returned URL as public evidence.
+Before an owner-authorized submission:
+
+1. Run `npm run validate:mcp-registry-metadata` followed by
+   `npm run preflight:mcp-registry`. The latter checks the published npm
+   artifact and searches the official registry; it does not authenticate or
+   publish.
+2. Inspect `registry/server.json` from the exact release tag and confirm the
+   entry continues to describe only the local `stdio` route. Do not present the
+   local Premiere bridge as a hosted service.
+3. Obtain action-time approval, authenticate with `mcp-publisher login github`,
+   and publish once with `mcp-publisher publish registry/server.json`.
+4. Query the registry for the exact listing name and retain the returned URL as
+   public evidence. Do not create a second record merely because search results
+   are delayed.
 
 Use only these evidence-bounded facts in a future directory entry:
 

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "test:coverage": "vitest run --coverage",
     "validate:host-report": "node scripts/validate-licensed-host-report.mjs",
     "validate:mcp-registry-metadata": "node scripts/validate-mcp-registry-metadata.mjs",
+    "preflight:mcp-registry": "node scripts/preflight-mcp-registry-submission.mjs",
     "product-manifest": "node scripts/generate-public-product-manifest.mjs",
     "product-manifest:check": "node scripts/generate-public-product-manifest.mjs --check",
     "validate:project-intake-host-report": "node scripts/validate-project-intake-host-report.mjs",

--- a/registry/server.json
+++ b/registry/server.json
@@ -1,8 +1,8 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.leancoderkavy/premiere-pro",
   "title": "MCP for Adobe Premiere Pro",
-  "description": "Free, MIT-licensed local MCP server for supported Adobe Premiere Pro workflows. Begin with a read-only connection check; supported operations remain capability- and host-dependent.",
+  "description": "Local-first MCP for supported Adobe Premiere Pro workflows; start with a read-only connection check.",
   "repository": {
     "url": "https://github.com/leancoderkavy/premiere-pro-mcp",
     "source": "github"

--- a/scripts/preflight-mcp-registry-submission.mjs
+++ b/scripts/preflight-mcp-registry-submission.mjs
@@ -1,0 +1,79 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(fileURLToPath(new URL("..", import.meta.url)));
+const readJson = (relativePath) =>
+  JSON.parse(readFileSync(join(root, relativePath), "utf8"));
+
+const packageJson = readJson("package.json");
+const manifest = readJson("registry/server.json");
+const npmPackage = manifest.packages?.[0];
+
+function fail(message) {
+  console.error(`MCP Registry submission preflight failed: ${message}`);
+  process.exitCode = 1;
+}
+
+if (!npmPackage || manifest.name !== packageJson.mcpName) {
+  fail("local registry metadata does not match package.json; run validate:mcp-registry-metadata first.");
+} else if (
+  manifest.version !== packageJson.version ||
+  npmPackage.identifier !== packageJson.name ||
+  npmPackage.version !== packageJson.version ||
+  npmPackage.transport?.type !== "stdio"
+) {
+  fail("local registry package, version, or transport metadata is not publishable.");
+} else {
+  const npmUrl = `https://registry.npmjs.org/${encodeURIComponent(packageJson.name)}/${encodeURIComponent(packageJson.version)}`;
+  const registryUrl = `https://registry.modelcontextprotocol.io/v0.1/servers?search=${encodeURIComponent(manifest.name)}`;
+
+  try {
+    const [npmResponse, registryResponse] = await Promise.all([
+      fetch(npmUrl, {
+        headers: { accept: "application/json" },
+        signal: AbortSignal.timeout(10_000),
+      }),
+      fetch(registryUrl, {
+        headers: { accept: "application/json" },
+        signal: AbortSignal.timeout(10_000),
+      }),
+    ]);
+
+    if (!npmResponse.ok) {
+      fail(`published npm artifact was not found (${npmResponse.status}).`);
+    } else if (!registryResponse.ok) {
+      fail(`official registry search failed (${registryResponse.status}).`);
+    } else {
+      const [publishedPackage, registrySearch] = await Promise.all([
+        npmResponse.json(),
+        registryResponse.json(),
+      ]);
+
+      if (
+        publishedPackage.version !== packageJson.version ||
+        publishedPackage.mcpName !== packageJson.mcpName
+      ) {
+        fail("published npm artifact does not expose the expected version and mcpName metadata.");
+      } else {
+        const servers = Array.isArray(registrySearch.servers)
+          ? registrySearch.servers
+          : [];
+        const matches = servers.filter((server) =>
+          [server.name, server.server?.name].includes(manifest.name),
+        );
+
+        console.log(
+          `Published npm artifact verified: ${packageJson.name}@${packageJson.version} (${packageJson.mcpName}).`,
+        );
+        console.log(
+          matches.length
+            ? `Official MCP Registry already has ${matches.length} matching record(s) for ${manifest.name}; inspect them before publishing another immutable version.`
+            : `Official MCP Registry has no matching record for ${manifest.name}; metadata is ready for the owner-authorized publisher login.`,
+        );
+      }
+    }
+  } catch (error) {
+    fail(error instanceof Error ? error.message : String(error));
+  }
+}

--- a/scripts/validate-mcp-registry-metadata.mjs
+++ b/scripts/validate-mcp-registry-metadata.mjs
@@ -17,8 +17,10 @@ const mcpName = packageJson.mcpName;
 const npmPackage = manifest.packages?.[0];
 
 expect(typeof mcpName === "string" && /^io\.github\.leancoderkavy\/[a-z0-9-]+$/.test(mcpName), "package.json mcpName must use the leancoderkavy GitHub namespace");
+expect(manifest.$schema === "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json", "registry/server.json must use the current official registry schema");
 expect(manifest.name === mcpName, "registry/server.json name must match package.json mcpName");
 expect(manifest.version === packageJson.version, "registry/server.json version must match package.json version");
+expect(typeof manifest.description === "string" && manifest.description.length <= 100, "registry/server.json description must stay within the official registry's 100-character limit");
 expect(manifest.repository?.url === "https://github.com/leancoderkavy/premiere-pro-mcp", "registry/server.json must reference the canonical GitHub repository");
 expect(npmPackage?.registryType === "npm", "registry/server.json must describe an npm package");
 expect(npmPackage?.identifier === packageJson.name, "registry npm identifier must match package.json name");


### PR DESCRIPTION
## Summary
- refresh the MCP Registry payload for the current schema and validator limits
- add a read-only published-package and registry-search preflight command
- add an evidence-bounded Adobe Video Partner application brief

## Validation
- `npm run check` (137 files, 2,510 tests)
- `mcp-publisher validate registry/server.json`
- `npm run preflight:mcp-registry`

## External boundaries
- The official Registry has no current matching listing, but publication still requires the owner's Registry device login.
- Adobe Marketplace and Video Partner submission remain portal/account-owner actions; this PR provides the validated material without claiming approval.