### PR TITLE
Release v1.14.9

### DIFF
--- a/.agents/product-marketing.md
+++ b/.agents/product-marketing.md
@@ -1,6 +1,6 @@
 # Product Marketing Context
 
-**Document version:** v10
+**Document version:** v11
 **Last updated:** 2026-09-04
 
 ## Product Overview
@@ -137,7 +137,7 @@
 
 ## Proof Points
 
-**Release facts:** v1.14.8 registers 349 core tools; the default profile exposes 347; an authenticated compatible UXP host can add 93 capability-gated tools for a 440-tool connected surface. The release also declares 43 modules, 4 MCP resources, and 16 workflow prompts. It adds a separately installed After Effects CEP connector and guarded MOGRT studio: five bounded recipes, optional brand-kit constraints, JSON/CSV batch previews, immutable local-library publishing, source inspection, queue-only renders, and explicit Premiere verification handoff. The feature requires a user-opened, saved After Effects project and does not claim visual, import, playback, or completed-render verification. These are catalog, packaging, and HTTP authorization facts from the repository, not a promise that a particular host operation will work.
+**Release facts:** v1.14.9 registers 349 core tools; the default profile exposes 347; an authenticated compatible UXP host can add 93 capability-gated tools for a 440-tool connected surface. The release also declares 43 modules, 4 MCP resources, and 16 workflow prompts. It adds a separately installed After Effects CEP connector and guarded MOGRT studio: five bounded recipes, optional brand-kit constraints, JSON/CSV batch previews, immutable local-library publishing, source inspection, queue-only renders, and explicit Premiere verification handoff. The feature requires a user-opened, saved After Effects project and does not claim visual, import, playback, or completed-render verification. These are catalog, packaging, and HTTP authorization facts from the repository, not a promise that a particular host operation will work.
 
 **Compatibility boundary:** The release targets Premiere Pro 2020–2026; UXP workflows require a compatible Premiere Pro 25.6.0+ host and advertised capabilities. CEP remains the default compatibility route. A compatibility range, package validation, CI pass, HTTP health check, or local build is not real-host proof.
 
@@ -174,6 +174,7 @@
 
 *Newest first. One line per revision: what changed and why.*
 
+- v11 (2026-09-04) — Aligned the public release facts with v1.14.9's guarded MOGRT studio, assistant workflows, and explicit host-proof boundaries.
 - v10 (2026-09-04) — Prepared v1.14.8 guarded After Effects MOGRT-authoring positioning; preserved the licensed-host, visual, and import-verification boundaries.
 - v9 (2026-08-23) — Refreshed the Adobe AI Assistant public-beta scope and added project-backup, visual-review, and delivery-QC guide intents with explicit evidence boundaries.
 - v8 (2026-08-22) — Prepared v1.13.0 release-candidate positioning for preview-only Project Intake while preserving the unpublished and licensed-host evidence boundaries.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "premiere-pro",
       "source": "./claude-plugins/premiere-pro",
       "description": "Inspect, edit, verify, and export local Premiere Pro projects through MCP.",
-      "version": "1.14.8",
+      "version": "1.14.9",
       "category": "creative",
       "tags": ["premiere-pro", "video-editing", "mcp"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,46 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.14.9] - 2026-09-04
+
+### Added
+
+- Expanded the separate After Effects CEP bridge into a guarded MOGRT studio.
+  Five deterministic title, callout, quote, and social recipes run only in an
+  already saved, workspace-contained After Effects project and export to an
+  existing approved directory.
+- Added optional brand-kit constraints, bounded JSON/CSV batch previews,
+  immutable workspace-contained version libraries, source inspection,
+  queue-only renders, and an explicit empty-track Premiere handoff that
+  verifies insertion and exposed-control descriptors.
+- Added capability-aware assistant-editor workflows and GPT-6 Astra discovery
+  guidance so clients can inspect the current, authorized tool surface before
+  proposing an editing workflow.
+
+### Changed
+
+- Hardened the MCP transport's bounded bridge-command backlog and refreshed
+  public tool counts, workflow documentation, registry metadata, and the
+  landing's machine-readable release references.
+
+### Safety
+
+- MOGRT workflows never accept arbitrary script text, create or switch After
+  Effects projects, overwrite artifacts, start a render queue, or treat host
+  acceptance, a ZIP header, or an import descriptor as rendered-frame or
+  visual proof.
+- Capability discovery and workflow guidance describe the current host surface;
+  they do not grant authority or establish licensed-host, playback, render, or
+  marketplace verification.
+
 ## [1.14.8] - 2026-09-04
 
 ### Added
 
-- Added a separate After Effects CEP bridge and guarded MOGRT studio. Five
-  deterministic title, callout, quote, and social recipes run only in an
-  already saved, workspace-contained AE project and export to an existing
-  approved directory.
+- Added a separate After Effects CEP bridge and four approval-gated MOGRT
+  authoring tools. The initial `lower_third` recipe only runs in an already
+  saved, workspace-contained AE project and exports to an existing approved
+  directory.
 - Added one-time preview tokens, explicit export confirmation, isolated AE
   bridge helpers/temp directory, and local ZIP-header artifact verification.
 - Added a local SRT/VTT timing-review plan for lecture and interview captions,
@@ -48,13 +80,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Caption timing plans, editorial evidence import, doctor repair plans, and
   public workflow materials remain distinct from licensed-host, playback,
   rendered-output, provider, or marketplace verification.
-- Added optional brand-kit constraints, bounded JSON/CSV batch previews,
-  immutable workspace-contained version libraries, source inspection,
-  queue-only After Effects renders, and an explicit empty-track Premiere
-  handoff that verifies insertion and exposed-control descriptors.
-- MOGRT workflows never accept arbitrary script text, create or switch AE
-  projects, overwrite artifacts, start a render queue, or treat host
-  acceptance/a ZIP header/import descriptor as rendered-frame or visual proof.
 
 ## [1.14.7] - 2026-09-02
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ An [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that l
 
 The AI handles the entire workflow through 349 core tools spanning the supported ExtendScript, QE DOM, local media and interchange analysis, revisioned project-context retrieval, safe edit-planning, project-intake preview, review handoff, connection verification, and guarded After Effects MOGRT authoring, batch, library, render-queue, inspection, and Premiere-handoff workflows. A compatible, authenticated UXP panel adds 93 documented, capability-gated tools without replacing the production CEP bridge.
 
-### Latest release: 1.14.8
+### Latest release: 1.14.9
 
 - **MOGRT studio:** an optional, separate After Effects CEP connector can
   author approval-gated title, callout, quote, and social recipes; constrain
@@ -61,7 +61,7 @@ The AI handles the entire workflow through 349 core tools spanning the supported
   local Premiere processes. See the generated [supported action catalog](docs/supported-actions.md)
   for individual capability and verification contracts.
 
-See the [v1.14.8 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.14.8)
+See the [v1.14.9 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.14.9)
 for complete details. Live installation in Premiere Pro still requires host verification.
 
 ### Current MCP protocol support
@@ -108,9 +108,9 @@ their bins, media rules, and organization rules before a facility uses one.
 
 ### Easiest supported path: Claude Desktop
 
-1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.8/premiere-pro-mcp-1.14.8.mcpb).
+1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.9/premiere-pro-mcp-1.14.9.mcpb).
 2. In Claude Desktop, open **Settings > Extensions > Advanced settings > Install Extension**, select the downloaded bundle, and restart Claude Desktop.
-3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.8/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
+3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.9/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
 4. Restart Premiere, open a project, then open **Window > Extensions > MCP for Adobe Premiere Pro**.
 5. In Claude, enter: `Safely check my Premiere connection with verify_premiere_connection. Make no changes.`
 
@@ -407,11 +407,11 @@ From a clone of this repository:
 ```bash
 codex plugin marketplace add .
 codex plugin add premiere-pro@premiere-pro-mcp
-npx -y premiere-pro-mcp@1.14.8 --install-cep
+npx -y premiere-pro-mcp@1.14.9 --install-cep
 ```
 
 Restart Premiere Pro and start a new Codex session after installation. The plugin
-launches `premiere-pro-mcp@1.14.8` through `npx`; the separate CEP installation is
+launches `premiere-pro-mcp@1.14.9` through `npx`; the separate CEP installation is
 required because the MCP server communicates with the running Premiere host through
 the local bridge.
 
@@ -442,7 +442,7 @@ For Claude Code, add this repository as a marketplace and install the plugin:
 Then install the Premiere bridge and start a new Claude Code session:
 
 ```bash
-npx -y premiere-pro-mcp@1.14.8 --install-cep
+npx -y premiere-pro-mcp@1.14.9 --install-cep
 ```
 
 The Claude Code package lives in

--- a/after-effects-cep-plugin/CSXS/manifest.xml
+++ b/after-effects-cep-plugin/CSXS/manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.aftereffects.bridge" ExtensionBundleVersion="1.14.8" ExtensionBundleName="MCP for Adobe After Effects">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.aftereffects.bridge" ExtensionBundleVersion="1.14.9" ExtensionBundleName="MCP for Adobe After Effects">
   <ExtensionList>
-    <Extension Id="com.mcp.aftereffects.bridge.panel" Version="1.14.8"/>
+    <Extension Id="com.mcp.aftereffects.bridge.panel" Version="1.14.9"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.14.8" ExtensionBundleName="MCP for Adobe Premiere Pro">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.14.9" ExtensionBundleName="MCP for Adobe Premiere Pro">
   <ExtensionList>
-    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.14.8"/>
-    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.14.8"/>
+    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.14.9"/>
+    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.14.9"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/cep-plugin/index.html
+++ b/cep-plugin/index.html
@@ -81,7 +81,7 @@
     <section class="update-section" aria-live="polite">
       <div class="update-copy">
         <span class="section-label">MCP updates</span>
-        <strong id="updateTitle">Version 1.14.8</strong>
+        <strong id="updateTitle">Version 1.14.9</strong>
         <span id="updateDetail">Checking the global MCP server and connector release…</span>
       </div>
       <button id="btnUpdate" class="button button-update" onclick="handleUpdateClick()" type="button" aria-describedby="updateDetail" disabled>

--- a/cep-plugin/updater.cjs
+++ b/cep-plugin/updater.cjs
@@ -7,7 +7,7 @@
 })(this, function () {
   "use strict";
 
-  var CURRENT_VERSION = "1.14.8";
+  var CURRENT_VERSION = "1.14.9";
   var PACKAGE_NAME = "premiere-pro-mcp";
   var LATEST_PACKAGE_API = "https://registry.npmjs.org/" + PACKAGE_NAME;
   var LATEST_RELEASE_API =

--- a/claude-desktop/manifest.json
+++ b/claude-desktop/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "premiere-pro-mcp",
   "display_name": "MCP for Adobe Premiere Pro",
-  "version": "1.14.8",
+  "version": "1.14.9",
   "description": "Control a local Adobe Premiere Pro project through MCP.",
   "long_description": "Inspect projects, assemble and modify timelines, manage media, effects, audio and captions, and export deliverables through a local bridge to Adobe Premiere Pro.",
   "author": {

--- a/claude-plugins/premiere-pro/.claude-plugin/plugin.json
+++ b/claude-plugins/premiere-pro/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "premiere-pro",
   "displayName": "Premiere Pro MCP",
-  "version": "1.14.8",
+  "version": "1.14.9",
   "description": "Inspect, edit, verify, and export local Adobe Premiere Pro projects through MCP.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/claude-plugins/premiere-pro/.mcp.json
+++ b/claude-plugins/premiere-pro/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "premiere-pro": {
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.14.8"]
+      "args": ["-y", "premiere-pro-mcp@1.14.9"]
     }
   }
 }

--- a/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -19,7 +19,7 @@ project state, make only requested changes, and verify the timeline after mutati
    silently fall back to CEP after a failed UXP probe.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.14.8 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.14.9 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -5,17 +5,44 @@ import { product } from "@/lib/product"
 
 const releases = [
   {
-    version: "1.14.8",
+    version: "1.14.9",
     date: "2026-09-04",
-    label: "Guarded After Effects MOGRT studio",
+    label: "Guarded After Effects MOGRT studio and assistant workflows",
     groups: [
       {
         title: "Added",
         items: [
           "An optional, separate After Effects CEP connector can author five approval-gated title, callout, quote, and social Motion Graphics Template recipes in an already saved, workspace-contained project.",
-          "The studio includes brand-kit constraints, bounded JSON/CSV batches, immutable local template libraries, source inspection, queue-only renders, and explicit Premiere handoff verification.",
-          "Caption timing review plans parse caller-supplied SRT/VTT locally, while revision-bound editorial evidence import accepts only caller-supplied, opt-in context data.",
-          "A generated public workflow manifest, proof-receipt runbook, universal setup guide, and no-write doctor repair-plan preview make the supported path and its evidence boundaries inspectable.",
+          "The studio adds brand-kit constraints, bounded JSON/CSV batches, immutable local template libraries, source inspection, queue-only renders, and explicit Premiere handoff verification.",
+          "Capability-aware assistant-editor workflows and GPT-6 Astra guidance help compatible clients inspect the authorized tool surface before proposing a workflow.",
+        ],
+      },
+      {
+        title: "Changed",
+        items: [
+          "The MCP transport now applies bounded bridge-command backlog limits, and the public registry metadata and machine-readable references match the expanded tool surface.",
+        ],
+      },
+      {
+        title: "Safety",
+        items: [
+          "The authoring path does not accept arbitrary scripts, create or switch projects, create output folders, overwrite artifacts, start renders, or claim that host acceptance, archive presence, or import descriptors are visual proof.",
+          "Capability discovery does not grant authority or turn a catalog, host acceptance, archive presence, or import descriptor into playback, render, or visual proof.",
+        ],
+      },
+    ],
+  },
+  {
+    version: "1.14.8",
+    date: "2026-09-04",
+    label: "Guarded After Effects MOGRT authoring and safer updates",
+    groups: [
+      {
+        title: "Added",
+        items: [
+          "An optional, separate After Effects CEP connector can author one approval-gated lower-third Motion Graphics Template in an already saved, workspace-contained project.",
+          "The workflow includes a one-time preview token, explicit export confirmation, isolated local bridge channel, and local ZIP-header artifact check.",
+          "Caption timing review plans, revision-bound editorial evidence import, a no-write doctor repair-plan preview, and inspectable public workflow materials add bounded local guidance.",
         ],
       },
       {
@@ -23,13 +50,13 @@ const releases = [
         items: [
           "Global npm installations can use the Windows CEP panel to review the server and connector update state, then explicitly hand off the published-package update after Premiere closes. It does not force-close Premiere or alter projects, client configuration, source checkouts, or custom npm-prefix installs.",
           "Stateless MCP construction reuses immutable descriptors and schemas while retaining isolated context, telemetry, and UXP state. Concurrent CEP commands share a response-directory watcher with polling retained as the correctness fallback.",
-          "The public landing now uses a lighter mobile-first workflow treatment, explicit reduced-motion behavior, and current facts, structured data, sitemap, crawl policy, and machine-readable references for public pages.",
+          "The public landing uses a lighter mobile-first workflow treatment, explicit reduced-motion behavior, and current facts, structured data, sitemap, crawl policy, and machine-readable references for public pages.",
         ],
       },
       {
         title: "Safety",
         items: [
-          "The authoring path does not accept arbitrary scripts, create or switch projects, create output folders, overwrite artifacts, start renders, or claim that host acceptance, archive presence, or import descriptors are visual proof.",
+          "The authoring path does not accept arbitrary scripts, create or switch projects, create output folders, overwrite artifacts, or claim that host acceptance or archive presence is import, rendered-frame, or visual proof.",
           "Local timing plans, editorial evidence, repair plans, and public workflow materials remain separate from licensed-host, playback, rendered-output, provider, and marketplace verification.",
         ],
       },

--- a/landing/lib/product.ts
+++ b/landing/lib/product.ts
@@ -1,6 +1,6 @@
 export const product = {
   name: "MCP for Adobe Premiere Pro",
-  version: "1.14.8",
+  version: "1.14.9",
   releaseDate: "2026-09-04",
   coreToolCount: 349,
   defaultProfileToolCount: 347,
@@ -10,10 +10,10 @@ export const product = {
   uxpMinimumVersion: "25.6",
   downloads: {
     claudeBundle:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.8/premiere-pro-mcp-1.14.8.mcpb",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.9/premiere-pro-mcp-1.14.9.mcpb",
     signedCepConnector:
-      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.8/MCPBridgeCEP.zxp",
-    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.14.8",
+      "https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.9/MCPBridgeCEP.zxp",
+    releaseNotes: "https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.14.9",
   },
   links: {
     repository: "https://github.com/leancoderkavy/premiere-pro-mcp",

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -31,7 +31,7 @@ Compatibility alias: https://premiere-pro-mcp.com/llm.txt
 Source: https://github.com/leancoderkavy/premiere-pro-mcp
 npm: https://www.npmjs.com/package/premiere-pro-mcp
 License: MIT
-Current release: 1.14.8
+Current release: 1.14.9
 
 ## What it does
 

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -54,7 +54,7 @@ The Project Intake guide includes no-sensitive-data starter templates for a path
 
 ## Verified facts
 
-- Current project release: 1.14.8.
+- Current project release: 1.14.9.
 - Tool surface: 349 core structured MCP tools are registered; the default profile exposes 347. With an authenticated compatible UXP panel, 93 additional capability-gated tools bring the connected surface to 440. The server also exposes 4 resources and 16 workflow prompts.
 - Supported desktop platforms: Windows and macOS.
 - Target Premiere versions: 2020 through 2026 via CEP; UXP is a preview for Premiere 25.6 and newer.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.14.8",
+  "version": "1.14.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "premiere-pro-mcp",
-      "version": "1.14.8",
+      "version": "1.14.9",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/node": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "premiere-pro-mcp",
   "mcpName": "io.github.leancoderkavy/premiere-pro",
-  "version": "1.14.8",
+  "version": "1.14.9",
   "description": "MCP server for Adobe Premiere Pro with 349 core AI video editing tools, a guarded After Effects MOGRT studio, and a capability-aware UXP bridge for supported Premiere workflows.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/premiere-pro/.codex-plugin/plugin.json
+++ b/plugins/premiere-pro/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro",
-  "version": "1.14.8",
+  "version": "1.14.9",
   "description": "Plan, execute, verify, and export video edits in Adobe Premiere Pro through the Premiere Pro MCP server.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/plugins/premiere-pro/.mcp.json
+++ b/plugins/premiere-pro/.mcp.json
@@ -4,7 +4,7 @@
       "title": "Premiere Pro MCP",
       "description": "Inspect and edit a local Adobe Premiere Pro project through the Premiere Pro MCP bridge.",
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.14.8"]
+      "args": ["-y", "premiere-pro-mcp@1.14.9"]
     }
   }
 }

--- a/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -19,7 +19,7 @@ project state, make only requested changes, and verify the timeline after mutati
    silently fall back to CEP after a failed UXP probe.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.14.8 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.14.9 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/public-product-manifest.json
+++ b/public-product-manifest.json
@@ -9,7 +9,7 @@
     "name": "MCP for Adobe Premiere Pro",
     "mcpName": "io.github.leancoderkavy/premiere-pro",
     "npmPackage": "premiere-pro-mcp",
-    "version": "1.14.8",
+    "version": "1.14.9",
     "repository": "https://github.com/leancoderkavy/premiere-pro-mcp",
     "homepage": "https://premiere-pro-mcp.com/",
     "license": "MIT",

--- a/registry/server.json
+++ b/registry/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/leancoderkavy/premiere-pro-mcp",
     "source": "github"
   },
-  "version": "1.14.8",
+  "version": "1.14.9",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "premiere-pro-mcp",
-      "version": "1.14.8",
+      "version": "1.14.9",
       "transport": {
         "type": "stdio"
       }

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.14.8",
+  "version": "1.14.9",
   "coreTools": 349,
   "defaultProfileTools": 347,
   "uxpAdditionalTools": 93,

--- a/tests/entrypoints-unit.test.ts
+++ b/tests/entrypoints-unit.test.ts
@@ -233,15 +233,15 @@ describe("stdio CLI entry point", () => {
 
   it("checks for a newer release and updates a global npm installation", async () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
-    mocks.fetchLatestNpmVersion.mockResolvedValueOnce("1.14.9");
+    mocks.fetchLatestNpmVersion.mockResolvedValueOnce("1.15.0");
     let loaded = await importCli(["--check-update"]);
     await expect(loaded.promise).rejects.toThrow("EXIT:0");
-    expect(log).toHaveBeenCalledWith(expect.stringContaining("1.14.8 → 1.14.9"));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("1.14.9 → 1.15.0"));
 
     vi.resetModules();
     vi.clearAllMocks();
     log.mockClear();
-    mocks.fetchLatestNpmVersion.mockResolvedValueOnce("1.14.9");
+    mocks.fetchLatestNpmVersion.mockResolvedValueOnce("1.15.0");
     mocks.spawnSync.mockReturnValue({ status: 0, stdout: `${dirname(process.cwd())}\n` });
     loaded = await importCli(["--update"]);
     await expect(loaded.promise).rejects.toThrow("EXIT:0");
@@ -266,7 +266,7 @@ describe("stdio CLI entry point", () => {
     vi.resetModules();
     vi.clearAllMocks();
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
-    mocks.fetchLatestNpmVersion.mockResolvedValueOnce("1.14.8");
+    mocks.fetchLatestNpmVersion.mockResolvedValueOnce("1.14.9");
     loaded = await importCli(["--update"]);
     await expect(loaded.promise).rejects.toThrow("EXIT:0");
     expect(log).toHaveBeenCalledWith(expect.stringContaining("is current"));

--- a/uxp-plugin/manifest.json
+++ b/uxp-plugin/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.ppmcp.premiere.uxp",
   "name": "MCP for Adobe Premiere Pro",
-  "version": "1.14.8",
+  "version": "1.14.9",
   "main": "index.html",
   "host": { "app": "premierepro", "minVersion": "25.6.0" },
   "entrypoints": [


### PR DESCRIPTION
## Release v1.14.9

Prepares the current `main` changes for publication:

- Synchronizes npm, CEP, UXP, Claude, Codex, registry, landing, and release metadata to `1.14.9`.
- Records guarded MOGRT studio, assistant-workflow, and bounded transport changes in the changelog.
- Keeps explicit licensed-host, render, and marketplace-proof boundaries.

Validation completed locally:

- `npm ci`
- `npm run check`
- `npm run pack:check`
- `npm --prefix landing ci`
- `npm --prefix landing run build`
- `npm run build:claude`