### PR TITLE
fix: resolve 12 reported tool defects (#454-#466)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,55 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   approximate TikTok, Reels, Shorts, YouTube, LinkedIn, X, and Facebook limits.
   Both are read-only and never change Premiere.
 
+### Fixed
+
+- `inspect_video_transition_uxp` now resolves the documented
+  `VideoClipTrackItem` surface through `VideoClipTrackItem.cast()` before
+  reporting a capability gap, so it returns a target snapshot again on
+  Premiere 26.3 and `add_video_transition_uxp` / `remove_video_transition_uxp`
+  are reachable. A genuine gap now names the missing methods. (#454)
+- `ripple_delete_track_item_uxp` and `slip_track_item_uxp` no longer report a
+  bare failure after the host has already committed the transaction. A
+  divergent result now fails with `UXP_COMMITTED_UNVERIFIED`, states that the
+  project has already changed, describes what actually landed (for example a
+  delete that left a gap instead of rippling), and tells the caller not to
+  retry. (#455)
+- `inspect_source_proxy_uxp`, `manage_timeline_source_label_uxp`, and
+  `inspect_source_media_provenance_uxp` now read project-item identity through
+  the documented `ProjectItem.cast()` and await it, instead of failing
+  universally with "Premiere does not expose getId for this target". Bins that
+  expose no readable ID are traversed rather than rejected. (#456)
+- `roll_edit` now moves the source out point and the incoming clip's in point
+  with the visible cut and verifies all four values, so the timeline and the
+  clips' in/out metadata can no longer disagree after a reported success. (#457)
+- `import_fcp_xml` now passes both arguments `app.openFCPXML(path, projPath)`
+  requires. It takes a new required `project_path`, checks that the XML exists,
+  refuses to overwrite an existing project, and verifies the destination
+  project was created. (#458)
+- `manage_sequences_uxp` now forwards only the parameters each action accepts
+  instead of blanket-forwarding every documented field, and explains locally
+  which parameters an action takes when given one it does not. (#459)
+- `attach_custom_property` now reads the sequence project item's XMP packet
+  before and after the write and fails when the property never lands in XMP,
+  instead of reporting an unverified success. (#460)
+- `undo` and `redo` now fail closed with a named capability error, matching the
+  fix already shipped for `multiple_undo`. `undo` no longer throws
+  `ReferenceError: app.project.undo is not a function`, and `redo` no longer
+  reports an unverifiable success. (#462)
+- `set_effect_property` now accepts array values for 2D vector properties such
+  as Motion > Position and Anchor Point, and verifies an array readback
+  component by component instead of with strict equality. (#463)
+- `import_ae_comps` now fails closed when the `.aep` file does not exist and
+  when the target bin gains no items, instead of reporting success for a
+  nonexistent path. (#464)
+- `add_tracks` now fingerprints every existing track before the call and
+  locates those fingerprints afterwards, so it reports explicitly when QE
+  inserted the new tracks at index 0 and shifted every existing track up. A
+  matching total count alone no longer implies success. (#465)
+- `get_render_queue_status` now returns a capability error naming
+  `app.encoder.isRunning` when the host does not expose it, instead of an
+  `isRunning: "unknown"` string that reads as a legitimate status. (#466)
+
 ## [1.14.9] - 2026-09-04
 
 ### Added

--- a/docs/supported-actions.md
+++ b/docs/supported-actions.md
@@ -47,7 +47,7 @@ operation” when the tool has no enum-based mode.
 | `add_to_timeline` | Default profile | Single operation | Insert a project item at a timeline position and verify Premiere added no unexpected same-track fragments. |
 | `add_to_timeline_batch` | Default profile | Single operation | Insert up to 32 project items in one validated CEP request. All items and target tracks are preflighted before the first insertion; every requested placement is read back, and the tool fails closed if Premiere cannot verify one. |
 | `add_track` | Default profile | `track_type`: `video`, `audio` | Add verified video or audio tracks to the active sequence. Returns an error if Premiere cannot add the exact requested count. |
-| `add_tracks` | Default profile | Single operation | Add video and/or audio tracks through QE and verify the active sequence gained the exact requested counts |
+| `add_tracks` | Default profile | Single operation | Add video and/or audio tracks through QE, verify the active sequence gained the exact requested counts, and report explicitly when QE inserted the new tracks at index 0 and shifted every existing track up. |
 | `add_transition` | Default profile | Single operation | Add a video transition between two clips at a cut point. Uses QE DOM. |
 | `add_transition_to_clip` | Default profile | `position`: `start`, `end`, `both` | Add a transition to a specific clip's start or end |
 | `adjust_audio_levels` | Default profile | Single operation | Adjust a clip's Volume > Level in dB. Does not read or change Essential Sound Amplify automation. |
@@ -61,7 +61,7 @@ operation” when the tool has no enum-based mode.
 | `apply_lut` | Default profile | Single operation | Apply a LUT file to a clip via Lumetri Color |
 | `apply_mogrt_premiere_handoff` | Default profile | Single operation | Import exactly one previewed MOGRT into the empty track of the explicit disposable Premiere verification sequence, then read back insertion and control descriptors. Requires explicit confirmation; no rendered-frame claim is made. |
 | `apply_spot_workflow_plan` | Default profile | Single operation | Apply one exact previewed motion-demo, product-spot, or brand-spot plan. Requires edit authority, requires filesystem authority for a MOGRT, and only targets empty explicitly named tracks. Host readback is not playback or render verification. |
-| `attach_custom_property` | Default profile | Single operation | Attach a custom property (key/value pair) to the active sequence |
+| `attach_custom_property` | Default profile | Single operation | Attach a custom property (key/value pair) to the active sequence and confirm it against the sequence project item's XMP packet. Reports failure when the property never lands in XMP. |
 | `audit_timeline_health` | Default profile | Single operation | Audit one sequence snapshot for flash frames, gaps, overlaps, disabled clips, repeated shots, video without audio, extreme speed, invalid times, empty tracks, leading black, and trailing gaps; returns a 0..100 score, findings with timecodes, and fix routes. Local-only; never changes Premiere. |
 | `auto_reframe_sequence` | Default profile | `motion_preset`: `slower`, `default`, `faster` | Auto-reframe a sequence for a different aspect ratio |
 | `batch_add_transitions` | Default profile | Single operation | Add the same transition to all cut points on a track |
@@ -180,7 +180,7 @@ operation” when the tool has no enum-based mode.
 | `get_project_panel_metadata` | Default profile | Single operation | Get the current project panel metadata/column configuration as XML |
 | `get_project_scratch_disks` | Default profile | Single operation | Get the current scratch disk paths for the project. |
 | `get_qe_clip_info` | Default profile | `track_type`: `video`, `audio` | Get QE DOM information about a clip, including properties not available through the standard API. |
-| `get_render_queue_status` | Default profile | Single operation | Get the current status of the Adobe Media Encoder render queue |
+| `get_render_queue_status` | Default profile | Single operation | Report the Adobe Media Encoder queue running state, or fail closed with a named capability error when this Premiere build exposes no queue-status method on app.encoder. |
 | `get_selected_clips` | Default profile | Single operation | Get the currently selected clips in the active sequence |
 | `get_sequence_count` | Default profile | Single operation | Get the total number of sequences in the project. |
 | `get_sequence_in_out_points` | Default profile | Single operation | Get the current sequence in and out points |
@@ -202,9 +202,9 @@ operation” when the tool has no enum-based mode.
 | `get_workspaces` | Default profile | Single operation | List all available workspace layouts in Premiere Pro |
 | `get_xmp_metadata` | Default profile | Single operation | Get the raw XMP metadata for a project item (includes EXIF, IPTC, Dublin Core, etc.) |
 | `has_proxy` | Default profile | Single operation | Check if a project item has a proxy attached |
-| `import_ae_comps` | Default profile | Single operation | Import After Effects compositions from an .aep file |
+| `import_ae_comps` | Default profile | Single operation | Import After Effects compositions from an .aep file, failing closed when the file does not exist or when the target bin gains no items. |
 | `import_edl` | Default profile | Single operation | Unavailable by design: CMX 3600 EDL import opens Premiere UI that can block the CEP bridge. No import is attempted; convert the EDL to FCP7 XML and use import_fcp_xml for unattended interchange. |
-| `import_fcp_xml` | Default profile | Single operation | Import a Final Cut Pro XML file into the current project |
+| `import_fcp_xml` | Default profile | Single operation | Open a Final Cut Pro XML file as a new Premiere project. app.openFCPXML(path, projPath) requires a destination project path; it does not merge the XML into the currently open project. |
 | `import_folder` | Default profile | Single operation | Import an entire folder of media into the project |
 | `import_image_sequence` | Default profile | Single operation | Import a numbered image sequence as a single video clip. |
 | `import_media` | Default profile | Single operation | Import media files into the project |
@@ -288,7 +288,7 @@ operation” when the tool has no enum-based mode.
 | `razor_all_tracks` | Default profile | `track_type`: `video`, `audio`, `both` | Razor (split) all clips at the playhead position across all tracks, or at a specific time. |
 | `read_sequence_captions` | Default profile | Single operation | Diagnose whether the active Premiere scripting host can enumerate caption tracks. It never treats an empty result as proof that the sequence has no captions, because most CEP builds expose caption creation but not caption reads. |
 | `read_video_scopes` | Default profile | Single operation | Read waveform percentiles, RGB parade percentiles, saturation, and near-black/near-white RGB occupancy from one bounded decoded local-media frame. Read-only; this is a sampled analytical proxy, not Premiere's rendered scopes. |
-| `redo` | Default profile | Single operation | Redo the last undone action in Premiere Pro. |
+| `redo` | Default profile | Single operation | Unavailable: Premiere exposes no supported, observable redo-stack API, so a scripted redo cannot be performed or verified. |
 | `refresh_media` | Default profile | Single operation | Refresh a project item to pick up changes to the source file |
 | `relink_media` | Default profile | Single operation | Relink an offline media item to a new file path |
 | `remove_all_effects` | Default profile | Single operation | Remove ALL effects from a clip. Uses QE DOM. |
@@ -306,7 +306,7 @@ operation” when the tool has no enum-based mode.
 | `replace_clip_media` | Default profile | Single operation | Unavailable by design: the legacy ExtendScript overwrite route cannot prove that replacing media preserves the original clip's trim, position, linked audio, or adjacent clips, so this tool performs no mutation. |
 | `reverse_clip` | Default profile | Single operation | Unavailable: Premiere does not expose a supported scripting API for reversing a timeline clip's playback direction. |
 | `ripple_delete` | Default profile | Single operation | Ripple delete a clip (removes clip and closes the gap). Uses QE DOM. |
-| `roll_edit` | Default profile | Single operation | Perform a verified roll edit at the outgoing cut of a clip using the public timeline DOM. |
+| `roll_edit` | Default profile | Single operation | Perform a verified roll edit at the outgoing cut of a clip using the public timeline DOM, moving both visible edges and their source in/out points and verifying all four. |
 | `save_project` | Default profile | Single operation | Save the current Premiere Pro project |
 | `save_project_as` | Default profile | Single operation | Save the current project to a new location |
 | `scene_edit_detection` | Default profile | `CreateMarkers`, `ApplyCuts` | Perform scene edit detection on the selected clips in the active sequence. Defaults to creating markers rather than cutting. |
@@ -338,7 +338,7 @@ operation” when the tool has no enum-based mode.
 | `set_clips_volume` | Default profile | Single operation | Set the volume (in dB) on every audio clip of a track, or on a list of clip indices. One round trip instead of one call per clip - essential for sequences with dozens of clips. |
 | `set_color_label` | Default profile | Single operation | Set the color label on a project item or clip |
 | `set_color_value` | Default profile | Single operation | Set a color value on an effect property (e.g., tint color, fill color) |
-| `set_effect_property` | Default profile | Single operation | Set the value of a specific effect property on a clip |
+| `set_effect_property` | Default profile | Single operation | Set the value of a specific effect property on a clip. Accepts scalar, boolean, string, and array-shaped vector values (for example Motion > Position as [x, y]) and verifies the readback component by component. |
 | `set_footage_interpretation` | Default profile | Single operation | Set footage interpretation settings for a project item |
 | `set_frame_blend` | Default profile | Single operation | Enable or disable frame blending on a clip. Uses QE DOM. |
 | `set_graphics_white_luminance` | Default profile | Single operation | Set the graphics white luminance value (HDR setting) for the project |
@@ -384,7 +384,7 @@ operation” when the tool has no enum-based mode.
 | `stop_playback` | Default profile | Single operation | Request that active-sequence timeline playback stop through QE. The legacy API does not provide a same-call playhead readback, so stopped state is not reported as verified. |
 | `toggle_track_visibility` | Default profile | Single operation | Toggle a video track's visibility (eye icon) |
 | `trim_clip` | Default profile | `keyframe_policy`: `reject`, `preserve` | Trim exactly one source in/out point and verify the corresponding visible timeline edge. Refuses retimed clips and, by default, trims that would leave effect keyframes outside the visible clip. |
-| `undo` | Default profile | Single operation | Undo the last action in Premiere Pro |
+| `undo` | Default profile | Single operation | Unavailable: Premiere exposes no supported, observable undo-stack API, so a scripted undo cannot be performed or verified. |
 | `unlink_selection` | Default profile | Single operation | Unlink the currently selected video and audio clips in the active sequence |
 | `unnest_sequence` | Default profile | Single operation | Unnest a nested sequence on the timeline, replacing it with the contents of the nested sequence |
 | `update_marker` | Default profile | Single operation | Update an existing marker's properties |
@@ -478,7 +478,7 @@ authenticated and the connected host advertises the required command capabilitie
 | `manage_sequence_preview_frame_uxp` | Connected UXP | `inspect`, `update` | Inspect or set one explicit sequence's documented preview-frame rectangle. Update requires the complete inspected snapshot, explicit confirmation, and an operation ID; it serializes preview-frame updates by reviewed project and sequence, commits one undoable settings transaction, then reads the same sequence back. It does not set sequence video dimensions, alter media or exports, prove rendered preview output, persistence, Undo behavior, or coordinate with Premiere UI or other extensions between native calls. |
 | `manage_sequence_range_uxp` | Connected UXP | `inspect`, `update` | Inspect or update the active sequence's in, out, and zero points through documented Premiere UXP actions. Updates require the complete inspect snapshot, run in one undoable transaction, and return native readback; a runtime capability probe remains authoritative. |
 | `manage_sequence_settings_uxp` | Connected UXP | `get`, `update` | Inspect sequence settings or apply a bounded settings profile in one documented, undoable UXP transaction with readback. |
-| `manage_sequences_uxp` | Connected UXP | `inspect`, `create_from_media`, `clone`, `subsequence`, `activate`, `open`, `close`, `delete` | Inspect, create-from-media, clone, derive, activate, open, close, or explicitly delete sequences through documented stable UXP APIs. |
+| `manage_sequences_uxp` | Connected UXP | `inspect`, `create_from_media`, `clone`, `subsequence`, `activate`, `open`, `close`, `delete` | Inspect, create-from-media, clone, derive, activate, open, close, or explicitly delete sequences through documented stable UXP APIs. Each action accepts only its own parameters: inspect takes none and lists every sequence; clone/subsequence/activate/open/close/delete take sequence_id; create_from_media takes name and project_item_ids. |
 | `manage_source_clip_uxp` | Connected UXP | `inspect`, `update` | Inspect or transactionally update source-clip in/out points and request scale-to-frame for up to 64 media items. In/out values are read back; Adobe exposes no getter for clear or scale state, so those requests remain committed-unverified. |
 | `manage_source_media_overrides_uxp` | Connected UXP | `inspect`, `update` | Inspect or transactionally set one source media item's explicit frame-rate and/or pixel-aspect-ratio override through stable Premiere 26.3 UXP actions. Updates require the complete effective-interpretation snapshot, explicit confirmation, an operation_id, per-item serialization, one undoable transaction, and native effective-value readback. Premiere does not expose an override-presence getter, so this tool cannot clear or distinguish an explicit override from matching file-native interpretation. |
 | `manage_source_media_timing_uxp` | Connected UXP | `inspect`, `set_start` | Inspect or transactionally set one source media item's timecode start through stable Premiere 26.3 UXP APIs. Setting requires the exact bounded timing snapshot, explicit confirmation, one undoable transaction, per-item serialization, and native readback. |

--- a/src/tools/advanced.ts
+++ b/src/tools/advanced.ts
@@ -50,7 +50,7 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
 
     roll_edit: {
       description:
-        "Perform a verified roll edit at the outgoing cut of a clip using the public timeline DOM.",
+        "Perform a verified roll edit at the outgoing cut of a clip using the public timeline DOM, moving both visible edges and their source in/out points and verifying all four.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -85,23 +85,50 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
           if (newCutTicks <= parseFloat(result.clip.start.ticks) || newCutTicks >= parseFloat(outgoing.end.ticks)) {
             return __error("The requested roll offset would create a zero- or negative-duration clip.");
           }
+          // A roll moves the shared cut, so the source in/out points must move with
+          // the visible edges. Writing only start/end leaves inPoint/outPoint stale
+          // and inconsistent with what the timeline shows.
+          var offsetTicks = Math.round(__secondsToTicks(${args.offset_seconds}));
+          var beforeOut = String(result.clip.outPoint.ticks);
+          var beforeIncomingIn = String(outgoing.inPoint.ticks);
+          var expectedOut = String(Math.round(parseFloat(beforeOut) + offsetTicks));
+          var expectedIncomingIn = String(Math.round(parseFloat(beforeIncomingIn) + offsetTicks));
+
           var newCut = new Time();
           newCut.ticks = String(Math.round(newCutTicks));
           result.clip.end = newCut;
           outgoing.start = newCut;
+          try {
+            result.clip.outPoint = expectedOut;
+            outgoing.inPoint = expectedIncomingIn;
+          } catch (sourceRangeError) {
+            return __error("Premiere moved the visible cut but rejected the matching source in/out change, so the clips' in/out metadata no longer matches the timeline: " + sourceRangeError.toString());
+          }
+
           var after = __findClip("${escapeForExtendScript(args.node_id)}");
           if (!after) return __error("Clip could not be found after the roll edit");
           if (String(after.clip.start.ticks) === beforeStart && String(after.clip.end.ticks) === beforeEnd) {
             return __error("The roll edit returned without an observable timeline change; no successful edit is reported.");
           }
           if (String(after.clip.end.ticks) !== String(outgoing.start.ticks)) return __error("The roll edit left a gap or overlap at the edited cut.");
+          var afterOut = String(after.clip.outPoint.ticks);
+          var afterIncomingIn = String(outgoing.inPoint.ticks);
+          if (afterOut !== expectedOut || afterIncomingIn !== expectedIncomingIn) {
+            return __error("Premiere moved the visible cut but the source in/out metadata did not follow: outgoing outPoint is " + afterOut + " (expected " + expectedOut + ") and the incoming clip's inPoint is " + afterIncomingIn + " (expected " + expectedIncomingIn + "). The timeline is now inconsistent with the clips' in/out points; undo this edit in Premiere before continuing.");
+          }
           return __result({
             rolled: true,
             verified: true,
             clipName: after.clip.name,
             offsetSeconds: ${args.offset_seconds},
-            before: { startTicks: beforeStart, endTicks: beforeEnd },
-            after: { startTicks: String(after.clip.start.ticks), endTicks: String(after.clip.end.ticks) }
+            before: { startTicks: beforeStart, endTicks: beforeEnd, outPointTicks: beforeOut, incomingInPointTicks: beforeIncomingIn },
+            after: {
+              startTicks: String(after.clip.start.ticks),
+              endTicks: String(after.clip.end.ticks),
+              outPointTicks: afterOut,
+              incomingInPointTicks: afterIncomingIn
+            },
+            verification: "timeline_edge_and_source_in_out_readback"
           });
         `);
         return sendCommand(script, bridgeOptions);
@@ -972,7 +999,7 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
 
     add_tracks: {
       description:
-        "Add video and/or audio tracks through QE and verify the active sequence gained the exact requested counts",
+        "Add video and/or audio tracks through QE, verify the active sequence gained the exact requested counts, and report explicitly when QE inserted the new tracks at index 0 and shifted every existing track up.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -1023,8 +1050,45 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
         const script = buildToolScript(`
           var seq = app.project.activeSequence;
           if (!seq) return __error("No active sequence");
+
+          // A total-count check cannot tell "appended at the end" apart from
+          // "inserted at index 0 and every existing track shifted up", so
+          // fingerprint each existing track and locate those fingerprints again
+          // after the call.
+          function __trackFingerprints(collection) {
+            var fingerprints = [];
+            for (var t = 0; t < collection.numTracks; t++) {
+              var track = collection[t];
+              var clipCount = -1;
+              var firstClipNodeId = "";
+              try {
+                clipCount = track.clips.numItems;
+                if (clipCount > 0) firstClipNodeId = String(track.clips[0].nodeId || "");
+              } catch (clipError) {}
+              var trackId = "";
+              try { trackId = String(track.id); } catch (idError) { trackId = ""; }
+              fingerprints.push(trackId + "|" + String(track.name) + "|" + clipCount + "|" + firstClipNodeId);
+            }
+            return fingerprints;
+          }
+          function __offsetOfExistingTracks(before, after, added) {
+            // Returns the index the pre-existing tracks start at afterwards, or
+            // -1 when they cannot be located as a contiguous run.
+            if (before.length === 0) return 0;
+            for (var offset = 0; offset <= added; offset++) {
+              var matches = true;
+              for (var i = 0; i < before.length; i++) {
+                if (after[offset + i] !== before[i]) { matches = false; break; }
+              }
+              if (matches) return offset;
+            }
+            return -1;
+          }
+
           var beforeVideo = seq.videoTracks.numTracks;
           var beforeAudio = seq.audioTracks.numTracks;
+          var beforeVideoFingerprints = __trackFingerprints(seq.videoTracks);
+          var beforeAudioFingerprints = __trackFingerprints(seq.audioTracks);
           var expectedVideo = beforeVideo + ${v};
           var expectedAudio = beforeAudio + ${a + aMono + a51};
 
@@ -1049,15 +1113,30 @@ export function getAdvancedTools(bridgeOptions: BridgeOptions) {
             return __error("QE addTracks did not add the requested tracks: video " + beforeVideo + " -> " + afterVideo + " (expected " + expectedVideo + "), audio " + beforeAudio + " -> " + afterAudio + " (expected " + expectedAudio + ").");
           }
 
+          var videoOffset = __offsetOfExistingTracks(beforeVideoFingerprints, __trackFingerprints(seq.videoTracks), ${v});
+          var audioOffset = __offsetOfExistingTracks(beforeAudioFingerprints, __trackFingerprints(seq.audioTracks), ${a + aMono + a51});
+          var videoShifted = videoOffset > 0;
+          var audioShifted = audioOffset > 0;
+          var existingTracksUnlocatable = videoOffset === -1 || audioOffset === -1;
+
           return __result({
             added: true,
-            verified: true,
+            verified: !existingTracksUnlocatable,
             videoTracks: ${v},
             audioTracks: ${a},
             audioMonoTracks: ${aMono},
             audio51Tracks: ${a51},
             totalVideoTracks: afterVideo,
-            totalAudioTracks: afterAudio
+            totalAudioTracks: afterAudio,
+            newTracksInsertedAtStart: videoShifted || audioShifted,
+            existingVideoTracksShiftedBy: videoOffset === -1 ? null : videoOffset,
+            existingAudioTracksShiftedBy: audioOffset === -1 ? null : audioOffset,
+            existingTracksUnlocatable: existingTracksUnlocatable,
+            trackShiftWarning: existingTracksUnlocatable
+              ? "The pre-existing tracks could not be matched by fingerprint after the call, so their new indices are unknown. Re-read the sequence structure before addressing any track by index."
+              : (videoShifted || audioShifted
+                ? "QE inserted the new tracks at index 0 and shifted every pre-existing track up (video +" + videoOffset + ", audio +" + audioOffset + "). Clips that were on Video 1 are now on Video " + (1 + videoOffset) + ". Re-read the sequence structure before addressing any track by index."
+                : null)
           });
         `);
         return sendCommand(script, bridgeOptions);

--- a/src/tools/export.ts
+++ b/src/tools/export.ts
@@ -1128,16 +1128,32 @@ export function getExportTools(bridgeOptions: BridgeOptions) {
     },
 
     get_render_queue_status: {
-      description: "Get the current status of the Adobe Media Encoder render queue",
+      description:
+        "Report the Adobe Media Encoder queue running state, or fail closed with a named capability error when this Premiere build exposes no queue-status method on app.encoder.",
       parameters: {},
       handler: async () => {
         const script = buildToolScript(`
           var encoder = app.encoder;
           if (!encoder) return __error("Adobe Media Encoder not available");
-          
+
+          if (typeof encoder.isRunning !== "function") {
+            return __error("This Premiere build does not expose app.encoder.isRunning, and app.encoder exposes no other documented queue-status method, so the Adobe Media Encoder queue state cannot be read. Check the Adobe Media Encoder application directly. Exporting through export_sequence or encode_project_item is a separate code path and is unaffected.");
+          }
+
+          var isRunning;
+          try {
+            isRunning = encoder.isRunning();
+          } catch (encoderStatusError) {
+            return __error("app.encoder.isRunning exists but Premiere could not read the queue state: " + encoderStatusError.toString());
+          }
+          if (typeof isRunning !== "boolean") {
+            return __error("app.encoder.isRunning did not return a boolean queue state, so the Adobe Media Encoder queue status cannot be trusted.");
+          }
+
           return __result({
-            isRunning: encoder.isRunning ? encoder.isRunning() : "unknown",
-            info: "Check Adobe Media Encoder application for detailed queue status"
+            isRunning: isRunning,
+            source: "app.encoder.isRunning",
+            info: "Check Adobe Media Encoder application for detailed per-job queue status."
           });
         `);
         return sendCommand(script, bridgeOptions);

--- a/src/tools/keyframes.ts
+++ b/src/tools/keyframes.ts
@@ -63,7 +63,8 @@ export function getKeyframeTools(bridgeOptions: BridgeOptions) {
     },
 
     set_effect_property: {
-      description: "Set the value of a specific effect property on a clip",
+      description:
+        "Set the value of a specific effect property on a clip. Accepts scalar, boolean, string, and array-shaped vector values (for example Motion > Position as [x, y]) and verifies the readback component by component.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -80,17 +81,33 @@ export function getKeyframeTools(bridgeOptions: BridgeOptions) {
             description: "Display name of the property (e.g., 'Scale', 'Position', 'Opacity')",
           },
           value: {
-            type: ["number", "string"],
+            type: ["number", "string", "boolean", "array"],
             maxLength: 8192,
-            description: "Number or string value to set. Use the exact JSON string reported for a MOGRT text or graphic parameter.",
+            items: { type: "number" },
+            minItems: 1,
+            maxItems: 4,
+            description:
+              "Value to set. Use a number for scalar properties, an array of numbers for vector properties such as Motion > Position or Anchor Point ([x, y]), a boolean for checkbox properties, or the exact JSON string reported for a MOGRT text or graphic parameter.",
           },
         },
         required: ["node_id", "effect_name", "property_name", "value"],
       },
-      handler: async (args: { node_id: string; effect_name: string; property_name: string; value: number | string }) => {
-        const requestedValue = typeof args.value === "string"
-          ? `"${escapeForExtendScript(args.value)}"`
-          : String(args.value);
+      handler: async (args: { node_id: string; effect_name: string; property_name: string; value: number | string | boolean | number[] }) => {
+        if (Array.isArray(args.value)) {
+          if (!args.value.length || args.value.length > 4) {
+            return { success: false, error: "value must be an array of 1 to 4 numbers for a vector property" };
+          }
+          if (args.value.some((component) => typeof component !== "number" || !Number.isFinite(component))) {
+            return { success: false, error: "every component of a vector value must be a finite number" };
+          }
+        } else if (typeof args.value === "number" && !Number.isFinite(args.value)) {
+          return { success: false, error: "value must be a finite number" };
+        }
+        const requestedValue = Array.isArray(args.value)
+          ? `[${args.value.map((component) => String(component)).join(", ")}]`
+          : typeof args.value === "string"
+            ? `"${escapeForExtendScript(args.value)}"`
+            : String(args.value);
         const script = buildToolScript(`
           var result = __findClip("${escapeForExtendScript(args.node_id)}");
           if (!result) return __error("Clip not found");
@@ -128,13 +145,33 @@ export function getKeyframeTools(bridgeOptions: BridgeOptions) {
           } catch (eReadback) {
             readbackAvailable = false;
           }
+          // Array-shaped properties (Position, Anchor Point, and other vector
+          // parameters) are never === equal to the written value, so compare
+          // element by element with the same tolerance used for scalars.
+          function __sameParameterValue(actual, expected) {
+            var tolerance = 0.0001;
+            var actualIsArray = actual instanceof Array;
+            var expectedIsArray = expected instanceof Array;
+            if (actualIsArray !== expectedIsArray) return false;
+            if (actualIsArray) {
+              if (actual.length !== expected.length) return false;
+              for (var index = 0; index < expected.length; index++) {
+                if (!__sameParameterValue(actual[index], expected[index])) return false;
+              }
+              return true;
+            }
+            if (typeof actual === "number" && typeof expected === "number") {
+              return Math.abs(actual - expected) <= tolerance;
+            }
+            return actual === expected;
+          }
           return __result({
             set: true,
             effect: "${escapeForExtendScript(args.effect_name)}",
             property: "${escapeForExtendScript(args.property_name)}",
             value: readbackAvailable ? readbackValue : requestedValue,
             requestedValue: requestedValue,
-            readbackVerified: readbackAvailable && readbackValue === requestedValue,
+            readbackVerified: readbackAvailable && __sameParameterValue(readbackValue, requestedValue),
             verification: readbackAvailable
               ? "Premiere parameter readback only; verify playback or exported frames before delivery."
               : "Premiere accepted the parameter write, but this property did not expose a readback value. Verify playback or exported frames before delivery."

--- a/src/tools/project.ts
+++ b/src/tools/project.ts
@@ -94,7 +94,8 @@ export function getProjectTools(bridgeOptions: BridgeOptions) {
     },
 
     undo: {
-      description: "Undo the last action in Premiere Pro",
+      description:
+        "Unavailable: Premiere exposes no supported, observable undo-stack API, so a scripted undo cannot be performed or verified.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -105,14 +106,15 @@ export function getProjectTools(bridgeOptions: BridgeOptions) {
         },
       },
       handler: async (args: { count?: number }) => {
-        const count = args.count || 1;
-        const script = buildToolScript(`
-          for (var i = 0; i < ${count}; i++) {
-            app.project.undo();
-          }
-          return __result({ undone: ${count} });
-        `);
-        return sendCommand(script, bridgeOptions);
+        const count = args.count ?? 1;
+        if (!Number.isInteger(count) || count < 1 || count > 100) {
+          return { success: false, error: "count must be an integer from 1 through 100" };
+        }
+        return {
+          success: false,
+          error:
+            "undo is unavailable because Premiere exposes no supported undo API: app.project.undo is not a function on current Premiere builds, and no undo-stack query exists to verify an undo against. No mutation was attempted. Undo the action from Premiere's Edit menu instead.",
+        };
       },
     },
 
@@ -265,7 +267,8 @@ export function getProjectTools(bridgeOptions: BridgeOptions) {
     },
 
     import_ae_comps: {
-      description: "Import After Effects compositions from an .aep file",
+      description:
+        "Import After Effects compositions from an .aep file, failing closed when the file does not exist or when the target bin gains no items.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -291,25 +294,75 @@ export function getProjectTools(bridgeOptions: BridgeOptions) {
         comp_names?: string[];
         target_bin?: string;
       }) => {
+        if (typeof args.ae_project_path !== "string" || !args.ae_project_path.trim()) {
+          return { success: false, error: "ae_project_path must be a non-empty path to an After Effects .aep file" };
+        }
+        const aePath = escapeForExtendScript(args.ae_project_path);
         const binLookup = args.target_bin
           ? `var targetBin = __findProjectItem("${escapeForExtendScript(args.target_bin)}"); if (!targetBin) return __error("Bin not found");`
           : `var targetBin = app.project.rootItem;`;
+        // The After Effects import calls report nothing observable, so the file must
+        // exist before the call and the target bin must actually gain items after it.
+        const preflight = `
+            ${binLookup}
+            var aeFile = new File("${aePath}");
+            if (!aeFile.exists) {
+              return __error("After Effects project not found on disk: ${aePath}. No compositions were imported.");
+            }
+            if (!targetBin.children) {
+              return __error("The target bin does not expose a children collection, so an After Effects import cannot be verified.");
+            }
+            var beforeItems = targetBin.children.numItems;
+        `;
+        const verify = (importedDescription: string) => `
+            var afterItems = targetBin.children.numItems;
+            var addedItems = afterItems - beforeItems;
+            if (addedItems <= 0) {
+              return __error("Premiere reported no error, but the target bin gained no items, so ${importedDescription} were not imported from ${aePath}.");
+            }
+        `;
 
         if (args.comp_names && args.comp_names.length > 0) {
           const comps = args.comp_names
             .map((c) => `"${escapeForExtendScript(c)}"`)
             .join(", ");
           const script = buildToolScript(`
-            ${binLookup}
-            app.project.importAEComps("${escapeForExtendScript(args.ae_project_path)}", [${comps}], targetBin);
-            return __result({ imported: true, comps: [${comps}] });
+            ${preflight}
+            try {
+              app.project.importAEComps("${aePath}", [${comps}], targetBin);
+            } catch (importError) {
+              return __error("Premiere could not import the requested After Effects compositions: " + importError.toString());
+            }
+            ${verify("the requested compositions")}
+            return __result({
+              imported: true,
+              verified: true,
+              comps: [${comps}],
+              addedItems: addedItems,
+              binItemsBefore: beforeItems,
+              binItemsAfter: afterItems,
+              verification: "Target-bin item-count increase only; composition identity and rendered content are not verified."
+            });
           `);
           return sendCommand(script, bridgeOptions);
         } else {
           const script = buildToolScript(`
-            ${binLookup}
-            app.project.importAllAEComps("${escapeForExtendScript(args.ae_project_path)}", targetBin);
-            return __result({ imported: true, allComps: true });
+            ${preflight}
+            try {
+              app.project.importAllAEComps("${aePath}", targetBin);
+            } catch (importError) {
+              return __error("Premiere could not import the After Effects compositions: " + importError.toString());
+            }
+            ${verify("any compositions")}
+            return __result({
+              imported: true,
+              verified: true,
+              allComps: true,
+              addedItems: addedItems,
+              binItemsBefore: beforeItems,
+              binItemsAfter: afterItems,
+              verification: "Target-bin item-count increase only; composition identity and rendered content are not verified."
+            });
           `);
           return sendCommand(script, bridgeOptions);
         }
@@ -640,21 +693,67 @@ export function getProjectTools(bridgeOptions: BridgeOptions) {
     },
 
     import_fcp_xml: {
-      description: "Import a Final Cut Pro XML file into the current project",
+      description:
+        "Open a Final Cut Pro XML file as a new Premiere project. app.openFCPXML(path, projPath) requires a destination project path; it does not merge the XML into the currently open project.",
       parameters: {
         type: "object" as const,
         properties: {
           path: {
             type: "string",
-            description: "Full path to the FCP XML file",
+            description: "Full path to the FCP XML file to read",
+          },
+          project_path: {
+            type: "string",
+            description:
+              "Full path of the new .prproj file Premiere should create for the imported timeline. Required: app.openFCPXML takes both a source and a destination path.",
           },
         },
-        required: ["path"],
+        required: ["path", "project_path"],
       },
-      handler: async (args: { path: string }) => {
+      handler: async (args: { path: string; project_path: string }) => {
+        if (typeof args.path !== "string" || !args.path.trim()) {
+          return { success: false, error: "path must be a non-empty path to an FCP XML file" };
+        }
+        if (typeof args.project_path !== "string" || !args.project_path.trim()) {
+          return {
+            success: false,
+            error:
+              "project_path must be a non-empty destination .prproj path. app.openFCPXML(path, projPath) needs both arguments; passing only path fails with \"Not Enough Parameters\".",
+          };
+        }
+        const xmlPath = escapeForExtendScript(args.path);
+        const projectPath = escapeForExtendScript(args.project_path);
         const script = buildToolScript(`
-          app.openFCPXML("${escapeForExtendScript(args.path)}");
-          return __result({ imported: true, path: "${escapeForExtendScript(args.path)}" });
+          var xmlFile = new File("${xmlPath}");
+          if (!xmlFile.exists) return __error("FCP XML file not found on disk: ${xmlPath}");
+          var destinationFile = new File("${projectPath}");
+          if (destinationFile.exists) {
+            return __error("A project already exists at ${projectPath}. Choose a destination project_path that does not exist so an existing project is not overwritten.");
+          }
+
+          if (typeof app.openFCPXML !== "function") {
+            return __error("This Premiere build does not expose app.openFCPXML, so FCP XML cannot be imported.");
+          }
+          try {
+            app.openFCPXML("${xmlPath}", "${projectPath}");
+          } catch (importError) {
+            return __error("Premiere could not open the FCP XML file: " + importError.toString());
+          }
+
+          var openedPath = "";
+          try { openedPath = String(app.project.path); } catch (pathError) { openedPath = ""; }
+          if (!destinationFile.exists && !openedPath) {
+            return __error("Premiere returned without an error, but no project was created at ${projectPath} and no project path is readable, so the FCP XML import is not verified.");
+          }
+
+          return __result({
+            imported: true,
+            verified: destinationFile.exists,
+            path: "${xmlPath}",
+            projectPath: "${projectPath}",
+            openedProjectPath: openedPath,
+            verification: "Destination project file existence only; timeline, media links, and effect fidelity are not verified."
+          });
         `);
         return sendCommand(script, bridgeOptions);
       },

--- a/src/tools/sequence.ts
+++ b/src/tools/sequence.ts
@@ -516,7 +516,8 @@ export function getSequenceTools(bridgeOptions: BridgeOptions) {
     },
 
     attach_custom_property: {
-      description: "Attach a custom property (key/value pair) to the active sequence",
+      description:
+        "Attach a custom property (key/value pair) to the active sequence and confirm it against the sequence project item's XMP packet. Reports failure when the property never lands in XMP.",
       parameters: {
         type: "object" as const,
         properties: {
@@ -532,11 +533,57 @@ export function getSequenceTools(bridgeOptions: BridgeOptions) {
         required: ["property_id", "property_value"],
       },
       handler: async (args: { property_id: string; property_value: string }) => {
+        if (typeof args.property_id !== "string" || !args.property_id.trim()) {
+          return { success: false, error: "property_id must be a non-empty string" };
+        }
+        if (typeof args.property_value !== "string" || !args.property_value.length) {
+          return { success: false, error: "property_value must be a non-empty string" };
+        }
+        const propertyId = escapeForExtendScript(args.property_id);
+        const propertyValue = escapeForExtendScript(args.property_value);
         const script = buildToolScript(`
           var seq = app.project.activeSequence;
           if (!seq) return __error("No active sequence");
-          seq.attachCustomProperty("${escapeForExtendScript(args.property_id)}", "${escapeForExtendScript(args.property_value)}");
-          return __result({ attached: true, propertyId: "${escapeForExtendScript(args.property_id)}", value: "${escapeForExtendScript(args.property_value)}" });
+          if (typeof seq.attachCustomProperty !== "function") {
+            return __error("This Premiere build does not expose sequence.attachCustomProperty; no custom property was attached.");
+          }
+
+          // A custom property is only real once it is in the sequence project
+          // item's XMP packet, so read that packet on both sides of the write.
+          var sequenceItem = null;
+          try { sequenceItem = seq.projectItem; } catch (itemError) { sequenceItem = null; }
+          if (!sequenceItem || typeof sequenceItem.getXMPMetadata !== "function") {
+            return __error("The active sequence exposes no readable project item XMP packet, so an attached custom property cannot be verified. No property was attached.");
+          }
+
+          var beforePacket = "";
+          try { beforePacket = String(sequenceItem.getXMPMetadata() || ""); } catch (beforeError) { beforePacket = ""; }
+          if (!beforePacket) {
+            return __error("Premiere returned no readable XMP packet for the active sequence, so an attached custom property cannot be verified. No property was attached.");
+          }
+
+          try {
+            seq.attachCustomProperty("${propertyId}", "${propertyValue}");
+          } catch (attachError) {
+            return __error("Premiere could not attach the custom property: " + attachError.toString());
+          }
+
+          var afterPacket = "";
+          try { afterPacket = String(sequenceItem.getXMPMetadata() || ""); } catch (afterError) { afterPacket = ""; }
+          if (!afterPacket) {
+            return __error("Premiere returned no readable XMP packet after attachCustomProperty, so the custom property is not verified.");
+          }
+          if (afterPacket === beforePacket || afterPacket.indexOf("${propertyValue}") === -1) {
+            return __error("Premiere accepted attachCustomProperty without an error, but the sequence XMP packet does not contain the property value, so the property was not persisted. No success is reported.");
+          }
+
+          return __result({
+            attached: true,
+            verified: true,
+            propertyId: "${propertyId}",
+            value: "${propertyValue}",
+            verification: "sequence_project_item_xmp_readback"
+          });
         `);
         return sendCommand(script, bridgeOptions);
       },

--- a/src/tools/track-targeting.ts
+++ b/src/tools/track-targeting.ts
@@ -1386,20 +1386,14 @@ export function getTrackTargetingTools(bridgeOptions: BridgeOptions) {
     },
 
     redo: {
-      description: "Redo the last undone action in Premiere Pro.",
+      description:
+        "Unavailable: Premiere exposes no supported, observable redo-stack API, so a scripted redo cannot be performed or verified.",
       parameters: {},
-      handler: async () => {
-        const script = buildToolScript(`
-          app.enableQE();
-          try {
-            qe.project.redo();
-            return __result({ redone: true });
-          } catch(e) {
-            return __error("Redo failed: " + e.message);
-          }
-        `);
-        return sendCommand(script, bridgeOptions);
-      },
+      handler: async () => ({
+        success: false,
+        error:
+          "redo is unavailable because Premiere exposes no supported redo API that can be verified: qe.project.redo() returns nothing observable and no undo/redo-stack query exists to check it against, so a reported success would be unfounded. No mutation was attempted. Redo the action from Premiere's Edit menu instead.",
+      }),
     },
 
     multiple_undo: {

--- a/src/tools/uxp-advanced-workflows.ts
+++ b/src/tools/uxp-advanced-workflows.ts
@@ -862,7 +862,7 @@ export function getUxpAdvancedWorkflowTools(bridge: UxpWebSocketBridge) {
     },
 
     manage_sequences_uxp: {
-      description: "Inspect, create-from-media, clone, derive, activate, open, close, or explicitly delete sequences through documented stable UXP APIs.",
+      description: "Inspect, create-from-media, clone, derive, activate, open, close, or explicitly delete sequences through documented stable UXP APIs. Each action accepts only its own parameters: inspect takes none and lists every sequence; clone/subsequence/activate/open/close/delete take sequence_id; create_from_media takes name and project_item_ids.",
       parameters: {
         type: "object" as const,
         additionalProperties: false,
@@ -880,18 +880,56 @@ export function getUxpAdvancedWorkflowTools(bridge: UxpWebSocketBridge) {
         required: ["action"],
       },
       handler: async (args: AdvancedArgs) => {
-        const common = compact({
-          sequenceId: args.sequence_id, expectedName: args.expected_name, name: args.name,
-          projectItemIds: args.project_item_ids, targetBinId: args.target_bin_id,
-          ignoreTrackTargeting: args.ignore_track_targeting, confirmNonUndoable: args.confirm_non_undoable,
-        });
         const commands: Record<string, string> = {
           inspect: "sequences.inspect", create_from_media: "sequences.createFromMedia", clone: "sequences.clone",
           subsequence: "sequences.subsequence", activate: "sequences.activate", open: "sequences.open",
           close: "sequences.close", delete: "sequences.delete",
         };
         if (!args.action || !commands[args.action]) return invalidAction(args.action);
-        return invoke(bridge, commands[args.action], { ...common, ...operation(args) });
+
+        // Each sequence command accepts a different argument set and rejects
+        // anything else, so forward only what the chosen action takes instead of
+        // blanket-forwarding every documented parameter.
+        const supplied: Record<string, unknown> = compact({
+          sequence_id: args.sequence_id, expected_name: args.expected_name, name: args.name,
+          project_item_ids: args.project_item_ids, target_bin_id: args.target_bin_id,
+          ignore_track_targeting: args.ignore_track_targeting, confirm_non_undoable: args.confirm_non_undoable,
+          operation_id: args.operation_id,
+        });
+        const hostNames: Record<string, string> = {
+          sequence_id: "sequenceId", expected_name: "expectedName", name: "name",
+          project_item_ids: "projectItemIds", target_bin_id: "targetBinId",
+          ignore_track_targeting: "ignoreTrackTargeting", confirm_non_undoable: "confirmNonUndoable",
+          operation_id: "operationId",
+        };
+        const accepted: Record<string, readonly string[]> = {
+          inspect: [],
+          create_from_media: ["name", "project_item_ids", "target_bin_id", "confirm_non_undoable", "operation_id"],
+          clone: ["sequence_id", "operation_id"],
+          subsequence: ["sequence_id", "ignore_track_targeting", "confirm_non_undoable", "operation_id"],
+          activate: ["sequence_id", "operation_id"],
+          open: ["sequence_id", "operation_id"],
+          close: ["sequence_id", "operation_id"],
+          delete: ["sequence_id", "expected_name", "confirm_non_undoable", "operation_id"],
+        };
+        const allowed = accepted[args.action];
+        const rejected = Object.keys(supplied).filter((key) => !allowed.includes(key));
+        if (rejected.length) {
+          return {
+            success: false,
+            error: allowed.length
+              ? `manage_sequences_uxp action "${args.action}" does not accept ${rejected.join(", ")}. It accepts: ${allowed.join(", ")}.`
+              : `manage_sequences_uxp action "${args.action}" takes no other parameters, so ${rejected.join(", ")} cannot be used. Call it with action alone; it returns every sequence in the active project with its ID and name.`,
+          };
+        }
+
+        return invoke(
+          bridge,
+          commands[args.action],
+          Object.fromEntries(allowed
+            .filter((key) => key in supplied)
+            .map((key) => [hostNames[key], supplied[key]])),
+        );
       },
     },
 

--- a/tests/tools/issues-454-466.test.ts
+++ b/tests/tools/issues-454-466.test.ts
@@ -1,0 +1,295 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/bridge/file-bridge.js", () => ({
+  sendCommand: vi.fn().mockResolvedValue({ success: true, data: {} }),
+}));
+
+import { sendCommand } from "../../src/bridge/file-bridge.js";
+import { getAdvancedTools } from "../../src/tools/advanced.js";
+import { getExportTools } from "../../src/tools/export.js";
+import { getKeyframeTools } from "../../src/tools/keyframes.js";
+import { getProjectTools } from "../../src/tools/project.js";
+import { getSequenceTools } from "../../src/tools/sequence.js";
+import { getTrackTargetingTools } from "../../src/tools/track-targeting.js";
+import { getUxpAdvancedWorkflowTools } from "../../src/tools/uxp-advanced-workflows.js";
+import type { UxpWebSocketBridge } from "../../src/bridge/uxp-websocket-bridge.js";
+
+const mockedSendCommand = vi.mocked(sendCommand);
+const bridgeOptions = { tempDir: "/tmp/test-bridge", timeoutMs: 5_000 };
+
+const advanced = getAdvancedTools(bridgeOptions);
+const exports_ = getExportTools(bridgeOptions);
+const keyframes = getKeyframeTools(bridgeOptions);
+const project = getProjectTools(bridgeOptions);
+const sequence = getSequenceTools(bridgeOptions);
+const trackTargeting = getTrackTargetingTools(bridgeOptions);
+
+async function scriptFor(tool: { handler: (args: any) => Promise<unknown> }, args: unknown) {
+  mockedSendCommand.mockClear();
+  await tool.handler(args);
+  expect(mockedSendCommand).toHaveBeenCalledTimes(1);
+  return String(mockedSendCommand.mock.calls[0][0]);
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+// https://github.com/leancoderkavy/premiere-pro-mcp/issues/457
+describe("issue #457 — roll_edit must move source in/out with the visible cut", () => {
+  it("writes the matching outPoint and inPoint alongside the rolled edges", async () => {
+    const script = await scriptFor(advanced.roll_edit, { node_id: "clip-1", offset_seconds: 1 });
+
+    expect(script).toContain("result.clip.outPoint = expectedOut;");
+    expect(script).toContain("outgoing.inPoint = expectedIncomingIn;");
+    expect(script).toContain("var expectedOut = String(Math.round(parseFloat(beforeOut) + offsetTicks));");
+  });
+
+  it("fails when the source in/out metadata does not follow the visible cut", async () => {
+    const script = await scriptFor(advanced.roll_edit, { node_id: "clip-1", offset_seconds: 1 });
+
+    expect(script).toContain("afterOut !== expectedOut || afterIncomingIn !== expectedIncomingIn");
+    expect(script).toContain("the source in/out metadata did not follow");
+    expect(script).toContain('verification: "timeline_edge_and_source_in_out_readback"');
+  });
+});
+
+// https://github.com/leancoderkavy/premiere-pro-mcp/issues/458
+describe("issue #458 — import_fcp_xml supplies both openFCPXML arguments", () => {
+  it("requires the destination project path openFCPXML needs", async () => {
+    expect(project.import_fcp_xml.parameters.required).toEqual(["path", "project_path"]);
+
+    const result = await project.import_fcp_xml.handler({ path: "/tmp/edit.xml", project_path: "  " });
+    expect(result).toMatchObject({ success: false, error: expect.stringContaining("Not Enough Parameters") });
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+  });
+
+  it("passes both paths and verifies the destination project exists afterwards", async () => {
+    const script = await scriptFor(project.import_fcp_xml, {
+      path: "/tmp/edit.xml",
+      project_path: "/tmp/imported.prproj",
+    });
+
+    expect(script).toContain('app.openFCPXML("/tmp/edit.xml", "/tmp/imported.prproj");');
+    expect(script).toContain('var xmlFile = new File("/tmp/edit.xml");');
+    expect(script).toContain("if (!xmlFile.exists)");
+    expect(script).toContain("A project already exists at /tmp/imported.prproj");
+    expect(script).toContain("verified: destinationFile.exists");
+  });
+});
+
+// https://github.com/leancoderkavy/premiere-pro-mcp/issues/460
+describe("issue #460 — attach_custom_property verifies the XMP packet", () => {
+  it("reads the sequence project item XMP on both sides of the write", async () => {
+    const script = await scriptFor(sequence.attach_custom_property, {
+      property_id: "spot-code",
+      property_value: "ABC-123",
+    });
+
+    expect(script).toContain("var beforePacket");
+    expect(script).toContain("var afterPacket");
+    expect(script).toContain('afterPacket === beforePacket || afterPacket.indexOf("ABC-123") === -1');
+    expect(script).toContain("the sequence XMP packet does not contain the property value");
+    expect(script).toContain('verification: "sequence_project_item_xmp_readback"');
+  });
+
+  it("rejects an empty property id or value before touching the bridge", async () => {
+    await expect(sequence.attach_custom_property.handler({ property_id: " ", property_value: "x" }))
+      .resolves.toMatchObject({ success: false, error: expect.stringContaining("property_id") });
+    await expect(sequence.attach_custom_property.handler({ property_id: "x", property_value: "" }))
+      .resolves.toMatchObject({ success: false, error: expect.stringContaining("property_value") });
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+  });
+});
+
+// https://github.com/leancoderkavy/premiere-pro-mcp/issues/462
+describe("issue #462 — undo and redo fail closed like multiple_undo", () => {
+  it("does not call app.project.undo, which is not a function on current builds", async () => {
+    const result = await project.undo.handler({});
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("app.project.undo is not a function"),
+    });
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+  });
+
+  it("validates count before reporting the capability gap", async () => {
+    await expect(project.undo.handler({ count: 0 }))
+      .resolves.toMatchObject({ success: false, error: expect.stringContaining("count must be an integer") });
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+  });
+
+  it("never reports an unverifiable redo success", async () => {
+    const result = await trackTargeting.redo.handler({});
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("no supported redo API"),
+    });
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+  });
+});
+
+// https://github.com/leancoderkavy/premiere-pro-mcp/issues/463
+describe("issue #463 — set_effect_property handles 2D vector properties", () => {
+  it("accepts an array value for Position and Anchor Point", async () => {
+    expect(keyframes.set_effect_property.parameters.properties.value.type)
+      .toEqual(["number", "string", "boolean", "array"]);
+
+    const script = await scriptFor(keyframes.set_effect_property, {
+      node_id: "clip-1",
+      effect_name: "Motion",
+      property_name: "Position",
+      value: [0.25, 0.75],
+    });
+
+    expect(script).toContain("var requestedValue = [0.25, 0.75];");
+    expect(script).toContain("prop.setValue(requestedValue, true)");
+  });
+
+  it("compares an array readback component by component rather than with ===", async () => {
+    const script = await scriptFor(keyframes.set_effect_property, {
+      node_id: "clip-1",
+      effect_name: "Motion",
+      property_name: "Anchor Point",
+      value: [10, 20],
+    });
+
+    expect(script).toContain("function __sameParameterValue(actual, expected)");
+    expect(script).toContain("readbackVerified: readbackAvailable && __sameParameterValue(readbackValue, requestedValue)");
+    expect(script).not.toContain("readbackValue === requestedValue");
+  });
+
+  it("rejects malformed vector values locally", async () => {
+    await expect(keyframes.set_effect_property.handler({
+      node_id: "clip-1", effect_name: "Motion", property_name: "Position", value: [],
+    })).resolves.toMatchObject({ success: false, error: expect.stringContaining("1 to 4 numbers") });
+
+    await expect(keyframes.set_effect_property.handler({
+      node_id: "clip-1", effect_name: "Motion", property_name: "Position", value: [1, Number.NaN],
+    })).resolves.toMatchObject({ success: false, error: expect.stringContaining("finite number") });
+
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+  });
+});
+
+// https://github.com/leancoderkavy/premiere-pro-mcp/issues/464
+describe("issue #464 — import_ae_comps verifies the file and the bin", () => {
+  it("checks the .aep exists before importing all comps", async () => {
+    const script = await scriptFor(project.import_ae_comps, { ae_project_path: "/tmp/titles.aep" });
+
+    expect(script).toContain('var aeFile = new File("/tmp/titles.aep");');
+    expect(script).toContain("if (!aeFile.exists)");
+    expect(script).toContain("var beforeItems = targetBin.children.numItems;");
+    expect(script).toContain("if (addedItems <= 0)");
+    expect(script).toContain("app.project.importAllAEComps(");
+  });
+
+  it("checks the named-comp path the same way", async () => {
+    const script = await scriptFor(project.import_ae_comps, {
+      ae_project_path: "/tmp/titles.aep",
+      comp_names: ["Lower Third"],
+    });
+
+    expect(script).toContain('app.project.importAEComps("/tmp/titles.aep", ["Lower Third"], targetBin);');
+    expect(script).toContain("if (addedItems <= 0)");
+    expect(script).toContain("the target bin gained no items");
+  });
+
+  it("rejects an empty path before touching the bridge", async () => {
+    await expect(project.import_ae_comps.handler({ ae_project_path: "   " }))
+      .resolves.toMatchObject({ success: false, error: expect.stringContaining("ae_project_path") });
+    expect(mockedSendCommand).not.toHaveBeenCalled();
+  });
+});
+
+// https://github.com/leancoderkavy/premiere-pro-mcp/issues/465
+describe("issue #465 — add_tracks reports the QE index-0 track shift", () => {
+  it("fingerprints every existing track and locates it again afterwards", async () => {
+    const script = await scriptFor(advanced.add_tracks, { video_tracks: 1 });
+
+    expect(script).toContain("function __trackFingerprints(collection)");
+    expect(script).toContain("function __offsetOfExistingTracks(before, after, added)");
+    expect(script).toContain("var beforeVideoFingerprints = __trackFingerprints(seq.videoTracks);");
+    expect(script).toContain("var beforeAudioFingerprints = __trackFingerprints(seq.audioTracks);");
+  });
+
+  it("surfaces the shift instead of leaving a correct total count to imply success", async () => {
+    const script = await scriptFor(advanced.add_tracks, { video_tracks: 2, audio_tracks: 1 });
+
+    expect(script).toContain("newTracksInsertedAtStart: videoShifted || audioShifted");
+    expect(script).toContain("existingVideoTracksShiftedBy");
+    expect(script).toContain("existingAudioTracksShiftedBy");
+    expect(script).toContain("shifted every pre-existing track up");
+    expect(script).toContain("verified: !existingTracksUnlocatable");
+  });
+});
+
+// https://github.com/leancoderkavy/premiere-pro-mcp/issues/466
+describe("issue #466 — get_render_queue_status fails closed on a missing host API", () => {
+  it("never reports an \"unknown\" string as a queue state", async () => {
+    const script = await scriptFor(exports_.get_render_queue_status, {});
+
+    expect(script).not.toContain('"unknown"');
+    expect(script).toContain('typeof encoder.isRunning !== "function"');
+    expect(script).toContain("does not expose app.encoder.isRunning");
+    expect(script).toContain('typeof isRunning !== "boolean"');
+    expect(script).toContain('source: "app.encoder.isRunning"');
+  });
+});
+
+// https://github.com/leancoderkavy/premiere-pro-mcp/issues/459
+describe("issue #459 — manage_sequences_uxp forwards only each action's own parameters", () => {
+  const request = vi.fn().mockResolvedValue({ ok: true });
+  const bridge = { request, getState: () => ({ connected: true, authenticated: true }) } as unknown as UxpWebSocketBridge;
+  const tools = getUxpAdvancedWorkflowTools(bridge) as Record<string, {
+    handler: (args: any) => Promise<any>;
+  }>;
+
+  beforeEach(() => request.mockClear());
+
+  it("sends a documented sequence_id through for the actions that take one", async () => {
+    await tools.manage_sequences_uxp.handler({ action: "clone", sequence_id: "sequence-guid-1" });
+
+    expect(request).toHaveBeenCalledWith("sequences.clone", { sequenceId: "sequence-guid-1" });
+  });
+
+  it("sends the create_from_media parameters without leaking clone-only fields", async () => {
+    await tools.manage_sequences_uxp.handler({
+      action: "create_from_media",
+      name: "Cutdown",
+      project_item_ids: ["item-1"],
+      confirm_non_undoable: true,
+      operation_id: "op-1",
+    });
+
+    expect(request).toHaveBeenCalledWith("sequences.createFromMedia", {
+      name: "Cutdown",
+      projectItemIds: ["item-1"],
+      confirmNonUndoable: true,
+      operationId: "op-1",
+    });
+  });
+
+  it("explains that inspect takes no target instead of letting the host reject it", async () => {
+    const result = await tools.manage_sequences_uxp.handler({
+      action: "inspect",
+      sequence_id: "sequence-guid-1",
+    });
+
+    expect(result).toMatchObject({ success: false, error: expect.stringContaining("takes no other parameters") });
+    expect(result.error).toContain("sequence_id");
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it("names the accepted parameters when an action is given one it does not take", async () => {
+    const result = await tools.manage_sequences_uxp.handler({
+      action: "clone",
+      sequence_id: "sequence-guid-1",
+      name: "Cutdown",
+    });
+
+    expect(result).toMatchObject({ success: false, error: expect.stringContaining("does not accept name") });
+    expect(result.error).toContain("It accepts: sequence_id, operation_id");
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/tests/tools/regressions.test.ts
+++ b/tests/tools/regressions.test.ts
@@ -369,7 +369,7 @@ describe("issue #194 — string-backed MOGRT effect properties", () => {
 
   it("accepts and safely serializes the JSON string exposed by MOGRT text properties", async () => {
     expect(keyframes.set_effect_property.parameters.properties.value).toMatchObject({
-      type: ["number", "string"],
+      type: ["number", "string", "boolean", "array"],
     });
 
     const script = await scriptFor(keyframes.set_effect_property, {
@@ -381,7 +381,7 @@ describe("issue #194 — string-backed MOGRT effect properties", () => {
 
     expect(script).toContain('var requestedValue = "{\\"textEditValue\\":\\"Hello \\\\\\\"editor\\\\\\\"\\"}";');
     expect(script).toContain("prop.setValue(requestedValue, true)");
-    expect(script).toContain("readbackVerified: readbackAvailable && readbackValue === requestedValue");
+    expect(script).toContain("readbackVerified: readbackAvailable && __sameParameterValue(readbackValue, requestedValue)");
   });
 });
 

--- a/tests/tools/structural-verification.test.ts
+++ b/tests/tools/structural-verification.test.ts
@@ -324,7 +324,7 @@ describe("track creation verification", () => {
     expect(script).toContain("var expectedAudio = beforeAudio + 4");
     expect(script).toContain("typeof qeSeq.addTracks !== \"function\"");
     expect(script).toContain("afterVideo !== expectedVideo || afterAudio !== expectedAudio");
-    expect(script).toContain("verified: true");
+    expect(script).toContain("verified: !existingTracksUnlocatable");
   });
 
   it("rejects an empty add_tracks request locally rather than returning a successful no-op", async () => {

--- a/tests/tools/uxp-handler-coverage.test.ts
+++ b/tests/tools/uxp-handler-coverage.test.ts
@@ -60,6 +60,14 @@ describe("UXP tool handler coverage", () => {
     it.each([["required", false], ["all", true]])(`${name} handles %s arguments`, async (_label, all) => {
       const args = argsFor(tool.parameters, all);
       if (name === "manage_timeline_selection_uxp" && all) args.action = "replace";
+      // Each manage_sequences_uxp action accepts only its own parameters, so the
+      // "all properties" sweep has to narrow to one action's argument set.
+      if (name === "manage_sequences_uxp" && all) {
+        args.action = "delete";
+        for (const unsupported of ["name", "project_item_ids", "target_bin_id", "ignore_track_targeting"]) {
+          delete args[unsupported];
+        }
+      }
       const result = await tool.handler(args);
       expect(result).toBeDefined();
       if (name === "get_uxp_capabilities") expect(getState).toHaveBeenCalled();

--- a/tests/uxp/issue-455-committed-unverified.test.ts
+++ b/tests/uxp/issue-455-committed-unverified.test.ts
@@ -1,0 +1,191 @@
+import { createRequire } from "node:module";
+import { describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+const Commands = require("../../uxp-plugin/commands.cjs");
+const Protocol = require("../../uxp-plugin/protocol.cjs");
+
+// https://github.com/leancoderkavy/premiere-pro-mcp/issues/455
+// When the host commits the transaction but produces a different result, the
+// caller must be told the project already changed so it does not retry a
+// destructive edit or abandon one that landed.
+
+type SlipState = { start: number; end: number; inPoint: number; outPoint: number };
+
+function slipHost(apply: (state: SlipState, inSeconds: number, outSeconds: number) => void) {
+  const state: SlipState = { start: 10, end: 20, inPoint: 30, outPoint: 40 };
+  const item = {
+    getStartTime: vi.fn(async () => ({ seconds: state.start })),
+    getEndTime: vi.fn(async () => ({ seconds: state.end })),
+    getInPoint: vi.fn(async () => ({ seconds: state.inPoint })),
+    getOutPoint: vi.fn(async () => ({ seconds: state.outPoint })),
+    getDuration: vi.fn(async () => ({ seconds: state.end - state.start })),
+    getSpeed: vi.fn(async () => 1),
+    isSpeedReversed: vi.fn(async () => false),
+    createSetInPointAction: vi.fn((time: { seconds: number }) => ({ kind: "in", seconds: time.seconds })),
+    createSetOutPointAction: vi.fn((time: { seconds: number }) => ({ kind: "out", seconds: time.seconds })),
+  };
+  const pending: { kind: string; seconds: number }[] = [];
+  const videoTrack = { getTrackItems: vi.fn(async () => [item]) };
+  const sequence = {
+    guid: "sequence-1",
+    getVideoTrackCount: vi.fn(async () => 1),
+    getVideoTrack: vi.fn(async () => videoTrack),
+    getAudioTrackCount: vi.fn(async () => 0),
+    getAudioTrack: vi.fn(async () => null),
+  };
+  const project = {
+    guid: "project-1",
+    getActiveSequence: vi.fn(async () => sequence),
+    lockedAccess: vi.fn((callback: () => void) => callback()),
+    executeTransaction: vi.fn((callback: (compound: { addAction: (action: { kind: string; seconds: number }) => boolean }) => void) => {
+      pending.length = 0;
+      callback({ addAction: (action) => { pending.push(action); return true; } });
+      const inAction = pending.find((action) => action.kind === "in");
+      const outAction = pending.find((action) => action.kind === "out");
+      apply(state, inAction!.seconds, outAction!.seconds);
+      return true;
+    }),
+  };
+  const ppro = {
+    Project: { getActiveProject: vi.fn(async () => project) },
+    TickTime: { createWithSeconds: vi.fn((seconds: number) => ({ seconds })) },
+    Constants: { TrackItemType: { CLIP: 1 } },
+  };
+  return { state, project, registry: Commands.createCommandRegistry({ ppro, Protocol }) };
+}
+
+const slipSnapshot = {
+  projectGuid: "project-1", sequenceId: "sequence-1", mediaType: "video", trackIndex: 0, clipIndex: 0,
+  startSeconds: 10, endSeconds: 20, inSeconds: 30, outSeconds: 40, durationSeconds: 10, speed: 1, reversed: false,
+};
+
+describe("issue #455 — a committed slip that lands wrong is not reported as a plain failure", () => {
+  it("says the project already changed and describes the timeline move", async () => {
+    // The host moves the whole item instead of only the source range.
+    const host = slipHost((state, inSeconds, outSeconds) => {
+      const offset = inSeconds - state.inPoint;
+      state.inPoint = inSeconds;
+      state.outPoint = outSeconds;
+      state.start += offset;
+      state.end += offset;
+    });
+
+    const failure = await host.registry.dispatch("trackItem.slip", {
+      mediaType: "video", trackIndex: 0, clipIndex: 0,
+      expectedSnapshot: slipSnapshot, slipBySeconds: 1, confirmSlip: true, operationId: "slip-1",
+    }).catch((error: Error & { code?: string }) => error);
+
+    expect(failure).toMatchObject({ code: "UXP_COMMITTED_UNVERIFIED" });
+    expect((failure as Error).message).toContain("the project has already changed");
+    expect((failure as Error).message).toContain("the timeline position moved (start 10s -> 11s, end 20s -> 21s)");
+    expect((failure as Error).message).toContain("Do not retry this call");
+    expect(host.state).toEqual({ start: 11, end: 21, inPoint: 31, outPoint: 41 });
+  });
+
+  it("still reports a correct slip as verified", async () => {
+    const host = slipHost((state, inSeconds, outSeconds) => {
+      state.inPoint = inSeconds;
+      state.outPoint = outSeconds;
+    });
+
+    await expect(host.registry.dispatch("trackItem.slip", {
+      mediaType: "video", trackIndex: 0, clipIndex: 0,
+      expectedSnapshot: slipSnapshot, slipBySeconds: 1, confirmSlip: true, operationId: "slip-2",
+    })).resolves.toMatchObject({ slipped: true, outcome: "verified" });
+  });
+});
+
+type RippleState = { projectItemId: string; start: number; end: number; inPoint: number; outPoint: number };
+
+function rippleHost(ripple: boolean) {
+  const states: RippleState[] = [
+    { projectItemId: "target-1", start: 0, end: 10, inPoint: 20, outPoint: 30 },
+    { projectItemId: "following-1", start: 10, end: 20, inPoint: 40, outPoint: 50 },
+  ];
+  function itemFor(state: RippleState) {
+    return {
+      getProjectItem: vi.fn(async () => ({ getId: vi.fn(async () => state.projectItemId) })),
+      getStartTime: vi.fn(async () => ({ seconds: state.start })),
+      getEndTime: vi.fn(async () => ({ seconds: state.end })),
+      getInPoint: vi.fn(async () => ({ seconds: state.inPoint })),
+      getOutPoint: vi.fn(async () => ({ seconds: state.outPoint })),
+      getDuration: vi.fn(async () => ({ seconds: state.end - state.start })),
+      getSpeed: vi.fn(async () => 1),
+      isSpeedReversed: vi.fn(async () => false),
+    };
+  }
+  const items = states.map(itemFor);
+  const videoTrack = { getTrackItems: vi.fn(async () => items) };
+  const sequence = {
+    guid: "sequence-1",
+    getVideoTrackCount: vi.fn(async () => 1), getVideoTrack: vi.fn(async () => videoTrack),
+    getAudioTrackCount: vi.fn(async () => 0), getAudioTrack: vi.fn(async () => null),
+  };
+  let selected: typeof items[number] | null = null;
+  const createRemoveItemsAction = vi.fn(() => ({
+    apply: () => {
+      const index = items.indexOf(selected!);
+      const duration = states[index]!.end - states[index]!.start;
+      states.splice(index, 1);
+      items.splice(index, 1);
+      // A build that ignores the ripple flag deletes the clip and leaves a gap.
+      if (!ripple) return;
+      for (let later = index; later < states.length; later += 1) {
+        states[later]!.start -= duration;
+        states[later]!.end -= duration;
+      }
+    },
+  }));
+  const project = {
+    guid: "project-1", getActiveSequence: vi.fn(async () => sequence),
+    lockedAccess: vi.fn((callback: () => void) => callback()),
+    executeTransaction: vi.fn((callback: (compound: { addAction: (action: { apply: () => void }) => boolean }) => void) => {
+      callback({ addAction: (action) => { action.apply(); return true; } });
+      return true;
+    }),
+  };
+  const ppro = {
+    Project: { getActiveProject: vi.fn(async () => project) },
+    SequenceEditor: { getEditor: vi.fn(() => ({ createRemoveItemsAction })) },
+    TrackItemSelection: {
+      createEmptySelection: vi.fn((callback: (selection: { addItem: (item: typeof items[number]) => boolean }) => void) => {
+        callback({ addItem: (item) => { selected = item; return true; } });
+        return true;
+      }),
+    },
+    Constants: { TrackItemType: { CLIP: 1 }, MediaType: { VIDEO: 1, AUDIO: 2 } },
+  };
+  return { states, registry: Commands.createCommandRegistry({ ppro, Protocol }) };
+}
+
+const rippleSnapshot = {
+  projectGuid: "project-1", sequenceId: "sequence-1", mediaType: "video", trackIndex: 0, clipIndex: 0, trackItemCount: 2,
+  target: { projectItemId: "target-1", startSeconds: 0, endSeconds: 10, inSeconds: 20, outSeconds: 30, durationSeconds: 10, speed: 1, reversed: false },
+  following: { projectItemId: "following-1", startSeconds: 10, endSeconds: 20, inSeconds: 40, outSeconds: 50, durationSeconds: 10, speed: 1, reversed: false },
+};
+
+describe("issue #455 — a committed delete that did not ripple is reported as committed", () => {
+  it("names the gap the delete left instead of implying nothing happened", async () => {
+    const host = rippleHost(false);
+
+    const failure = await host.registry.dispatch("trackItem.rippleDelete", {
+      mediaType: "video", trackIndex: 0, clipIndex: 0,
+      expectedSnapshot: rippleSnapshot, confirmRippleDelete: true, operationId: "ripple-1",
+    }).catch((error: Error & { code?: string }) => error);
+
+    expect(failure).toMatchObject({ code: "UXP_COMMITTED_UNVERIFIED" });
+    expect((failure as Error).message).toContain("the project has already changed");
+    expect((failure as Error).message).toContain("the delete left a gap of 10s");
+    expect((failure as Error).message).toContain("Do not retry this call");
+    // The clip really is gone, which is exactly why a retry must not happen.
+    expect(host.states).toHaveLength(1);
+  });
+
+  it("still reports a genuine ripple delete as verified", async () => {
+    await expect(rippleHost(true).registry.dispatch("trackItem.rippleDelete", {
+      mediaType: "video", trackIndex: 0, clipIndex: 0,
+      expectedSnapshot: rippleSnapshot, confirmRippleDelete: true, operationId: "ripple-2",
+    })).resolves.toMatchObject({ rippleDeleted: true, outcome: "verified" });
+  });
+});

--- a/tests/uxp/issues-454-456.test.ts
+++ b/tests/uxp/issues-454-456.test.ts
@@ -1,0 +1,156 @@
+import { createRequire } from "node:module";
+import { describe, expect, it, vi } from "vitest";
+
+const require = createRequire(import.meta.url);
+const Commands = require("../../uxp-plugin/commands.cjs");
+const Protocol = require("../../uxp-plugin/protocol.cjs");
+
+// https://github.com/leancoderkavy/premiere-pro-mcp/issues/454
+// Premiere 26.3 hands back base track items whose documented transition, timing,
+// and identity getters only appear through VideoClipTrackItem.cast().
+describe("issue #454 — video-transition inspection casts the track item", () => {
+  function transitionHost(options: { castable?: boolean } = {}) {
+    const clipView = {
+      getProjectItem: vi.fn(async () => baseProjectItem),
+      getStartTime: vi.fn(async () => ({ seconds: 4 })),
+      getEndTime: vi.fn(async () => ({ seconds: 9 })),
+      hasVideoTransition: vi.fn(async () => false),
+    };
+    // The raw item exposes none of the VideoClipTrackItem surface.
+    const rawItem = { name: "clip" };
+    const projectItemView = { getId: vi.fn(async () => "project-item-1") };
+    const baseProjectItem = { name: "source" };
+    const videoTrack = { getTrackItems: vi.fn(async () => [rawItem]) };
+    const sequence = {
+      guid: "sequence-1",
+      getVideoTrackCount: vi.fn(async () => 1),
+      getVideoTrack: vi.fn(async () => videoTrack),
+    };
+    const project = { guid: "project-1", getActiveSequence: vi.fn(async () => sequence) };
+    const ppro: Record<string, unknown> = {
+      Project: { getActiveProject: vi.fn(async () => project) },
+      Constants: { TrackItemType: { CLIP: 1 }, TransitionPosition: { START: 0, END: 1 } },
+      ProjectItem: { cast: vi.fn((item: unknown) => (item === baseProjectItem ? projectItemView : null)) },
+    };
+    if (options.castable !== false) {
+      ppro.VideoClipTrackItem = { cast: vi.fn((item: unknown) => (item === rawItem ? clipView : null)) };
+    }
+    return { clipView, registry: Commands.createCommandRegistry({ ppro, Protocol }) };
+  }
+
+  const target = { videoTrackIndex: 0, clipIndex: 0, position: "end" };
+
+  it("reads a complete snapshot from an item that only exposes the cast surface", async () => {
+    const host = transitionHost();
+
+    await expect(host.registry.dispatch("transition.video.inspect", target)).resolves.toMatchObject({
+      target: {
+        sequenceGuid: "sequence-1",
+        videoTrackIndex: 0,
+        clipIndex: 0,
+        projectItemId: "project-item-1",
+        startSeconds: 4,
+        endSeconds: 9,
+        position: "end",
+        transitionPresent: false,
+      },
+    });
+    expect(host.clipView.hasVideoTransition).toHaveBeenCalled();
+  });
+
+  it("names the missing methods when no cast can supply them", async () => {
+    await expect(transitionHost({ castable: false }).registry.dispatch("transition.video.inspect", target))
+      .rejects.toMatchObject({
+        code: "UXP_COMMAND_UNAVAILABLE",
+        message: expect.stringContaining("VideoClipTrackItem.getProjectItem"),
+      });
+  });
+});
+
+// https://github.com/leancoderkavy/premiere-pro-mcp/issues/456
+// getId() is documented on ProjectItem, so a bin or clip reached through the
+// project tree has to be identified through ProjectItem.cast().
+describe("issue #456 — project-item identity resolves through ProjectItem.cast", () => {
+  function proxyHost() {
+    const clip = {
+      canChangeMediaPath: vi.fn(async () => true),
+      isOffline: vi.fn(async () => false),
+      canProxy: vi.fn(async () => true),
+      hasProxy: vi.fn(async () => false),
+    };
+    // Neither the root bin nor the clip exposes getId directly.
+    const root = { getItems: vi.fn(async () => [clip]) };
+    const project = { guid: "project-1", getRootItem: vi.fn(async () => root) };
+    const ppro = {
+      Project: { getActiveProject: vi.fn(async () => project) },
+      ProjectItem: { cast: vi.fn((item: unknown) => (item === clip ? { getId: async () => "clip-1" } : null)) },
+      FolderItem: { cast: vi.fn((item: unknown) => (item === root ? root : null)) },
+      ClipProjectItem: { cast: vi.fn((item: unknown) => (item === clip ? clip : null)) },
+    };
+    return { registry: Commands.createCommandRegistry({ ppro, Protocol }) };
+  }
+
+  it("inspects a proxy target whose ID is only reachable through the cast", async () => {
+    await expect(proxyHost().registry.dispatch("source.proxy.inspect", { projectItemId: "clip-1" })).resolves.toEqual({
+      projectGuid: "project-1",
+      projectItemId: "clip-1",
+      canChangeMediaPath: true,
+      isOffline: false,
+      canProxy: true,
+      hasProxy: false,
+    });
+  });
+
+  it("still reports an honest capability error when no cast exposes getId", async () => {
+    const clip = { canProxy: vi.fn(async () => true) };
+    const root = { getItems: vi.fn(async () => [clip]), getId: vi.fn(async () => "root-1") };
+    const project = { guid: "project-1", getRootItem: vi.fn(async () => root) };
+    const registry = Commands.createCommandRegistry({
+      ppro: {
+        Project: { getActiveProject: vi.fn(async () => project) },
+        FolderItem: { cast: vi.fn((item: unknown) => (item === root ? root : null)) },
+        ClipProjectItem: { cast: vi.fn(() => null) },
+      },
+      Protocol,
+    });
+
+    // The requested ID is never found because nothing can answer for identity.
+    await expect(registry.dispatch("source.proxy.inspect", { projectItemId: "clip-1" }))
+      .rejects.toMatchObject({ code: "UXP_TARGET_NOT_FOUND" });
+  });
+
+  it("identifies a timeline clip's source through ProjectItem.cast for source labels", async () => {
+    const source = {
+      getColorLabelIndex: vi.fn(async () => 3),
+    };
+    const rawSourceItem = { name: "source" };
+    const trackItem = {
+      getProjectItem: vi.fn(async () => rawSourceItem),
+      getStartTime: vi.fn(async () => ({ seconds: 1 })),
+      getEndTime: vi.fn(async () => ({ seconds: 6 })),
+    };
+    const videoTrack = { getTrackItems: vi.fn(async () => [trackItem]) };
+    const sequence = {
+      guid: "sequence-1",
+      getVideoTrackCount: vi.fn(async () => 1),
+      getVideoTrack: vi.fn(async () => videoTrack),
+    };
+    const project = { guid: "project-1", getActiveSequence: vi.fn(async () => sequence) };
+    const registry = Commands.createCommandRegistry({
+      ppro: {
+        Project: { getActiveProject: vi.fn(async () => project) },
+        Constants: { TrackItemType: { CLIP: 1 } },
+        ClipProjectItem: { cast: vi.fn((item: unknown) => (item === rawSourceItem ? source : null)) },
+        ProjectItem: { cast: vi.fn((item: unknown) => (item === rawSourceItem ? { getId: async () => "source-1" } : null)) },
+      },
+      Protocol,
+    });
+
+    await expect(registry.dispatch("timeline.sourceLabel.inspect", {
+      mediaType: "video", trackIndex: 0, clipIndex: 0,
+    })).resolves.toMatchObject({
+      sourceProjectItemId: "source-1",
+      sourceColorLabelIndex: 3,
+    });
+  });
+});

--- a/uxp-plugin/commands.cjs
+++ b/uxp-plugin/commands.cjs
@@ -1200,13 +1200,15 @@
       return { ...context, target, before, positionValue };
     }
     async function transitionTargetSnapshot(sequence, videoTrackIndex, clipIndex, position, target, positionValue) {
-      const item = target || await videoClipAt(sequence, videoTrackIndex, clipIndex);
+      const item = videoClipView(target) || await videoClipAt(sequence, videoTrackIndex, clipIndex);
       const edge = positionValue == null ? transitionPositionValue(position) : positionValue;
-      if (typeof item.getProjectItem !== "function" || typeof item.getStartTime !== "function" || typeof item.getEndTime !== "function" || typeof item.hasVideoTransition !== "function") {
-        throw commandError("UXP_COMMAND_UNAVAILABLE", "This Premiere build cannot read a complete video-transition target snapshot");
+      const missing = ["getProjectItem", "getStartTime", "getEndTime", "hasVideoTransition"]
+        .filter((method) => typeof item[method] !== "function");
+      if (missing.length) {
+        throw commandError("UXP_COMMAND_UNAVAILABLE", "This Premiere build cannot read a complete video-transition target snapshot: VideoClipTrackItem." + missing.join(", VideoClipTrackItem.") + " is unavailable on the resolved clip");
       }
-      const projectItem = await item.getProjectItem();
-      if (!projectItem || typeof projectItem.getId !== "function") throw commandError("UXP_COMMAND_UNAVAILABLE", "This Premiere build cannot identify the selected video clip");
+      const projectItem = projectItemIdentityView(await item.getProjectItem());
+      if (!projectItem) throw commandError("UXP_COMMAND_UNAVAILABLE", "This Premiere build cannot identify the selected video clip: getId is unavailable directly and through ProjectItem.cast");
       const projectItemId = await projectItem.getId();
       const startSeconds = tickSecondsRequired(await item.getStartTime(), "video transition target start"), endSeconds = tickSecondsRequired(await item.getEndTime(), "video transition target end");
       if (typeof projectItemId !== "string" || !projectItemId || endSeconds < startSeconds) {
@@ -1401,7 +1403,37 @@
       if (!track || !types || types.CLIP == null) throw commandError("UXP_COMMAND_UNAVAILABLE", "Premiere video track APIs are unavailable");
       const clips = await track.getTrackItems(types.CLIP, false);
       if (!clips || !clips[clipIndex]) throw commandError("UXP_TARGET_NOT_FOUND", "clipIndex " + clipIndex + " is out of range on video track " + trackIndex);
-      return clips[clipIndex];
+      return videoClipView(clips[clipIndex]);
+    }
+    // The transition, timing, and identity getters below are documented on
+    // VideoClipTrackItem. A track item returned by Track.getTrackItems() is not
+    // guaranteed to expose them directly, so read them through the documented
+    // cast before treating the build as incapable.
+    function videoClipView(item) {
+      if (!item) return item;
+      if (typeof item.hasVideoTransition === "function") return item;
+      if (ppro.VideoClipTrackItem && typeof ppro.VideoClipTrackItem.cast === "function") {
+        try {
+          const cast = ppro.VideoClipTrackItem.cast(item);
+          if (cast && typeof cast.hasVideoTransition === "function") return cast;
+        } catch (_) {
+          // A track item that cannot be cast simply has no transition surface.
+        }
+      }
+      return item;
+    }
+    function projectItemIdentityView(item) {
+      if (!item) return null;
+      if (typeof item.getId === "function") return item;
+      if (ppro.ProjectItem && typeof ppro.ProjectItem.cast === "function") {
+        try {
+          const cast = ppro.ProjectItem.cast(item);
+          if (cast && typeof cast.getId === "function") return cast;
+        } catch (_) {
+          // An item that cannot be cast simply cannot answer for its identity.
+        }
+      }
+      return null;
     }
     function assertTransactionCommitted(committed, operation) {
       if (!committed) throw commandError("UXP_TRANSACTION_FAILED", "Premiere did not commit the " + operation + " transaction");

--- a/uxp-plugin/ripple-delete-workflows.cjs
+++ b/uxp-plugin/ripple-delete-workflows.cjs
@@ -118,7 +118,15 @@
         }
         const after = await rippleReadback(afterContext, before);
         if (!sameRippleResult(before, after)) {
-          throw commandError("UXP_VERIFICATION_FAILED", "Premiere did not retain the requested contiguous ripple-delete result");
+          // The remove transaction already committed, so the project has
+          // changed even though the ripple result is wrong. Reporting a bare
+          // failure would invite a retry that deletes a second clip.
+          throw commandError(
+            "UXP_COMMITTED_UNVERIFIED",
+            "Premiere committed the remove transaction, so the project has already changed, but the result is not the requested contiguous ripple delete: " +
+              describeRippleDivergence(before, after) +
+              ". Do not retry this call. Inspect the track and undo the edit in Premiere if the result is unwanted."
+          );
         }
         return {
           rippleDeleted: true,
@@ -250,6 +258,40 @@
         numbersEqual(successor.inSeconds, following.inSeconds) && numbersEqual(successor.outSeconds, following.outSeconds) &&
         numbersEqual(successor.durationSeconds, following.durationSeconds) &&
         numbersEqual(successor.speed, following.speed) && successor.reversed === following.reversed;
+    }
+
+    function describeRippleDivergence(before, after) {
+      const notes = [];
+      const targetTimelineDuration = before.target.endSeconds - before.target.startSeconds;
+      const following = before.following, successor = after.successor;
+      if (after.projectGuid !== before.projectGuid || after.sequenceId !== before.sequenceId ||
+        after.mediaType !== before.mediaType || after.trackIndex !== before.trackIndex) {
+        notes.push("the coordinate no longer resolves the same project, sequence, or track");
+      }
+      if (after.trackItemCount === before.trackItemCount) {
+        notes.push("the track still holds " + after.trackItemCount + " clip items, so nothing was removed");
+      } else if (after.trackItemCount !== before.trackItemCount - 1) {
+        notes.push("the track holds " + after.trackItemCount + " clip items instead of the expected " + (before.trackItemCount - 1));
+      }
+      if (successor.projectItemId !== following.projectItemId) {
+        notes.push("a different clip now occupies the removed item's index");
+      } else if (!numbersEqual(successor.startSeconds, following.startSeconds - targetTimelineDuration)) {
+        notes.push(numbersEqual(successor.startSeconds, following.startSeconds)
+          ? "the following clip did not move, so the delete left a gap of " + seconds(targetTimelineDuration) +
+            " instead of rippling the track closed"
+          : "the following clip starts at " + seconds(successor.startSeconds) + " instead of the expected " +
+            seconds(following.startSeconds - targetTimelineDuration));
+      }
+      if (successor.projectItemId === following.projectItemId &&
+        (!numbersEqual(successor.inSeconds, following.inSeconds) || !numbersEqual(successor.outSeconds, following.outSeconds) ||
+          !numbersEqual(successor.durationSeconds, following.durationSeconds))) {
+        notes.push("the following clip's source range or duration changed, which a ripple delete must leave untouched");
+      }
+      return notes.length ? notes.join("; ") : "the readback did not match the requested ripple delete";
+    }
+
+    function seconds(value) {
+      return (Math.round(value * 1000) / 1000) + "s";
     }
 
     function sameSnapshot(left, right) {

--- a/uxp-plugin/slip-workflows.cjs
+++ b/uxp-plugin/slip-workflows.cjs
@@ -102,7 +102,15 @@
         }
         const after = await slipSnapshot(afterContext);
         if (!sameSlipResult(before, after, desired)) {
-          throw commandError("UXP_VERIFICATION_FAILED", "Premiere did not retain the requested source-only slip");
+          // The transaction already committed, so this is not a "nothing
+          // happened" failure. Say what actually landed and forbid a retry:
+          // re-issuing the slip would apply a second offset to a moved item.
+          throw commandError(
+            "UXP_COMMITTED_UNVERIFIED",
+            "Premiere committed the slip transaction, so the project has already changed, but the result is not the requested source-only slip: " +
+              describeSlipDivergence(before, after, desired) +
+              ". Do not retry this call. Inspect the item and undo the edit in Premiere if the result is unwanted."
+          );
         }
         return {
           slipped: true,
@@ -207,6 +215,32 @@
         numbersEqual(after.speed, before.speed) && after.reversed === before.reversed &&
         numbersEqual(after.inSeconds, desired.inSeconds) && numbersEqual(after.outSeconds, desired.outSeconds) &&
         numbersEqual(after.outSeconds - after.inSeconds, desired.sourceDuration);
+    }
+
+    function describeSlipDivergence(before, after, desired) {
+      const notes = [];
+      if (!sameSnapshotIdentity(before, after)) {
+        notes.push("the coordinate no longer resolves the same project, sequence, or track");
+      }
+      if (!numbersEqual(after.startSeconds, before.startSeconds) || !numbersEqual(after.endSeconds, before.endSeconds)) {
+        notes.push("the timeline position moved (start " + seconds(before.startSeconds) + " -> " + seconds(after.startSeconds) +
+          ", end " + seconds(before.endSeconds) + " -> " + seconds(after.endSeconds) + ") when a slip must leave it fixed");
+      }
+      if (!numbersEqual(after.inSeconds, desired.inSeconds) || !numbersEqual(after.outSeconds, desired.outSeconds)) {
+        notes.push("the source range is " + seconds(after.inSeconds) + "-" + seconds(after.outSeconds) +
+          " instead of the requested " + seconds(desired.inSeconds) + "-" + seconds(desired.outSeconds));
+      }
+      if (!numbersEqual(after.durationSeconds, before.durationSeconds)) {
+        notes.push("the duration changed from " + seconds(before.durationSeconds) + " to " + seconds(after.durationSeconds));
+      }
+      if (!numbersEqual(after.speed, before.speed) || after.reversed !== before.reversed) {
+        notes.push("the clip speed or direction changed");
+      }
+      return notes.length ? notes.join("; ") : "the readback did not match the requested slip";
+    }
+
+    function seconds(value) {
+      return (Math.round(value * 1000) / 1000) + "s";
     }
 
     function sameSnapshot(left, right) {

--- a/uxp-plugin/source-media-provenance-workflows.cjs
+++ b/uxp-plugin/source-media-provenance-workflows.cjs
@@ -67,12 +67,12 @@
       if (!projectItem) {
         throw commandError("UXP_TARGET_NOT_FOUND", "projectItemId does not identify an item in the active project");
       }
-      const resolvedId = requiredText(requiredMethod(projectItem, "getId")(), "resolved project item ID", 512);
+      const resolvedId = await requiredProjectItemId(projectItem, "resolved project item ID");
       if (resolvedId !== request.projectItemId) {
         throw commandError("UXP_STALE_SOURCE_PROVENANCE", "The resolved project item ID changed during provenance inspection");
       }
       const clipProjectItem = castClipProjectItem(projectItem);
-      const readbackId = requiredText(requiredMethod(projectItem, "getId")(), "resolved project item ID", 512);
+      const readbackId = await requiredProjectItemId(projectItem, "resolved project item ID");
       if (readbackId !== request.projectItemId) {
         throw commandError("UXP_STALE_SOURCE_PROVENANCE", "The resolved project item changed before provenance getters ran");
       }
@@ -84,6 +84,45 @@
         snapshot.originatingProjectPath = boundedPath(await requiredMethod(clipProjectItem, "getOriginatingProjectPath")(), "originating project path");
       }
       return snapshot;
+    }
+
+    // getId() is documented on ProjectItem. A project item reached through
+    // Project.getRootItem()/FolderItem.getItems() is not guaranteed to expose it
+    // directly, so identity has to be read through the documented ProjectItem
+    // cast before the method can be treated as unavailable.
+    function identityView(item) {
+      if (item && typeof item.getId === "function") return item;
+      if (item && ppro.ProjectItem && typeof ppro.ProjectItem.cast === "function") {
+        try {
+          const cast = ppro.ProjectItem.cast(item);
+          if (cast && typeof cast.getId === "function") return cast;
+        } catch (_) {
+          // An item that cannot be cast simply cannot answer for its identity.
+        }
+      }
+      return null;
+    }
+
+    async function requiredProjectItemId(item, name) {
+      const identity = identityView(item);
+      if (!identity) {
+        throw commandError("UXP_COMMAND_UNAVAILABLE", "Premiere does not expose getId for this target, directly or through ProjectItem.cast");
+      }
+      return requiredText(await identity.getId(), name, 512);
+    }
+
+    async function optionalProjectItemId(item) {
+      const identity = identityView(item);
+      if (!identity) return null;
+      let value;
+      try {
+        value = await identity.getId();
+      } catch (_) {
+        return null;
+      }
+      return typeof value === "string" && value.length && value.length <= 512 && value.indexOf("\u0000") === -1
+        ? value
+        : null;
     }
 
     async function activeProject() {
@@ -103,13 +142,15 @@
       const visited = new Set();
       while (pending.length) {
         const candidate = pending.shift();
-        const candidateId = requiredText(requiredMethod(candidate, "getId")(), "project item ID", 512);
-        if (visited.has(candidateId)) continue;
-        visited.add(candidateId);
+        if (!candidate || typeof candidate !== "object" || visited.has(candidate)) continue;
+        visited.add(candidate);
         if (visited.size > 4096) {
           throw commandError("UXP_TARGET_TOO_LARGE", "The active project has more than 4096 reachable project items");
         }
-        if (candidateId === expectedId) return candidate;
+        // A bin or root folder that exposes no readable ID is still traversed;
+        // only the requested target has to be identifiable.
+        const candidateId = await optionalProjectItemId(candidate);
+        if (candidateId && candidateId === expectedId) return candidate;
         const folder = castFolderItem(candidate);
         if (!folder) continue;
         const children = await requiredMethod(folder, "getItems")();

--- a/uxp-plugin/source-proxy-workflows.cjs
+++ b/uxp-plugin/source-proxy-workflows.cjs
@@ -57,12 +57,12 @@
       if (!projectItem) {
         throw commandError("UXP_TARGET_NOT_FOUND", "projectItemId does not identify an item in the active project");
       }
-      const resolvedId = requiredText(requiredMethod(projectItem, "getId")(), "resolved project item ID", 512);
+      const resolvedId = await requiredProjectItemId(projectItem, "resolved project item ID");
       if (resolvedId !== request.projectItemId) {
         throw commandError("UXP_STALE_SOURCE_PROXY", "The resolved project item ID changed during proxy inspection");
       }
       const clipProjectItem = castClipProjectItem(projectItem);
-      const readbackId = requiredText(requiredMethod(projectItem, "getId")(), "resolved project item ID", 512);
+      const readbackId = await requiredProjectItemId(projectItem, "resolved project item ID");
       if (readbackId !== request.projectItemId) {
         throw commandError("UXP_STALE_SOURCE_PROXY", "The resolved project item changed before proxy getters ran");
       }
@@ -78,6 +78,45 @@
         snapshot.proxyPath = boundedPath(await requiredMethod(clipProjectItem, "getProxyPath")(), "proxy path");
       }
       return snapshot;
+    }
+
+    // getId() is documented on ProjectItem. A project item reached through
+    // Project.getRootItem()/FolderItem.getItems() is not guaranteed to expose it
+    // directly, so identity has to be read through the documented ProjectItem
+    // cast before the method can be treated as unavailable.
+    function identityView(item) {
+      if (item && typeof item.getId === "function") return item;
+      if (item && ppro.ProjectItem && typeof ppro.ProjectItem.cast === "function") {
+        try {
+          const cast = ppro.ProjectItem.cast(item);
+          if (cast && typeof cast.getId === "function") return cast;
+        } catch (_) {
+          // An item that cannot be cast simply cannot answer for its identity.
+        }
+      }
+      return null;
+    }
+
+    async function requiredProjectItemId(item, name) {
+      const identity = identityView(item);
+      if (!identity) {
+        throw commandError("UXP_COMMAND_UNAVAILABLE", "Premiere does not expose getId for this target, directly or through ProjectItem.cast");
+      }
+      return requiredText(await identity.getId(), name, 512);
+    }
+
+    async function optionalProjectItemId(item) {
+      const identity = identityView(item);
+      if (!identity) return null;
+      let value;
+      try {
+        value = await identity.getId();
+      } catch (_) {
+        return null;
+      }
+      return typeof value === "string" && value.length && value.length <= 512 && value.indexOf("\u0000") === -1
+        ? value
+        : null;
     }
 
     async function activeProject() {
@@ -97,13 +136,15 @@
       const visited = new Set();
       while (pending.length) {
         const candidate = pending.shift();
-        const candidateId = requiredText(requiredMethod(candidate, "getId")(), "project item ID", 512);
-        if (visited.has(candidateId)) continue;
-        visited.add(candidateId);
+        if (!candidate || typeof candidate !== "object" || visited.has(candidate)) continue;
+        visited.add(candidate);
         if (visited.size > 4096) {
           throw commandError("UXP_TARGET_TOO_LARGE", "The active project has more than 4096 reachable project items");
         }
-        if (candidateId === expectedId) return candidate;
+        // A bin or root folder that exposes no readable ID is still traversed;
+        // only the requested target has to be identifiable.
+        const candidateId = await optionalProjectItemId(candidate);
+        if (candidateId && candidateId === expectedId) return candidate;
         const folder = castFolderItem(candidate);
         if (!folder) continue;
         const children = await requiredMethod(folder, "getItems")();

--- a/uxp-plugin/timeline-source-label-workflows.cjs
+++ b/uxp-plugin/timeline-source-label-workflows.cjs
@@ -34,6 +34,27 @@
       }
     };
 
+    // getId() is documented on ProjectItem, not on the ClipProjectItem or track
+    // item a caller resolves, so the identity read has to happen through the
+    // documented ProjectItem cast before it can be treated as unavailable.
+    function identityView(...candidates) {
+      for (const candidate of candidates) {
+        if (candidate && typeof candidate.getId === "function") return candidate;
+      }
+      if (ppro.ProjectItem && typeof ppro.ProjectItem.cast === "function") {
+        for (const candidate of candidates) {
+          if (!candidate) continue;
+          try {
+            const cast = ppro.ProjectItem.cast(candidate);
+            if (cast && typeof cast.getId === "function") return cast;
+          } catch (_) {
+            // A candidate that cannot be cast simply cannot answer for identity.
+          }
+        }
+      }
+      return candidates.find(Boolean) || null;
+    }
+
     function canUseTimelineSourceLabels() {
       return !!(ppro.Project && typeof ppro.Project.getActiveProject === "function" &&
         ppro.Constants && ppro.Constants.TrackItemType && ppro.ClipProjectItem && typeof ppro.ClipProjectItem.cast === "function");
@@ -127,7 +148,7 @@
       let source;
       try { source = ppro.ClipProjectItem.cast(sourceItem); } catch (_) { source = null; }
       if (!source) throw commandError("UXP_TARGET_UNSUPPORTED", "The resolved timeline item has no ClipProjectItem color-label surface");
-      const sourceProjectItemId = requiredIdentifier(await requiredMethod(source, "getId")(), "source project-item ID");
+      const sourceProjectItemId = requiredIdentifier(await requiredMethod(identityView(sourceItem, source), "getId")(), "source project-item ID");
       return {
         project,
         sequence,


### PR DESCRIPTION
Fixes every open bug reported against 1.14.9 on Premiere Pro 26.3.2 build 2.

Closes #454, closes #455, closes #456, closes #457, closes #458, closes #459, closes #460, closes #462, closes #463, closes #464, closes #465, closes #466.

## Root causes

**Missing UXP host-object casts (#454, #456).** `getId()` is documented on `ProjectItem` and the transition/timing getters on `VideoClipTrackItem`, but the objects returned by `FolderItem.getItems()`, `Track.getTrackItems()`, and `ClipProjectItem.cast()` do not expose them directly on this build. The plugin called them straight on the returned object, so `inspect_source_proxy_uxp` and `manage_timeline_source_label_uxp` failed universally with "Premiere does not expose getId for this target", and `inspect_video_transition_uxp` failed on every clip edge — taking `add_video_transition_uxp` / `remove_video_transition_uxp` down with it, since they need its snapshot. Identity and the transition surface are now resolved through the documented cast first; a genuine gap names the exact missing methods. Project-tree traversal no longer requires every bin to be identifiable, and the previously un-awaited `getId()` promise is awaited. `inspect_source_media_provenance_uxp` carried the identical three-line defect and is fixed with it.

**Committed-but-divergent mutations reported as plain failures (#455).** `ripple_delete_track_item_uxp` and `slip_track_item_uxp` commit their transaction, then verify. When the host produced a different result the tools threw a bare `UXP_VERIFICATION_FAILED`, which reads as "nothing happened" — so a caller could retry a destructive edit or abandon one that succeeded. Both now fail with `UXP_COMMITTED_UNVERIFIED`, state that the project has already changed, describe what actually landed (for example "the following clip did not move, so the delete left a gap of 10s instead of rippling the track closed"), and tell the caller not to retry.

**Wrong or missing host arguments (#458, #459).** `app.openFCPXML(path, projPath)` takes two arguments; the tool passed one, so every call failed with "Not Enough Parameters". `import_fcp_xml` now takes a required `project_path`, checks the XML exists, refuses to overwrite an existing project, and verifies the destination was created — and its description no longer claims it merges into the open project, which it never did. Separately, `manage_sequences_uxp` blanket-forwarded every documented parameter to commands that each accept only their own set (`sequences.inspect` accepts none), so its own documented `sequence_id` / `name` were rejected by the host. It now forwards only what the chosen action takes and explains locally which parameters that action accepts.

## Verification tightened

| Issue | Tool | Change |
|---|---|---|
| #457 | `roll_edit` | Moves the source out point and incoming in point with the visible cut and verifies all four, so the timeline can no longer disagree with the clips' in/out metadata after a reported success |
| #460 | `attach_custom_property` | Reads the sequence project item's XMP packet before and after the write; fails when the property never lands in XMP |
| #462 | `undo`, `redo` | Fail closed with a named capability error, matching the `multiple_undo` fix from #272/#281. No more `ReferenceError: app.project.undo is not a function`, no more unverifiable `{ redone: true }` |
| #463 | `set_effect_property` | Accepts array values for Position, Anchor Point, and other vector properties, and compares an array readback component by component instead of with `===` |
| #464 | `import_ae_comps` | Checks the `.aep` exists and that the target bin's item count actually increased |
| #465 | `add_tracks` | Fingerprints every existing track before the call and locates those fingerprints afterwards, reporting explicitly when QE inserted at index 0 and shifted everything up. A matching total count alone no longer implies success |
| #466 | `get_render_queue_status` | Returns a capability error naming `app.encoder.isRunning` instead of an `isRunning: "unknown"` string that reads as a legitimate status |

## Tests

Three new regression files (31 tests), covering all twelve issues:

- `tests/tools/issues-454-466.test.ts` — the CEP/ExtendScript tools and `manage_sequences_uxp` parameter routing
- `tests/uxp/issues-454-456.test.ts` — hosts whose objects only expose the documented surface through a cast
- `tests/uxp/issue-455-committed-unverified.test.ts` — a host that commits but slides instead of slipping, and one that deletes without rippling

Three existing assertions were updated to the new contracts (`set_effect_property`'s value schema, `add_tracks`' verification field, and the UXP handler sweep's per-action sequence arguments).

`npm run check` passes: 2722 tests, all inventory/docs/manifest checks green.

## Note on host verification

These were reproduced and fixed from the reports, the Adobe API inventories in this repo, and the plugin's own working call sites — not against a live Premiere 26.3.2 host, which this environment has no access to. The cast changes are strictly additive (an object that already exposes a method keeps using it), so they cannot regress a host where the direct call worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)