### PR TITLE
chore: release Premiere Pro MCP v1.15.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "premiere-pro",
       "source": "./claude-plugins/premiere-pro",
       "description": "Inspect, edit, verify, and export local Premiere Pro projects through MCP.",
-      "version": "1.14.9",
+      "version": "1.15.0",
       "category": "creative",
       "tags": ["premiere-pro", "video-editing", "mcp"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.15.0] - 2026-09-08
+
 ### Added
+
+- Added film editorial evidence, cross-app workflow planning, and verified After Effects render handoff workflows.
+- Improved setup discovery, troubleshooting documentation, and MCP Registry publication validation.
 
 - Added timeline QA: `diff_sequence_snapshots` compares two sequence
   snapshots (normalized, `get_sequence_structure`, or

--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ The current source exposes 369 core tools for supported workflow steps spanning 
 
 <a id="latest-release"></a>
 
-### Latest release: 1.14.9
+### Latest release: 1.15.0
 
-The published npm artifact contains **349 core tools**, 347 in its default profile,
+The previously published v1.14.9 npm artifact contains **349 core tools**, 347 in its default profile,
 and 440 with a compatible UXP connection. The development catalog above can include
 unreleased work. See the [versioned facts and package provenance](https://premiere-pro-mcp.com/facts/).
 
@@ -120,6 +120,10 @@ a disposable project and use [setup and recovery](https://premiere-pro-mcp.com/d
 if the connection is unavailable.
 
 ### Release highlights
+
+- **Editorial planning:** film evidence, transcript cleanup, caption authoring, shorts and chapter planning, rhythm and speaker layouts, timeline QA, and platform delivery plans.
+- **Cross-app handoff:** capability-aware workflow routes and guarded After Effects render-to-Premiere handoff.
+- **Editing correctness:** verified readback and explicit capability or committed-but-unverified failures across transition, import, effects, source identity, and track operations.
 
 - **MOGRT studio:** an optional, separate After Effects CEP connector can
   author approval-gated title, callout, quote, and social recipes; constrain
@@ -147,7 +151,7 @@ if the connection is unavailable.
   local Premiere processes. See the generated [supported action catalog](docs/supported-actions.md)
   for individual capability and verification contracts.
 
-See the [v1.14.9 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.14.9)
+See the [v1.15.0 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.15.0)
 for complete details. Live installation in Premiere Pro still requires host verification.
 
 ### Current MCP protocol support
@@ -194,9 +198,9 @@ their bins, media rules, and organization rules before a facility uses one.
 
 ### Easiest supported path: Claude Desktop
 
-1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.9/premiere-pro-mcp-1.14.9.mcpb).
+1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.15.0/premiere-pro-mcp-1.15.0.mcpb).
 2. In Claude Desktop, open **Settings > Extensions > Advanced settings > Install Extension**, select the downloaded bundle, and restart Claude Desktop.
-3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.14.9/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
+3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.15.0/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
 4. Restart Premiere, open a project, then open **Window > Extensions > MCP for Adobe Premiere Pro**.
 5. In Claude, enter: `Safely check my Premiere connection with verify_premiere_connection. Make no changes.`
 
@@ -493,11 +497,11 @@ From a clone of this repository:
 ```bash
 codex plugin marketplace add .
 codex plugin add premiere-pro@premiere-pro-mcp
-npx -y premiere-pro-mcp@1.14.9 --install-cep
+npx -y premiere-pro-mcp@1.15.0 --install-cep
 ```
 
 Restart Premiere Pro and start a new Codex session after installation. The plugin
-launches `premiere-pro-mcp@1.14.9` through `npx`; the separate CEP installation is
+launches `premiere-pro-mcp@1.15.0` through `npx`; the separate CEP installation is
 required because the MCP server communicates with the running Premiere host through
 the local bridge.
 
@@ -528,7 +532,7 @@ For Claude Code, add this repository as a marketplace and install the plugin:
 Then install the Premiere bridge and start a new Claude Code session:
 
 ```bash
-npx -y premiere-pro-mcp@1.14.9 --install-cep
+npx -y premiere-pro-mcp@1.15.0 --install-cep
 ```
 
 The Claude Code package lives in

--- a/after-effects-cep-plugin/CSXS/manifest.xml
+++ b/after-effects-cep-plugin/CSXS/manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.aftereffects.bridge" ExtensionBundleVersion="1.14.9" ExtensionBundleName="MCP for Adobe After Effects">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.aftereffects.bridge" ExtensionBundleVersion="1.15.0" ExtensionBundleName="MCP for Adobe After Effects">
   <ExtensionList>
-    <Extension Id="com.mcp.aftereffects.bridge.panel" Version="1.14.9"/>
+    <Extension Id="com.mcp.aftereffects.bridge.panel" Version="1.15.0"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.14.9" ExtensionBundleName="MCP for Adobe Premiere Pro">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.15.0" ExtensionBundleName="MCP for Adobe Premiere Pro">
   <ExtensionList>
-    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.14.9"/>
-    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.14.9"/>
+    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.15.0"/>
+    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.15.0"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/cep-plugin/index.html
+++ b/cep-plugin/index.html
@@ -81,7 +81,7 @@
     <section class="update-section" aria-live="polite">
       <div class="update-copy">
         <span class="section-label">MCP updates</span>
-        <strong id="updateTitle">Version 1.14.9</strong>
+        <strong id="updateTitle">Version 1.15.0</strong>
         <span id="updateDetail">Checking the global MCP server and connector release…</span>
       </div>
       <button id="btnUpdate" class="button button-update" onclick="handleUpdateClick()" type="button" aria-describedby="updateDetail" disabled>

--- a/cep-plugin/updater.cjs
+++ b/cep-plugin/updater.cjs
@@ -7,7 +7,7 @@
 })(this, function () {
   "use strict";
 
-  var CURRENT_VERSION = "1.14.9";
+  var CURRENT_VERSION = "1.15.0";
   var PACKAGE_NAME = "premiere-pro-mcp";
   var LATEST_PACKAGE_API = "https://registry.npmjs.org/" + PACKAGE_NAME;
   var LATEST_RELEASE_API =

--- a/claude-desktop/manifest.json
+++ b/claude-desktop/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "premiere-pro-mcp",
   "display_name": "MCP for Adobe Premiere Pro",
-  "version": "1.14.9",
+  "version": "1.15.0",
   "description": "Control a local Adobe Premiere Pro project through MCP.",
   "long_description": "Inspect projects, assemble and modify timelines, manage media, effects, audio and captions, and export deliverables through a local bridge to Adobe Premiere Pro.",
   "author": {

--- a/claude-plugins/premiere-pro/.claude-plugin/plugin.json
+++ b/claude-plugins/premiere-pro/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "premiere-pro",
   "displayName": "Premiere Pro MCP",
-  "version": "1.14.9",
+  "version": "1.15.0",
   "description": "Inspect, edit, verify, and export local Adobe Premiere Pro projects through MCP.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/claude-plugins/premiere-pro/.mcp.json
+++ b/claude-plugins/premiere-pro/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "premiere-pro": {
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.14.9"]
+      "args": ["-y", "premiere-pro-mcp@1.15.0"]
     }
   }
 }

--- a/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -19,7 +19,7 @@ project state, make only requested changes, and verify the timeline after mutati
    silently fall back to CEP after a failed UXP probe.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.14.9 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.15.0 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -5,6 +5,23 @@ import { product } from "@/lib/product"
 
 const releases = [
   {
+    version: "1.15.0",
+    date: "2026-09-08",
+    label: "Editorial planning, cross-app handoff, and verified editing fixes",
+    groups: [
+      { title: "Added", items: [
+        "Film editorial evidence, cross-app workflow planning, and After Effects render handoff workflows.",
+        "Transcript cleanup, dynamic captions, short-form candidate ranking, chapter markers, rhythm and speaker layout plans, timeline QA, and platform delivery planning.",
+        "369 core tools, 367 default-profile tools, and 93 capability-gated UXP additions for 460 connected tools."
+      ] },
+      { title: "Fixed", items: [
+        "More accurate transition and project-item inspection, editing readback, FCP XML import, effect arrays, track insertion reporting, and explicit committed-but-unverified outcomes.",
+        "Clearer setup discovery, troubleshooting guides, and registry metadata validation."
+      ] },
+      { title: "Verification scope", items: ["Plans and automated checks do not establish licensed-host playback or rendered-output verification."] }
+    ],
+  },
+  {
     version: "1.14.9",
     date: "2026-09-04",
     label: "Guarded After Effects MOGRT studio and assistant workflows",

--- a/landing/lib/source-catalog.json
+++ b/landing/lib/source-catalog.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.14.9",
+  "version": "1.15.0",
   "coreTools": 369,
   "defaultProfileTools": 367,
   "uxpAdditionalTools": 93,

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -13,7 +13,7 @@ Release: https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.14.9
 
 ## Development source, separate from publication
 
-Current source metadata registers 369 core structured MCP tools, 367 in the default profile, and 93 capability-gated tools for 460 connected tools. Source package version: 1.14.9. Main may include changes not in the published package even when its version string is unchanged.
+Current source metadata registers 369 core structured MCP tools, 367 in the default profile, and 93 capability-gated tools for 460 connected tools. Source package version: 1.15.0. Main may include changes not in the published package even when its version string is unchanged.
 
 ## Start a workflow
 

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -13,7 +13,7 @@ Release: https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.14.9
 
 ## Development source, separate from publication
 
-Current source metadata registers 369 core structured MCP tools, 367 in the default profile, and 93 capability-gated tools for 460 connected tools. Source package version: 1.14.9. Main may include changes not in the published package even when its version string is unchanged.
+Current source metadata registers 369 core structured MCP tools, 367 in the default profile, and 93 capability-gated tools for 460 connected tools. Source package version: 1.15.0. Main may include changes not in the published package even when its version string is unchanged.
 
 ## Start a workflow
 

--- a/landing/public/marketing-facts.json
+++ b/landing/public/marketing-facts.json
@@ -25,7 +25,7 @@
     }
   },
   "developmentSource": {
-    "version": "1.14.9",
+    "version": "1.15.0",
     "coreTools": 369,
     "defaultProfileTools": 367,
     "uxpAdditionalTools": 93,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.14.9",
+  "version": "1.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "premiere-pro-mcp",
-      "version": "1.14.9",
+      "version": "1.15.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/node": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "premiere-pro-mcp",
   "mcpName": "io.github.leancoderkavy/premiere-pro",
-  "version": "1.14.9",
+  "version": "1.15.0",
   "description": "MCP server for Adobe Premiere Pro with 369 core AI video editing tools, a guarded After Effects MOGRT studio, and a capability-aware UXP bridge for supported Premiere workflows.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/premiere-pro/.codex-plugin/plugin.json
+++ b/plugins/premiere-pro/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro",
-  "version": "1.14.9",
+  "version": "1.15.0",
   "description": "Plan, execute, verify, and export video edits in Adobe Premiere Pro through the Premiere Pro MCP server.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/plugins/premiere-pro/.mcp.json
+++ b/plugins/premiere-pro/.mcp.json
@@ -4,7 +4,7 @@
       "title": "Premiere Pro MCP",
       "description": "Inspect and edit a local Adobe Premiere Pro project through the Premiere Pro MCP bridge.",
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.14.9"]
+      "args": ["-y", "premiere-pro-mcp@1.15.0"]
     }
   }
 }

--- a/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -19,7 +19,7 @@ project state, make only requested changes, and verify the timeline after mutati
    silently fall back to CEP after a failed UXP probe.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.14.9 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.15.0 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/public-product-manifest.json
+++ b/public-product-manifest.json
@@ -10,7 +10,7 @@
     "name": "MCP for Adobe Premiere Pro",
     "mcpName": "io.github.leancoderkavy/premiere-pro",
     "npmPackage": "premiere-pro-mcp",
-    "version": "1.14.9",
+    "version": "1.15.0",
     "repository": "https://github.com/leancoderkavy/premiere-pro-mcp",
     "homepage": "https://premiere-pro-mcp.com/",
     "license": "MIT",

--- a/registry/server.json
+++ b/registry/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/leancoderkavy/premiere-pro-mcp",
     "source": "github"
   },
-  "version": "1.14.9",
+  "version": "1.15.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "premiere-pro-mcp",
-      "version": "1.14.9",
+      "version": "1.15.0",
       "transport": {
         "type": "stdio"
       }

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.14.9",
+  "version": "1.15.0",
   "coreTools": 369,
   "defaultProfileTools": 367,
   "uxpAdditionalTools": 93,

--- a/tests/entrypoints-unit.test.ts
+++ b/tests/entrypoints-unit.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { RequestBodyTooLargeError } from "../src/http-admission.js";
+
+const currentVersion = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")).version as string;
+const nextVersion = `${Number(currentVersion.split(".")[0]) + 1}.0.0`;
 
 const mocks = vi.hoisted(() => ({
   requestHandler: undefined as undefined | ((req: any, res: any) => Promise<void>),
@@ -233,15 +237,15 @@ describe("stdio CLI entry point", () => {
 
   it("checks for a newer release and updates a global npm installation", async () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
-    mocks.fetchLatestNpmVersion.mockResolvedValueOnce("1.15.0");
+    mocks.fetchLatestNpmVersion.mockResolvedValueOnce(nextVersion);
     let loaded = await importCli(["--check-update"]);
     await expect(loaded.promise).rejects.toThrow("EXIT:0");
-    expect(log).toHaveBeenCalledWith(expect.stringContaining("1.14.9 → 1.15.0"));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining(`${currentVersion} → ${nextVersion}`));
 
     vi.resetModules();
     vi.clearAllMocks();
     log.mockClear();
-    mocks.fetchLatestNpmVersion.mockResolvedValueOnce("1.15.0");
+    mocks.fetchLatestNpmVersion.mockResolvedValueOnce(nextVersion);
     mocks.spawnSync.mockReturnValue({ status: 0, stdout: `${dirname(process.cwd())}\n` });
     loaded = await importCli(["--update"]);
     await expect(loaded.promise).rejects.toThrow("EXIT:0");
@@ -266,7 +270,7 @@ describe("stdio CLI entry point", () => {
     vi.resetModules();
     vi.clearAllMocks();
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
-    mocks.fetchLatestNpmVersion.mockResolvedValueOnce("1.14.9");
+    mocks.fetchLatestNpmVersion.mockResolvedValueOnce(currentVersion);
     loaded = await importCli(["--update"]);
     await expect(loaded.promise).rejects.toThrow("EXIT:0");
     expect(log).toHaveBeenCalledWith(expect.stringContaining("is current"));

--- a/tests/release-metadata.test.ts
+++ b/tests/release-metadata.test.ts
@@ -63,11 +63,11 @@ describe("canonical release metadata", () => {
       `${release.defaultProfileWithUxpTools} with a connected UXP bridge`,
     );
     expect(readme).toContain(`${release.uxpAdditionalTools} capability-gated tools`);
-    expect(llms).toContain(`Current project release: ${release.version}`);
+    expect(llms).toContain(`Current project release: ${readJson("landing/lib/published-release.json").version}`);
     expect(llms).toContain(
       `${release.coreTools} core structured MCP tools`,
     );
-    expect(llmsFull).toContain(`Current release: ${release.version}`);
+    expect(llmsFull).toContain(`Current release: ${readJson("landing/lib/published-release.json").version}`);
     expect(llmsFull).toContain(
       `${release.uxpAdditionalTools} capability-gated tools`,
     );

--- a/uxp-plugin/manifest.json
+++ b/uxp-plugin/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.ppmcp.premiere.uxp",
   "name": "MCP for Adobe Premiere Pro",
-  "version": "1.14.9",
+  "version": "1.15.0",
   "main": "index.html",
   "host": { "app": "premierepro", "minVersion": "25.6.0" },
   "entrypoints": [


### PR DESCRIPTION
Prepare v1.15.0 for the merged editorial planning, cross-app handoff, and editing correctness changes. Align distributable versions and release notes; derive update tests from the package version. Preserve inspected public artifact provenance until npm publication, then refresh it before production deployment.

Validation: build and full suite (3197 passed initially; two publication-facts failures corrected and all 55 affected tests passed), npm package install check, MCPB build, landing build and performance budget, root and landing production audits (zero vulnerabilities), and diff check.
