### PR TITLE
Fix duplicate search URLs with canonical page redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 Free, MIT licensed, local-first, and published to npm as [`premiere-pro-mcp`](https://www.npmjs.com/package/premiere-pro-mcp) — the only package name that installs this project.
 
+[Website](https://premiere-pro-mcp.com/) · [Setup guides](https://premiere-pro-mcp.com/blog/how-to-set-up-premiere-pro-mcp/) · [Troubleshooting](https://premiere-pro-mcp.com/docs/troubleshooting/) · [Release facts](https://premiere-pro-mcp.com/facts/)
+
 Development source: 369 core tools across 53 modules, 4 resources, and 17 guided workflows. A connected UXP host adds 93 capability-gated tools.
 
 The [completed AE render handoff](docs/after-effects-render-handoff.md) previews and confirms importing one finished render into an existing Premiere bin, with host and file rechecks and an import receipt.

--- a/docs/marketing/search-growth-scorecard.md
+++ b/docs/marketing/search-growth-scorecard.md
@@ -1,0 +1,55 @@
+# Search growth scorecard
+
+First run: September 8, 2026. Scope: `premiere-pro-mcp.com` and
+`leancoderkavy/premiere-pro-mcp`. Continue the existing
+[90-day growth plan](90-day-growth-plan-2026-09-04.md); prioritize measured defects
+and improvements to existing pages before adding overlapping guides.
+
+## Baseline and first improvement
+
+| Check | Live observation before this change | Action or measurement boundary |
+| --- | --- | --- |
+| Sitemap | 24 URLs, all HTTP 200 | Keep canonical URLs crawlable. |
+| Page identity | All 24 returned one H1 and a matching canonical URL | Preserve existing page identity. |
+| Indexing directives | No `noindex` in the inspected HTML or `X-Robots-Tag` headers | Crawl eligibility does not establish Google indexation. |
+| Duplicate URLs | The explainer article returned HTTP 200 at `www`, without its trailing slash, and at `/index.html` | Permanently redirect real exported page aliases to one canonical address, preserving query parameters. |
+| Missing page | An intentionally nonexistent path returned HTTP 404 | Keep missing routes outside canonical redirects. |
+| Search crawlers | Live robots allows public pages, including OAI-SearchBot, Claude-SearchBot and PerplexityBot | Preserve MCP and health exclusions. Training crawler access is separate from search visibility. |
+| Repository identity | GitHub API returned the correct homepage, current workflow description and relevant topics | Add prominent website, setup, troubleshooting and release-facts links to the README. |
+| Public search sample | Quoted domain and branded repository queries surfaced the repository and third-party listings, including stale tool counts and package availability claims | A discovery sample, not a rank, traffic estimate, or complete index inventory. Do not copy third-party claims into product facts. |
+| GSC standard and AI reports | Not measured in this run | Obtain authorized reports before claiming clicks, impressions, CTR, position or AI citation changes. |
+| Field performance and AI answer citations | Not measured | Do not substitute build budgets or public search snippets for field metrics or sampled AI answers. |
+
+The HTTP change applies only after resolving a real exported `index.html` inside
+the static root. It consolidates page paths and the two known public host aliases
+(`www.premiere-pro-mcp.com` and `premiere-pro-mcp.fly.dev`) in one hop. Local and
+self-hosted origins stay local. Assets, missing pages, health, OAuth discovery and
+MCP transport requests retain their routing. Query parameters are preserved.
+
+## Repeat each morning
+
+1. Refresh main and inspect pending search-growth PRs before creating work.
+2. Recheck sitemap pages, canonical targets, response directives, duplicate-path
+   redirects, missing routes, and relevant internal links. Run the export check
+   after a landing build: `node landing/scripts/check-seo-export.mjs`.
+3. Read authorized GSC reports using complete comparable 7-day and 28-day windows.
+   Save private query/page exports outside public Git. Record the data-through
+   date, device/country filters, brand/nonbrand split, and hidden query coverage.
+   Treat average position as an average, never a fixed search rank.
+4. Keep public search and AI samples separate: exact query, engine, date, locale
+   when known, observed URL, brand mention, and claim accuracy. An unknown locale
+   or missing result remains unknown. Repeat unexpected observations.
+5. Implement justified improvements, verify and merge the exact tested PR head,
+   then confirm resulting-main CI, the deployed image and live behavior. Record
+   merge/deployment evidence in the PR. Technical delivery and later search
+   outcomes are separate milestones.
+
+## Sources checked September 8, 2026
+
+- [Google canonicalization guidance](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls): redirects and canonical annotations are complementary signals for consolidating duplicate URLs.
+- [Google generative AI search guidance](https://developers.google.com/search/docs/fundamentals/ai-optimization-guide): prioritize useful original content and technical SEO; special AI text files and inauthentic mentions are not a substitute.
+- [Live sitemap](https://premiere-pro-mcp.com/sitemap.xml) and [robots policy](https://premiere-pro-mcp.com/robots.txt).
+- [Repository](https://github.com/leancoderkavy/premiere-pro-mcp) and [release facts](https://premiere-pro-mcp.com/facts/).
+
+No ranking improvement is claimed by this implementation. The initial run has no
+comparable GSC baseline or verified AI citation baseline.

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -156,6 +156,31 @@ function serveLanding(req: http.IncomingMessage, res: http.ServerResponse, scrip
   }
   if (!fileStats.isFile()) return false;
 
+  // Consolidate only real exported pages, after containment and file checks.
+  // Keep assets, missing routes, MCP, health and OAuth discovery untouched.
+  if (path.basename(filePath) === "index.html") {
+    const pageDirectory = path.relative(LANDING_DIR, path.dirname(filePath));
+    const canonicalPath = pageDirectory
+      ? `/${pageDirectory.split(path.sep).map(encodeURIComponent).join("/")}/`
+      : "/";
+    const rawPath = req.url!.split("?")[0];
+    const queryIndex = req.url!.indexOf("?");
+    const query = queryIndex >= 0 ? req.url!.slice(queryIndex) : "";
+    const hostname = req.headers.host?.toLowerCase();
+    const publicAlias = hostname === "www.premiere-pro-mcp.com" || hostname === "premiere-pro-mcp.fly.dev";
+    if (publicAlias || rawPath !== canonicalPath) {
+      // Never derive a redirect origin from Host or forwarded headers. Local and
+      // self-hosted installs retain their origin; known public aliases use HTTPS.
+      const origin = publicAlias ? "https://premiere-pro-mcp.com" : "";
+      res.writeHead(308, {
+        "Location": `${origin}${canonicalPath}${query}`,
+        "Cache-Control": "public, max-age=3600",
+      });
+      res.end();
+      return true;
+    }
+  }
+
   const ext = path.extname(filePath);
   const contentType = MIME[ext] ?? "application/octet-stream";
   const headers = {

--- a/tests/entrypoints-unit.test.ts
+++ b/tests/entrypoints-unit.test.ts
@@ -699,7 +699,7 @@ describe("HTTP entry point", () => {
     expect(mocks.fsReadFileSync).toHaveBeenCalledOnce();
   });
 
-  it("serves extensionless landing routes from their index file", async () => {
+  it("redirects extensionless landing routes to their canonical directory", async () => {
     mocks.fsExists.mockReturnValue(true);
     mocks.fsStat
       .mockReturnValueOnce({ isDirectory: () => true, isFile: () => false })
@@ -707,11 +707,49 @@ describe("HTTP entry point", () => {
     const handler = await loadHttp();
     const res = response();
     await handler({ method: "GET", url: "/changelog", headers: {} }, res);
-    expect(mocks.fsReadFileSync).toHaveBeenCalledWith(
-      expect.stringMatching(/[\\/]changelog[\\/]index\.html$/),
-      "utf8",
-    );
-    expect(res.statusCode).toBe(200);
+    expect(res.writeHead).toHaveBeenCalledWith(308, expect.objectContaining({ Location: "/changelog/" }));
+    expect(mocks.fsReadFileSync).not.toHaveBeenCalled();
+  });
+
+  it("consolidates index files and public host aliases in one hop, preserving queries", async () => {
+    mocks.fsExists.mockReturnValue(true);
+    const handler = await loadHttp();
+    for (const [url, host, expected] of [
+      ["/index.html", "localhost:3000", "/"],
+      ["/docs/index.html?utm_source=github&x=%2F", "localhost:3000", "/docs/?utm_source=github&x=%2F"],
+      ["/docs/index.html?utm_source=github", "www.premiere-pro-mcp.com", "https://premiere-pro-mcp.com/docs/?utm_source=github"],
+      ["/docs/", "premiere-pro-mcp.fly.dev", "https://premiere-pro-mcp.com/docs/"],
+      ["/", "WWW.PREMIERE-PRO-MCP.COM", "https://premiere-pro-mcp.com/"],
+      ["//untrusted.example/index.html", "localhost:3000", "/untrusted.example/"],
+    ]) {
+      for (const method of ["GET", "HEAD"]) {
+        const res = response();
+        await handler({ method, url, headers: { host } }, res);
+        expect(res.writeHead).toHaveBeenCalledWith(308, expect.objectContaining({ Location: expected }));
+        expect(res.body).toBe("");
+      }
+    }
+    expect(mocks.fsReadFileSync).not.toHaveBeenCalled();
+  });
+
+  it("does not redirect canonical pages or trust forwarded host names", async () => {
+    mocks.fsExists.mockReturnValue(true);
+    const handler = await loadHttp();
+    for (const host of ["premiere-pro-mcp.com", "localhost:3000", "self-hosted.example", "www.premiere-pro-mcp.com.attacker.example"]) {
+      const res = response();
+      await handler({ method: "GET", url: "/docs/?ref=readme", headers: { host, "x-forwarded-host": "www.premiere-pro-mcp.com" } }, res);
+      expect(res.statusCode).toBe(200);
+    }
+  });
+
+  it("keeps public alias assets and API endpoints outside page redirects", async () => {
+    mocks.fsExists.mockReturnValue(true);
+    const handler = await loadHttp();
+    for (const [url, status] of [["/robots.txt", 200], ["/health", 200], ["/mcp", 401]] as const) {
+      const res = response();
+      await handler({ method: "GET", url, headers: { host: "www.premiere-pro-mcp.com" } }, res);
+      expect(res.statusCode).toBe(status);
+    }
   });
 
   it("marks hashed Next static assets immutable", async () => {


### PR DESCRIPTION
Public articles currently return HTTP 200 at duplicate addresses such as `/blog/what-is-a-premiere-pro-mcp-server`, its `/index.html` path, and the `www` host. Consolidate real exported pages with a single 308 redirect to the existing canonical path, retaining query parameters. Known public aliases use the canonical HTTPS origin; local and self-hosted installations keep their origin. File validation precedes redirects, and assets, missing routes, health, OAuth and MCP routing are preserved.

Add prominent setup, troubleshooting and facts links to the README and a dated search-growth scorecard. This implements Google's [canonicalization guidance](https://developers.google.com/search/docs/crawling-indexing/consolidate-duplicate-urls) and follows its [AI search guidance](https://developers.google.com/search/docs/fundamentals/ai-optimization-guide) on technical SEO and accurate content. GSC metrics and AI answer citation changes remain unmeasured; no ranking improvement is claimed.

Validation:
- `npm run check`: 169 files, 3,202 tests passed.
- Landing lint, production build and performance budget passed.
- SEO export: 24 canonical/indexable pages and 410 internal links/anchors passed.
- Focused HTTP regression tests cover GET/HEAD redirects, one-hop alias consolidation, query retention, untrusted headers, local origins and API exclusions.
- Local compiled HTTP server: aliases 308, missing page 404, health 200, unauthenticated MCP 401.
- Playwright desktop 1280px and mobile 390px: canonical article loads after redirect, JSON-LD parses, one H1, no horizontal overflow or console errors.

Merged with `gh pr merge --squash --admin --match-head-commit` as `dcafe7a965a2a50648cd166a62f015ad810870c6` after every PR check passed. The merged tree is identical to tested head `53e6b6d2d6a487612ccdd235a12b176a600dd0c1`.

Resulting-main verification:
- [Cross-platform validation](https://github.com/leancoderkavy/premiere-pro-mcp/actions/runs/34318172138): all six OS/Node combinations, coverage and package verification passed.
- [Landing validation](https://github.com/leancoderkavy/premiere-pro-mcp/actions/runs/34318172121), [connector installers](https://github.com/leancoderkavy/premiere-pro-mcp/actions/runs/34318172116), and [analysis](https://github.com/leancoderkavy/premiere-pro-mcp/actions/runs/34318171322) passed.
- Fly release 70 deployed immutable image `sha256:80762c1c55b9071602db27e4b43b9eea596f3dcc3f4526086c9d7d3b894150d1`, built from a tracked-file archive of the verified head; machine started and health passing.
- Production verification at 2026-09-09T06:15:02Z: 24 canonical pages and 96 redirect checks passed; health 200, unauthenticated MCP 401 and unknown page 404.
- Production Playwright: combined `www` plus `/index.html` alias redirects to the canonical HTTPS article with query retained; desktop 1280px and mobile 390px show no horizontal overflow; no console errors.

GSC remains unmeasured: Computer Use stopped before Search Console inspection because it could not confidently verify the active browser URL. No authenticated reports were accessed or sitemap submissions performed. Public checks and isolated browser QA do not establish Google indexation or improved rankings.
