### PR TITLE
Improve client setup and add sourced Premiere MCP comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ It is also separate from other MCP servers for Premiere Pro. The only npm packag
 published from this repository is `premiere-pro-mcp`, and no other package name
 installs it.
 
+**Comparing similarly named packages?** Both this package and
+`adobe-premiere-pro-mcp` declare a `premiere-pro-mcp` executable. Verify the package
+and repository before configuring a client. The new
+[local configuration helper](docs/client-configuration.md) prints Claude, Cursor,
+VS Code, or Codex settings that point directly to this installation. It is a
+development-source feature; the published v1.15.0 package does not include it.
+
 The current source exposes 369 core tools for supported workflow steps spanning the supported ExtendScript, QE DOM, local media and interchange analysis, revisioned project-context retrieval, safe edit-planning, project-intake preview, review handoff, connection verification, and guarded After Effects MOGRT authoring, batch, library, render-queue, inspection, and Premiere-handoff workflows. A compatible, authenticated UXP panel adds 93 documented, capability-gated tools without replacing the production CEP bridge.
 
 <a id="latest-release"></a>

--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -1,0 +1,59 @@
+# Configure an exact local server installation
+
+Development source feature, added September 9, 2026. The published v1.15.0 package
+does **not** include `--print-client-config`; use a built checkout containing this
+change until a release includes it.
+
+The `premiere-pro-mcp` and `adobe-premiere-pro-mcp` npm packages belong to separate
+repositories, but both declare a `premiere-pro-mcp` command. A command name alone
+does not identify its package. This helper prints a client entry that invokes the
+current Node executable and this copy's server file by absolute path.
+
+From this checkout, after `npm ci` and `npm run build`:
+
+```sh
+node dist/index.js --print-client-config claude
+node dist/index.js --print-client-config cursor
+node dist/index.js --print-client-config vscode
+node dist/index.js --print-client-config codex
+```
+
+Choose one command for your client. Each prints only its JSON or TOML entry;
+it does not install anything, write configuration, inspect your existing settings,
+contact Premiere, start an MCP session, or copy environment variables.
+
+| Target | Where to merge the entry |
+| --- | --- |
+| `claude` | The `mcpServers` object in Claude Desktop's developer configuration; the same shape can be used for Claude Code's local MCP JSON configuration |
+| `cursor` | The `mcpServers` object in Cursor's local MCP configuration |
+| `vscode` | The `servers` object in the local user MCP configuration opened with **MCP: Open User Configuration** |
+| `codex` | A single `[mcp_servers.premiere-pro-leancoderkavy]` table in your local Codex configuration |
+
+Merge the entry named `premiere-pro-leancoderkavy` into existing configuration.
+Preserve other entries and settings; do not replace the whole file or create a
+duplicate TOML table. Disable the previous entry for this Premiere connection
+before starting the replacement, so only one server and matching connector are
+active. Connector installation is still separate.
+
+The output contains local executable paths and may include your user name. Keep
+it local rather than posting it as a support bundle. Use a stable installation
+directory: moving/removing that directory or changing the Node installation
+requires regenerating the entry. In-place package updates continue to use that
+path; this is a path selection, not a version lock or package integrity check.
+Generate it from the intended installation on the same computer as Premiere.
+
+After reviewing and merging the entry, restart the client, open a disposable
+Premiere project, start this project's connector, and ask:
+
+> Safely check my Premiere connection with verify_premiere_connection. Make no changes.
+
+Configuration output establishes only the command and arguments. Actual client
+discovery, connection, editing, and rendering require separate validation.
+
+Sources checked September 9, 2026:
+
+- [Other package's bin declaration at the inspected commit](https://github.com/hetpatel-11/Adobe_Premiere_Pro_MCP/blob/ee31c3def7c3ca1c68662ea7737a9f8e5a2b634f/package.json)
+- [npm executable mapping](https://docs.npmjs.com/cli/v11/configuring-npm/package-json/#bin)
+- [VS Code MCP configuration](https://code.visualstudio.com/docs/agent-customization/mcp-servers)
+- [Cursor MCP configuration](https://cursor.com/docs/mcp)
+- [Codex MCP configuration](https://developers.openai.com/codex/mcp)

--- a/docs/marketing/competitive-baseline-2026-09-09.json
+++ b/docs/marketing/competitive-baseline-2026-09-09.json
@@ -1,0 +1,67 @@
+{
+  "schemaVersion": "premiere-pro-mcp.competitive-scorecard.v1",
+  "observedAt": "2026-09-09T07:07:26.476Z",
+  "projects": [
+    {
+      "role": "ours",
+      "repository": "leancoderkavy/premiere-pro-mcp",
+      "package": "premiere-pro-mcp",
+      "github": {
+        "state": "observed",
+        "source": "https://api.github.com/repos/leancoderkavy/premiere-pro-mcp",
+        "reason": null,
+        "stars": 240,
+        "forks": 39
+      },
+      "npm": {
+        "state": "observed",
+        "source": "https://api.npmjs.org/downloads/point/last-week/premiere-pro-mcp",
+        "reason": null,
+        "downloads": 1897,
+        "start": "2026-08-31",
+        "end": "2026-09-06"
+      }
+    },
+    {
+      "role": "comparison",
+      "repository": "hetpatel-11/Adobe_Premiere_Pro_MCP",
+      "package": "adobe-premiere-pro-mcp",
+      "github": {
+        "state": "observed",
+        "source": "https://api.github.com/repos/hetpatel-11/Adobe_Premiere_Pro_MCP",
+        "reason": null,
+        "stars": 530,
+        "forks": 110
+      },
+      "npm": {
+        "state": "observed",
+        "source": "https://api.npmjs.org/downloads/point/last-week/adobe-premiere-pro-mcp",
+        "reason": null,
+        "downloads": 1123,
+        "start": "2026-08-31",
+        "end": "2026-09-06"
+      }
+    }
+  ],
+  "comparison": {
+    "starsToLead": 291,
+    "starLead": -290,
+    "npmDownloadLead": 774,
+    "npmWindowsComparable": true
+  },
+  "search": {
+    "state": "not_measured",
+    "googlePosition": null,
+    "githubSearchPosition": null
+  },
+  "workflowSuccess": {
+    "state": "not_measured",
+    "licensedHostRuns": null
+  },
+  "boundaries": [
+    "Stars and forks are public repository signals, not active editors or workflow quality.",
+    "npm counts include CI, repeat downloads, and automation; they do not establish unique installs or users.",
+    "The star target changes when either repository gains or loses stars.",
+    "Unknown or failed measurements remain null. Search results require a separately dated query, engine, locale, and method."
+  ]
+}

--- a/docs/marketing/competitive-search-baseline-2026-09-09.json
+++ b/docs/marketing/competitive-search-baseline-2026-09-09.json
@@ -1,0 +1,94 @@
+{
+  "schemaVersion": "premiere-pro-mcp.competitive-scorecard.v1",
+  "observedAt": "2026-09-09T07:21:33.628Z",
+  "projects": [
+    {
+      "role": "ours",
+      "repository": "leancoderkavy/premiere-pro-mcp",
+      "package": "premiere-pro-mcp",
+      "github": {
+        "state": "observed",
+        "source": "https://api.github.com/repos/leancoderkavy/premiere-pro-mcp",
+        "reason": null,
+        "stars": 241,
+        "forks": 39
+      },
+      "npm": {
+        "state": "observed",
+        "source": "https://api.npmjs.org/downloads/point/last-week/premiere-pro-mcp",
+        "reason": null,
+        "downloads": 1897,
+        "start": "2026-08-31",
+        "end": "2026-09-06"
+      }
+    },
+    {
+      "role": "comparison",
+      "repository": "hetpatel-11/Adobe_Premiere_Pro_MCP",
+      "package": "adobe-premiere-pro-mcp",
+      "github": {
+        "state": "observed",
+        "source": "https://api.github.com/repos/hetpatel-11/Adobe_Premiere_Pro_MCP",
+        "reason": null,
+        "stars": 530,
+        "forks": 110
+      },
+      "npm": {
+        "state": "observed",
+        "source": "https://api.npmjs.org/downloads/point/last-week/adobe-premiere-pro-mcp",
+        "reason": null,
+        "downloads": 1123,
+        "start": "2026-08-31",
+        "end": "2026-09-06"
+      }
+    }
+  ],
+  "comparison": {
+    "starsToLead": 290,
+    "starLead": -289,
+    "npmDownloadLead": 774,
+    "npmWindowsComparable": true
+  },
+  "search": {
+    "google": {
+      "state": "not_measured",
+      "position": null
+    },
+    "github": {
+      "state": "observed",
+      "reason": null,
+      "source": "https://api.github.com/search/repositories?q=premiere%20pro%20mcp&per_page=100&page=1",
+      "query": "premiere pro mcp",
+      "method": "github_rest_best_match_unauthenticated",
+      "page": 1,
+      "limit": 100,
+      "totalCount": 47,
+      "returnedCount": 47,
+      "positions": [
+        {
+          "role": "ours",
+          "repository": "leancoderkavy/premiere-pro-mcp",
+          "position": 2,
+          "state": "observed"
+        },
+        {
+          "role": "comparison",
+          "repository": "hetpatel-11/Adobe_Premiere_Pro_MCP",
+          "position": 1,
+          "state": "observed"
+        }
+      ]
+    }
+  },
+  "workflowSuccess": {
+    "state": "not_measured",
+    "licensedHostRuns": null
+  },
+  "boundaries": [
+    "Stars and forks are public repository signals, not active editors or workflow quality.",
+    "npm counts include CI, repeat downloads, and automation; they do not establish unique installs or users.",
+    "The star target changes when either repository gains or loses stars.",
+    "Unknown or failed measurements remain null. Search results require a separately dated query, engine, locale, and method.",
+    "GitHub API best-match order is one query sample, not a Google rank, GitHub Trending rank, or personalized browser result. Absence from the returned page is not an inferred position."
+  ]
+}

--- a/landing/lib/articles.ts
+++ b/landing/lib/articles.ts
@@ -33,6 +33,89 @@ export type Article = {
 
 export const articles: Article[] = [
   {
+    slug: "premiere-pro-mcp-vs-adobe-premiere-pro-mcp",
+    seoTitle: "Compare Two Premiere MCP Packages",
+    title: "premiere-pro-mcp vs adobe-premiere-pro-mcp: Packages, Setup, and Workflows",
+    description: "Compare leancoderkavy and hetpatel-11's separate Premiere MCP projects, verify the npm package, and evaluate the same workflow before switching.",
+    eyebrow: "Package comparison",
+    publishedAt: "2026-09-09",
+    modifiedAt: "2026-09-09",
+    readingTime: "6 min read",
+    keywords: ["premiere-pro-mcp vs adobe-premiere-pro-mcp", "Premiere MCP comparison", "hetpatel Premiere MCP", "Premiere MCP package setup"],
+    sections: [
+      {
+        heading: "Two repositories, two packages, one command name",
+        paragraphs: [
+          "MCP for Adobe Premiere Pro is maintained at leancoderkavy/premiere-pro-mcp and published as premiere-pro-mcp. The separate hetpatel-11/Adobe_Premiere_Pro_MCP repository publishes adobe-premiere-pro-mcp. Installing one package does not install the other project.",
+          "Both packages declare an executable named premiere-pro-mcp. A copied command or an existing global executable can therefore be ambiguous. Check the package identity and use the matching connector and client instructions. This comparison is written by the maintainers of the leancoderkavy project. We inspected the other project's README and package metadata at commit ee31c3d on September 9, 2026; we did not run its tools inside Premiere.",
+        ],
+        codeBlocks: [{ label: "Read public package identity without installing either package", code: "npm view premiere-pro-mcp name version repository.url bin --json\nnpm view adobe-premiere-pro-mcp name version repository.url bin --json" }],
+        links: [
+          { label: "leancoderkavy repository", href: product.links.repository },
+          { label: "hetpatel-11 package at the inspected commit", href: "https://github.com/hetpatel-11/Adobe_Premiere_Pro_MCP/blob/ee31c3def7c3ca1c68662ea7737a9f8e5a2b634f/package.json" },
+        ],
+      },
+      {
+        heading: "Compare workflow scope and evidence",
+        paragraphs: [
+          `Our published v${product.version} artifact contains ${product.coreToolCount} core tools. Its source includes revision-bound editorial planning, a project-intake preview, review-frame workflows, local media and delivery analysis, and guarded After Effects handoff routes. Those are different kinds of capabilities: a local plan is not a timeline mutation, and an import receipt is not playback or render proof.`,
+          "At the inspected commit, hetpatel-11's README describes 283 catalog tools, including search_tools, get_tool_schema, and invoke_tool, plus 13 resources and 10 guided prompts. It emphasizes CEP workflows including product-spot assembly and a live tool sweep. It reports active use and testing on Premiere 26.0 and calls UXP experimental. These are the maintainer's documented claims, not our independent host test results.",
+          "The catalog counts use different groupings and are not a feature-quality score. Both projects offer a local CEP route and require a compatible Premiere installation. Evaluate the operations you need, their prerequisites, and what their returned results actually establish.",
+        ],
+        links: [
+          { label: "Our published package facts and provenance", href: "/facts/" },
+          { label: "Our supported action contracts", href: `${product.links.repository}/blob/main/docs/supported-actions.md` },
+          { label: "Other project's README at the inspected commit", href: "https://github.com/hetpatel-11/Adobe_Premiere_Pro_MCP/blob/ee31c3def7c3ca1c68662ea7737a9f8e5a2b634f/README.md" },
+        ],
+      },
+      {
+        heading: "Evaluate the same small project in each",
+        paragraphs: ["Use a copied project and the same source media, requested outcome, host version, and operating system for each evaluation. Record the installed package version and connector. Never turn a planned operation or an accepted host response into a completed-edit claim."],
+        steps: [
+          "Start with verify_premiere_connection and request no changes. Record whether the intended project and sequence are ready.",
+          "Inspect one sequence. Compare the report with Premiere and note omissions, stale state, or unsupported operations.",
+          "Request one product-spot preview or another bounded workflow. Check source ranges, tracks, prerequisites, and whether approval is required before any writes.",
+          "If testing an edit, explicitly approve the exact change in the disposable project. Inspect the timeline, Undo behavior, save/reopen result, and playback separately.",
+          "If testing delivery, inspect the exported file separately. Record elapsed time and failures for this fixture; a single run is not a general speed benchmark.",
+        ],
+        links: [{ label: "Download our synthetic workflow starter kit", href: "/workflows/" }],
+      },
+      {
+        heading: "Switch without mixing configurations",
+        paragraphs: [
+          "Save a copy of your client configuration and note which package and connector it starts. Stop that MCP entry and its panel before testing a replacement. Follow the chosen repository's installation instructions; do not assume the connectors, environment variables, or tool names are interchangeable.",
+          "For this project, the Claude Desktop bundle and its separate Premiere connector are the documented release route. For source users, the new --print-client-config helper emits a client entry pointing at the current Node executable and server file. It writes no files. This helper is a development-source feature and is absent from the published v1.15.0 package.",
+          "Merge the generated entry into existing settings and preserve other servers. Its local paths may contain your user name; keep the output private. A moved checkout or Node installation requires a refreshed entry. Restart your client and repeat the read-only connection check before editing.",
+        ],
+        links: [
+          { label: "Release setup guide", href: "/blog/how-to-set-up-premiere-pro-mcp/" },
+          { label: "Source configuration helper and commands", href: `${product.links.repository}/blob/main/docs/client-configuration.md` },
+          { label: "Connection troubleshooting", href: "/docs/troubleshooting/" },
+        ],
+      },
+      {
+        heading: "Share a reproducible result",
+        paragraphs: [
+          "After a successful evaluation, a useful contribution is a short account of the workflow, package version, OS, Premiere build, expected result, and observed result. Use synthetic material; exclude client media, paths, tokens, and private transcripts from public reports.",
+          "If this project is useful to you, a GitHub star helps others discover it. The starter kit, installation, and contribution process remain available without a star. Independent workflow reports are more informative than catalog size alone.",
+        ],
+        links: [{ label: "View or star our repository", href: product.links.repository }],
+      },
+    ],
+    faqs: [
+      { question: "Are premiere-pro-mcp and adobe-premiere-pro-mcp the same package?", answer: "No. premiere-pro-mcp belongs to leancoderkavy/premiere-pro-mcp; adobe-premiere-pro-mcp belongs to hetpatel-11/Adobe_Premiere_Pro_MCP. They both declare a premiere-pro-mcp command, so verify the package and repository before installation." },
+      { question: "Does the larger catalog prove that one works better?", answer: "No. Catalog registrations, sub-actions, local plans, and host operations have different scopes. Compare the same workflow on your intended Premiere version and verify the result." },
+      { question: "Can either hosted website edit the Premiere project on my computer?", answer: "A website or repository alone cannot establish a local Premiere connection. Follow the selected project's local server and connector setup. This project's hosted endpoint does not automatically pair with a visitor's computer." },
+    ],
+    resources: [
+      { label: "Our npm package", href: product.links.npm },
+      { label: "Other project's npm package", href: "https://www.npmjs.com/package/adobe-premiere-pro-mcp" },
+      { label: "Our package facts", href: "/facts/" },
+      { label: "npm executable mapping", href: "https://docs.npmjs.com/cli/v11/configuring-npm/package-json/#bin" },
+    ],
+    relatedSlugs: ["how-to-set-up-premiere-pro-mcp", "premiere-pro-ai-workflow-checklist"],
+  },
+  {
     slug: "premiere-pro-project-intake-checklist",
     seoTitle: "Project Intake Checklist",
     title: "Premiere Pro Project Intake Checklist: Prepare a Read-Only Review Before Organizing Media",

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -32,6 +32,7 @@ The hosted endpoint does not automatically pair a visitor to their local Premier
 - Claude setup: https://premiere-pro-mcp.com/blog/claude-desktop-premiere-pro-mcp-setup/
 - Codex setup: https://premiere-pro-mcp.com/blog/codex-premiere-pro-mcp-setup/
 - MCP setup: https://premiere-pro-mcp.com/blog/how-to-set-up-premiere-pro-mcp/
+- Package comparison: https://premiere-pro-mcp.com/blog/premiere-pro-mcp-vs-adobe-premiere-pro-mcp/
 - AI in Premiere: https://premiere-pro-mcp.com/blog/set-up-ai-in-premiere-pro/
 - ChatGPT connection options: https://premiere-pro-mcp.com/blog/chatgpt-premiere-pro-mcp/
 - Workflow automation: https://premiere-pro-mcp.com/blog/premiere-pro-workflow-automation/

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -32,6 +32,7 @@ The hosted endpoint does not automatically pair a visitor to their local Premier
 - Claude setup: https://premiere-pro-mcp.com/blog/claude-desktop-premiere-pro-mcp-setup/
 - Codex setup: https://premiere-pro-mcp.com/blog/codex-premiere-pro-mcp-setup/
 - MCP setup: https://premiere-pro-mcp.com/blog/how-to-set-up-premiere-pro-mcp/
+- Package comparison: https://premiere-pro-mcp.com/blog/premiere-pro-mcp-vs-adobe-premiere-pro-mcp/
 - AI in Premiere: https://premiere-pro-mcp.com/blog/set-up-ai-in-premiere-pro/
 - ChatGPT connection options: https://premiere-pro-mcp.com/blog/chatgpt-premiere-pro-mcp/
 - Workflow automation: https://premiere-pro-mcp.com/blog/premiere-pro-workflow-automation/

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "validate:host-report": "node scripts/validate-licensed-host-report.mjs",
     "validate:mcp-registry-metadata": "node scripts/validate-mcp-registry-metadata.mjs",
     "preflight:mcp-registry": "node scripts/preflight-mcp-registry-submission.mjs",
+    "growth:scorecard": "node scripts/competitive-scorecard.mjs",
     "product-manifest": "node scripts/generate-public-product-manifest.mjs",
     "product-manifest:check": "node scripts/generate-public-product-manifest.mjs --check",
     "validate:project-intake-host-report": "node scripts/validate-project-intake-host-report.mjs",

--- a/product-growth-runs/premiere-pro-mcp/2026-09-09/00-executive-summary.md
+++ b/product-growth-runs/premiere-pro-mcp/2026-09-09/00-executive-summary.md
@@ -8,11 +8,17 @@ The objective is to overtake `hetpatel-11/Adobe_Premiere_Pro_MCP` in relevant
 discovery, demonstrated workflow quality, and stars. This run delivers a first
 implementation toward that objective; it does not establish that we have won.
 
-The latest [saved public snapshot](../../../docs/marketing/competitive-baseline-2026-09-09.json)
+The initial [saved public snapshot](../../../docs/marketing/competitive-baseline-2026-09-09.json)
 has **240 vs 530 stars**, **39 vs 110 forks**, and **1,897 vs 1,123 npm downloads**
 for August 31–September 6. We need **291 additional stars relative to their current
 count** to lead. Their stars rose from 529 to 530 during this research, illustrating
 why the target must move. Downloads are not unique users. [Sources](sources.md)
+
+The later [search-enabled snapshot](../../../docs/marketing/competitive-search-baseline-2026-09-09.json)
+at 07:21 UTC records **241 vs 530 stars** (290 relative additions to lead) and
+**GitHub API best-match positions 2 vs 1** for `premiere pro mcp`. It returned all
+47 matches without an incomplete-results warning. This is one unauthenticated API
+query sample; Google rankings remain unmeasured.
 
 The strongest verified opportunity is package confusion: both packages declare
 the same executable. The new configuration helper selects this installation by

--- a/product-growth-runs/premiere-pro-mcp/2026-09-09/00-executive-summary.md
+++ b/product-growth-runs/premiere-pro-mcp/2026-09-09/00-executive-summary.md
@@ -1,0 +1,58 @@
+# Competitive execution: MCP for Adobe Premiere Pro
+
+Market: English-language Premiere MCP discovery and local editing workflows.
+Date: September 9, 2026. Status: researched; implementation prepared for review.
+Scope: product onboarding, organic search, real adoption, and GitHub stars.
+
+The objective is to overtake `hetpatel-11/Adobe_Premiere_Pro_MCP` in relevant
+discovery, demonstrated workflow quality, and stars. This run delivers a first
+implementation toward that objective; it does not establish that we have won.
+
+The latest [saved public snapshot](../../../docs/marketing/competitive-baseline-2026-09-09.json)
+has **240 vs 530 stars**, **39 vs 110 forks**, and **1,897 vs 1,123 npm downloads**
+for August 31–September 6. We need **291 additional stars relative to their current
+count** to lead. Their stars rose from 529 to 530 during this research, illustrating
+why the target must move. Downloads are not unique users. [Sources](sources.md)
+
+The strongest verified opportunity is package confusion: both packages declare
+the same executable. The new configuration helper selects this installation by
+absolute path for Claude, Cursor, VS Code, and Codex. It prints an entry without
+changing existing client settings. A comparison guide explains the identity
+boundary, cites the competitor's inspected commit, and provides a common
+evaluation procedure. `npm run growth:scorecard` makes public measurements
+repeatable and preserves unavailable values as unknown. (INS-001–003.)
+
+Positioning: **Connect your assistant to a Premiere workflow you can inspect and
+verify.** The reason to choose us should be a reproducible useful result. Both
+projects have broad catalogs; their differently grouped counts cannot establish
+which host workflows work better. (ANG-001, INS-004.)
+
+First creative concept: an uncut real recording showing package identity, client
+configuration, connection verification, then a small sequence inspection. Use the
+existing synthetic workflow kit and receipt template. A designed illustration is
+not that recording. Paid ads are outside this run's scope.
+
+Next seven actions, in order:
+
+1. Review and integrate the configuration helper and comparison content after checks.
+2. Deploy the guide, verifying its canonical URL, response, sitemap and internal links.
+3. Release the CLI helper through the existing versioned release pipeline; until then,
+   retain the explicit development-source label. Do not advertise it as part of v1.15.0.
+4. Reproduce the first workflow on licensed Windows and macOS Premiere hosts using
+   `docs/workflow-proof-runbook.md`; record the exact versions and observed limitations.
+5. Turn that evidence into one short recording and a reproducible setup/workflow kit.
+6. After authorization, share the kit with a small relevant editor audience and seek
+   independent reproduction. Use `docs/marketing/mcp-registry-readiness.md` for
+   existing listing identity; official v1.15.0 registry publication is already done.
+7. Review equal-window search, activation, and star changes weekly. Improve the step
+   with measured failure before expanding features or producing more content.
+
+First SEO cluster: package comparison and installation identity (SEO-001). Existing
+Claude/Codex/setup guides and the existing 90-day plan remain the foundation.
+
+Next actions: finish checks, review, then execute the ordered list.
+Owner: repository maintainer; licensed-host workflow reviewer for step 4.
+Approval needed: public deployment/release and any outreach; no paid spend proposed.
+Completion criteria: a tested reviewable implementation now; later, observed search
+leadership for specified queries and a sustained star lead, supported by successful
+independent workflow runs.

--- a/product-growth-runs/premiere-pro-mcp/2026-09-09/01-product-truth.md
+++ b/product-growth-runs/premiere-pro-mcp/2026-09-09/01-product-truth.md
@@ -13,10 +13,11 @@ Date: September 9, 2026. Scope: competitive claims. Status: evidence recorded.
 | Our v1.15.0 official registry record is active and latest | SRC-005, checked live | High / verified registry response | Publication status; no downstream listing or ranking claim |
 | Our local config helper is development source | `src/client-config.ts` and `src/index.ts` | Verified local code | Source setup only until released |
 | 240 vs 530 stars; 1,897 vs 1,123 npm downloads in equal dates | Saved baseline, SRC-006–009 | Verified API snapshot | Dated repository/download signals only |
+| Later snapshot: 241 vs 530 stars; GitHub API search positions 2 vs 1 | Saved search baseline, SRC-012 | Verified API sample | Exact query and method only; no Google claim |
 
 | Unverified claim | Required evidence |
 | --- | --- |
-| We rank above the other project | Dated query/engine/locale/device observations and comparable Search Console reports |
+| We rank above the other project | Current GitHub sample instead places us second; require repeated observations and comparable Google Search Console reports |
 | We have more active editors | Direct, consent-respecting activation/retention evidence |
 | Our workflows are faster or more reliable | Same fixture, package versions, OS/Premiere/client conditions, repeated host runs |
 | This configuration was accepted by all four real clients | Individual client discovery and local host checks |

--- a/product-growth-runs/premiere-pro-mcp/2026-09-09/01-product-truth.md
+++ b/product-growth-runs/premiere-pro-mcp/2026-09-09/01-product-truth.md
@@ -1,0 +1,28 @@
+# Product truth
+
+Product: MCP for Adobe Premiere Pro. Market: local Premiere MCP workflows.
+Date: September 9, 2026. Scope: competitive claims. Status: evidence recorded.
+
+| Fact | Source | Confidence / state | Allowed use |
+| --- | --- | --- | --- |
+| Our package is `premiere-pro-mcp`; the other is `adobe-premiere-pro-mcp` | SRC-001, SRC-002 | High / verified metadata | Exact install identity |
+| Both declare `premiere-pro-mcp` as a binary | SRC-001, SRC-002 | High / verified source | Explain ambiguity; do not claim a collision was reproduced on an editor's machine |
+| Our released v1.15.0 facts report 369 core tools | `landing/lib/published-release.json`, SRC-003 | High / repository artifact provenance | Published catalog size, not working-edit count |
+| The other README reports 283 tools, 13 resources, 10 prompts | SRC-004 | Page evidence | Attribute to their inspected README and date |
+| Their README reports Premiere 26.0 testing | SRC-004 | Page evidence | Maintainer-reported testing; not independent verification |
+| Our v1.15.0 official registry record is active and latest | SRC-005, checked live | High / verified registry response | Publication status; no downstream listing or ranking claim |
+| Our local config helper is development source | `src/client-config.ts` and `src/index.ts` | Verified local code | Source setup only until released |
+| 240 vs 530 stars; 1,897 vs 1,123 npm downloads in equal dates | Saved baseline, SRC-006–009 | Verified API snapshot | Dated repository/download signals only |
+
+| Unverified claim | Required evidence |
+| --- | --- |
+| We rank above the other project | Dated query/engine/locale/device observations and comparable Search Console reports |
+| We have more active editors | Direct, consent-respecting activation/retention evidence |
+| Our workflows are faster or more reliable | Same fixture, package versions, OS/Premiere/client conditions, repeated host runs |
+| This configuration was accepted by all four real clients | Individual client discovery and local host checks |
+| All registered tools work on a licensed host | Version-specific host execution and outcome verification |
+
+Next actions: use only the allowed claims in public content.
+Owner: repository maintainer.
+Approval needed: publication only; no new external data access requested.
+Completion criteria: each new claim has an inspectable source and the right evidence scope.

--- a/product-growth-runs/premiere-pro-mcp/2026-09-09/02-market-research.md
+++ b/product-growth-runs/premiere-pro-mcp/2026-09-09/02-market-research.md
@@ -12,12 +12,14 @@ Status: source review and public API measurements; no comparative live-host test
 | INS-004 | Editors comparing features | Know what succeeds in their host | Broad documented catalogs use different groupings and verification boundaries | SRC-003–004 | Source evidence only | Compare common workflow fixtures and outcomes | inference |
 | INS-005 | Maintainer | Avoid duplicate distribution work | Official v1.15.0 registry entry is already active/latest | SRC-005 | Direct API | Verify downstream identity rather than republish blindly | verified |
 | INS-006 | Maintainer | Understand adoption beyond GitHub | Our npm download count is larger in the same full week | SRC-008–009 | Direct API; no unique-user semantics | Prioritize successful installation and workflow proof | inference |
+| INS-007 | Maintainer | Track a specific discovery gap | GitHub API best-match search returns theirs first, ours second | SRC-012, later saved snapshot | Direct API sample | Repeat the same query and method; track Google separately | verified |
 
 The public search tool returned both projects and our existing guides, but its
 ordered results do not establish a Google or GitHub search position. No Ahrefs or
 Search Console connector was callable in this task. Prior rank and Ahrefs notes
-are historical only. We have no fresh exact rank, keyword volume, CTR, or conversion
-rate. No community anecdotes were treated as customer interviews.
+are historical only. A separate GitHub REST sample now records positions 2 vs 1
+for `premiere pro mcp`; we have no fresh Google rank, keyword volume, CTR, or
+conversion rate. No community anecdotes were treated as customer interviews.
 
 Next actions: obtain comparable search/activation evidence and run the same workflow fixture.
 Owner: maintainer and workflow reviewer.

--- a/product-growth-runs/premiere-pro-mcp/2026-09-09/02-market-research.md
+++ b/product-growth-runs/premiere-pro-mcp/2026-09-09/02-market-research.md
@@ -1,0 +1,25 @@
+# Competitive research
+
+Product: MCP for Adobe Premiere Pro. Market: English-language local Premiere MCP.
+Date: September 9, 2026. Scope: named competitor and existing distribution.
+Status: source review and public API measurements; no comparative live-host test.
+
+| ID | Audience | Pain or desire | Evidence | Source | Strength | Implication | State |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| INS-001 | Editors configuring a client | Know which project will run | Different packages declare the same binary name | SRC-001–002 | Direct source | Generate paths for the chosen installation and clarify identity | verified |
+| INS-002 | Evaluators arriving from search | Choose the correct package and workflow | Both projects appear in the live search sample for related queries | SRC-010 | Directional; unknown locale and unstable ordering | One sourced comparison page linking existing setup guides | page evidence |
+| INS-003 | Maintainer | Track the actual star gap | Latest counts 240 and 530 | SRC-006–007, saved snapshot | Direct API | A moving target and repeated dated measurements | verified |
+| INS-004 | Editors comparing features | Know what succeeds in their host | Broad documented catalogs use different groupings and verification boundaries | SRC-003–004 | Source evidence only | Compare common workflow fixtures and outcomes | inference |
+| INS-005 | Maintainer | Avoid duplicate distribution work | Official v1.15.0 registry entry is already active/latest | SRC-005 | Direct API | Verify downstream identity rather than republish blindly | verified |
+| INS-006 | Maintainer | Understand adoption beyond GitHub | Our npm download count is larger in the same full week | SRC-008–009 | Direct API; no unique-user semantics | Prioritize successful installation and workflow proof | inference |
+
+The public search tool returned both projects and our existing guides, but its
+ordered results do not establish a Google or GitHub search position. No Ahrefs or
+Search Console connector was callable in this task. Prior rank and Ahrefs notes
+are historical only. We have no fresh exact rank, keyword volume, CTR, or conversion
+rate. No community anecdotes were treated as customer interviews.
+
+Next actions: obtain comparable search/activation evidence and run the same workflow fixture.
+Owner: maintainer and workflow reviewer.
+Approval needed: no outreach has been sent; authorize any later contacts separately.
+Completion criteria: repeatable comparisons replace hypotheses with observed results.

--- a/product-growth-runs/premiere-pro-mcp/2026-09-09/03-positioning.md
+++ b/product-growth-runs/premiere-pro-mcp/2026-09-09/03-positioning.md
@@ -1,0 +1,33 @@
+# Positioning and feature priorities
+
+Product: MCP for Adobe Premiere Pro. Market: technical editors and assistant editors.
+Date: September 9, 2026. Scope: organic evaluation and onboarding.
+Status: recommended positioning; performance differentiation remains unproven.
+
+Primary audience: an editor or small post team evaluating one repeatable local
+workflow with their preferred assistant. The immediate job is to connect the
+correct software, inspect a project, and get a useful result they can check.
+
+| ID | Message | Evidence and application |
+| --- | --- | --- |
+| ANG-001 | Connect your assistant to a Premiere workflow you can inspect and verify. | INS-004; primary direction, demonstrated with a small workflow |
+| ANG-002 | Configure the exact installation you intend to run. | INS-001; CLI helper and comparison guide |
+| ANG-003 | Try the same project, inspect the result, and share what happened. | INS-004; existing synthetic kit plus real-host receipt |
+
+| Priority | Outcome | Acceptance criterion | Evidence |
+| --- | --- | --- | --- |
+| P0, implemented in this branch | Deterministic client setup output | Four formats, absolute executable/entrypoint paths, no writes, mixed actions rejected | INS-001 |
+| P0, before a workflow campaign | Real first-use proof | Exact released versions; connection, sequence inspection and limitations documented on Windows/macOS | INS-004 |
+| P1 | Reliable product-spot workflow | Same synthetic media and intended timing; preview, approval, timeline, Undo, reopen and playback reviewed | INS-004 |
+| P1 | Review/delivery handoff proof | Approved file outputs checked for existence/content, with host and render evidence kept distinct | INS-004 |
+| P2, based on observed failures | Client and connector recovery | Repeated external setup failures reproduced and resolved | INS-006 |
+
+Objection: the other repo has more stars. Response: that is currently true; try a
+common workflow and compare outcomes. Objection: a larger catalog means it is
+better. Response: ask which operations are supported on the intended host and how
+success is verified. Neither objection warrants an unsupported superiority claim.
+
+Next actions: make ANG-001 demonstrable, then distribute that evidence.
+Owner: maintainer and independent workflow evaluators.
+Approval needed: any external campaign or request to others.
+Completion criteria: chosen message is supported by a reproducible workflow, not just copy.

--- a/product-growth-runs/premiere-pro-mcp/2026-09-09/07-ahrefs-seo.md
+++ b/product-growth-runs/premiere-pro-mcp/2026-09-09/07-ahrefs-seo.md
@@ -17,6 +17,11 @@ on main. This change adds one distinct comparison intent rather than another
 generic setup article. Existing article templates supply its canonical, metadata,
 Article/FAQ structured data, sitemap and guide-index discovery.
 
+The scorecard's separate GitHub REST best-match sample reports positions 2 vs 1
+for `premiere pro mcp` at 07:21 UTC. It repeats that exact unauthenticated query,
+retains returned/total result counts, and withholds positions for incomplete or
+missing results. It cannot substitute for Google measurements. (INS-007.)
+
 Measure US English desktop and mobile separately, documenting engine, exact query,
 time, login state and result types. Treat each SERP as a sample. Prefer authorized
 Search Console page/query reports over anecdotal observations; retain country,

--- a/product-growth-runs/premiere-pro-mcp/2026-09-09/07-ahrefs-seo.md
+++ b/product-growth-runs/premiere-pro-mcp/2026-09-09/07-ahrefs-seo.md
@@ -1,0 +1,34 @@
+# Search execution queue
+
+Product: MCP for Adobe Premiere Pro. Market: English-language Premiere searches.
+Date: September 9, 2026. Scope: organic comparison and existing setup pages.
+Status: one new distinct comparison guide prepared; search outcomes unmeasured.
+
+| ID | Intent | Topic or query | Page type | Evidence source | Ahrefs data needed | Priority | State |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| SEO-001 | Comparison | `premiere-pro-mcp vs adobe-premiere-pro-mcp` | Sourced comparison and switching guide | INS-001–002 | Volume, difficulty, referring pages | P0 | implemented locally |
+| SEO-002 | Setup | `Premiere MCP wrong package`, `Premiere MCP configuration` | Existing setup guide links to comparison/helper | INS-001 | Related queries and actual support demand | P0 | content prepared |
+| SEO-003 | Evaluation | `Premiere MCP workflow` | Improve existing workflow kit with real recording | INS-004 | Query/page opportunities; competing demonstrations | P1 | pending live verification |
+| SEO-004 | Discovery | `premiere pro mcp`, `adobe premiere pro mcp` | Existing homepage/repo and registry downstream pages | INS-002, INS-005 | SERP snapshots and referring domains | P1 | measure before further copy changes |
+
+No keyword volumes, difficulty, traffic, or positions are invented. The existing
+canonical redirect, sitemap, setup content, and official registry work is already
+on main. This change adds one distinct comparison intent rather than another
+generic setup article. Existing article templates supply its canonical, metadata,
+Article/FAQ structured data, sitemap and guide-index discovery.
+
+Measure US English desktop and mobile separately, documenting engine, exact query,
+time, login state and result types. Treat each SERP as a sample. Prefer authorized
+Search Console page/query reports over anecdotal observations; retain country,
+device and data-through dates. Compare complete equal 28-day windows. Review the
+guide's clicks through to setup and workflow actions separately from position.
+
+Success target: appear above the named competitor for the agreed query set on
+repeated observations and sustain useful setup traffic. This is a target, not a
+forecast or a claim about current rankings. Technical checks establish crawlable
+content; they do not establish indexing or ranking.
+
+Next actions: publish after approval, verify live URLs, then collect comparable data.
+Owner: maintainer.
+Approval needed: deployment and later directory outreach.
+Completion criteria: correct live identity/content and measurable search changes.

--- a/product-growth-runs/premiere-pro-mcp/2026-09-09/08-approval-measurement.md
+++ b/product-growth-runs/premiere-pro-mcp/2026-09-09/08-approval-measurement.md
@@ -8,7 +8,8 @@ Local evidence for this implementation:
 
 - `npm run check`: 171 files, 3,224 tests passed, including build, inventories,
   source/release metadata, branding, registry metadata, and documentation checks.
-- Focused configuration/measurement checks: 22 tests passed. A generated entry
+- Focused configuration/measurement checks: 24 tests passed after adding the
+  GitHub search sample and incomplete/missing-result cases. A generated entry
   launched this package's `--version`; generated Codex TOML also parsed with an
   independent TOML parser. No real AI-client acceptance is claimed.
 - Landing lint, production build and performance budget passed. SEO export check:
@@ -32,17 +33,19 @@ npm run growth:scorecard -- --output docs/marketing/competitive-baseline-YYYY-MM
 ```
 
 Choose a new filename for every run. Existing snapshots are never overwritten.
-The script reads public GitHub repository counts and npm downloads only, records
+The script reads public GitHub repository counts, a fixed GitHub search and npm downloads, records
 their sources and date ranges, and exits unsuccessfully if a required measurement
 is unavailable. Failed requests leave nulls, never fabricated zeroes. It makes no
-search-engine, user-count, or licensed-host claims.
+Google-ranking, user-count, or licensed-host claims. GitHub search is explicitly a
+single unauthenticated best-match query sample, capped at 100 returned results.
 
 | Outcome | Baseline | Decision rule |
 | --- | --- | --- |
-| Stars | 240 vs 530; relative lead -290 | Overtake by at least one and sustain the lead across weekly snapshots |
+| Stars | Initial 240 vs 530; later 241 vs 530, relative lead -289 | Overtake by at least one and sustain the lead across weekly snapshots |
 | Growth pace | No same-method weekly trend established | Working target: improve relative lead by at least 25/week; 12 such weeks would overcome today's gap. This is an experimental target, not a forecast |
 | npm distribution | 1,897 vs 1,123, August 31–September 6 | Compare only equal API date ranges; do not infer unique installs |
-| Search | No fresh controlled rank or GSC baseline | Compare full equal windows and documented query/locale/device samples |
+| GitHub search | API best-match positions 2 vs 1 for `premiere pro mcp` | Repeat exact unauthenticated query; omit incomplete or missing positions |
+| Google search | No fresh controlled rank or GSC baseline | Compare full equal windows and documented query/locale/device samples |
 | Activation | No current first-run completion rate measured | Measure successful connection and first useful workflow; do not divide downloads by stars |
 | Workflow quality | No comparative licensed-host runs in this task | Same fixture; exact versions; expected vs observed result; Undo, reopen and output inspection |
 

--- a/product-growth-runs/premiere-pro-mcp/2026-09-09/08-approval-measurement.md
+++ b/product-growth-runs/premiere-pro-mcp/2026-09-09/08-approval-measurement.md
@@ -1,0 +1,66 @@
+# Execution and measurement
+
+Product: MCP for Adobe Premiere Pro. Market: local Premiere editors and developers.
+Date: September 9, 2026. Scope: organic adoption and named-repo comparison.
+Status: local verification passed; external outcomes not yet established.
+
+Local evidence for this implementation:
+
+- `npm run check`: 171 files, 3,224 tests passed, including build, inventories,
+  source/release metadata, branding, registry metadata, and documentation checks.
+- Focused configuration/measurement checks: 22 tests passed. A generated entry
+  launched this package's `--version`; generated Codex TOML also parsed with an
+  independent TOML parser. No real AI-client acceptance is claimed.
+- Landing lint, production build and performance budget passed. SEO export check:
+  25 canonical pages, unique titles/descriptions, valid JSON-LD, 428 internal
+  links and anchors.
+- `npm run pack:check` passed its package-content and isolated-install checks.
+- Playwright on the production HTTP server locally: 1440px desktop and 390px
+  mobile, one H1, correct canonical, no horizontal overflow, FAQ click/keyboard
+  interaction, and navigation into the setup guide. The production server had no
+  console errors in this pass. The initial generic Python preview server lacked
+  Next Flight filename remapping, so final navigation checks used the actual
+  application server. Screenshots remain local under `output/playwright/`.
+- Current remote main was still `dcafe7a965a2a50648cd166a62f015ad810870c6`
+  when these results were prepared. CI, deployment, new release and licensed-host
+  results remain separate checks.
+
+Refresh the public baseline from this checkout:
+
+```sh
+npm run growth:scorecard -- --output docs/marketing/competitive-baseline-YYYY-MM-DD.json
+```
+
+Choose a new filename for every run. Existing snapshots are never overwritten.
+The script reads public GitHub repository counts and npm downloads only, records
+their sources and date ranges, and exits unsuccessfully if a required measurement
+is unavailable. Failed requests leave nulls, never fabricated zeroes. It makes no
+search-engine, user-count, or licensed-host claims.
+
+| Outcome | Baseline | Decision rule |
+| --- | --- | --- |
+| Stars | 240 vs 530; relative lead -290 | Overtake by at least one and sustain the lead across weekly snapshots |
+| Growth pace | No same-method weekly trend established | Working target: improve relative lead by at least 25/week; 12 such weeks would overcome today's gap. This is an experimental target, not a forecast |
+| npm distribution | 1,897 vs 1,123, August 31–September 6 | Compare only equal API date ranges; do not infer unique installs |
+| Search | No fresh controlled rank or GSC baseline | Compare full equal windows and documented query/locale/device samples |
+| Activation | No current first-run completion rate measured | Measure successful connection and first useful workflow; do not divide downloads by stars |
+| Workflow quality | No comparative licensed-host runs in this task | Same fixture; exact versions; expected vs observed result; Undo, reopen and output inspection |
+
+The weekly review should answer: what changed, which step improved or failed,
+which evidence supports the explanation, and which one change to test next.
+Keep raw private Search Console or telemetry exports outside public Git. Existing
+browser and runtime events do not establish a shared editor identity.
+
+Before any public workflow campaign, use `docs/workflow-proof-runbook.md` and
+`docs/workflow-proof-receipt.template.json`. Record synthetic/local evidence first.
+Then prepare a single demonstration and a relevant destination; request a star
+only after the reader has received useful material. No contacts, posts, ad spend,
+or paid media generation were performed in this run.
+
+Next actions: review the implementation, verify deployment after approval, then run
+the existing host-proof workflow and repeat the measurements.
+Owner: repository maintainer.
+Approval needed: merge/deploy/release and specific external outreach. The source
+helper must remain marked unreleased until the package release includes it.
+Completion criteria: tested changes reviewed now; star/search objectives remain
+open until later measurements demonstrate them.

--- a/product-growth-runs/premiere-pro-mcp/2026-09-09/sources.md
+++ b/product-growth-runs/premiere-pro-mcp/2026-09-09/sources.md
@@ -1,0 +1,22 @@
+# Sources
+
+Product: MCP for Adobe Premiere Pro. Market: local Premiere MCP integrations.
+Date: September 9, 2026. Scope: public metadata, source inspection and search.
+Status: checked during this run; linked moving APIs will change after this date.
+
+- SRC-001: [Our package at inspected main](https://github.com/leancoderkavy/premiere-pro-mcp/blob/dcafe7a/package.json).
+- SRC-002: [Other package at inspected commit](https://github.com/hetpatel-11/Adobe_Premiere_Pro_MCP/blob/ee31c3def7c3ca1c68662ea7737a9f8e5a2b634f/package.json).
+- SRC-003: [Our v1.15.0 release](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.15.0) and [published facts](https://premiere-pro-mcp.com/facts/); local `landing/lib/published-release.json` carries artifact provenance.
+- SRC-004: [Other README at inspected commit](https://github.com/hetpatel-11/Adobe_Premiere_Pro_MCP/blob/ee31c3def7c3ca1c68662ea7737a9f8e5a2b634f/README.md).
+- SRC-005: [Official registry namespace query](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.leancoderkavy/premiere-pro). Returned v1.15.0 active/latest, published September 8, 2026.
+- SRC-006: [Our GitHub repository API](https://api.github.com/repos/leancoderkavy/premiere-pro-mcp).
+- SRC-007: [Other GitHub repository API](https://api.github.com/repos/hetpatel-11/Adobe_Premiere_Pro_MCP).
+- SRC-008: [Our exact npm window](https://api.npmjs.org/downloads/point/2026-08-31:2026-09-06/premiere-pro-mcp).
+- SRC-009: [Other exact npm window](https://api.npmjs.org/downloads/point/2026-08-31:2026-09-06/adobe-premiere-pro-mcp).
+- SRC-010: Live web search sample, queries `Premiere Pro MCP` and `Adobe Premiere Pro MCP server AI video editing`. Returned both repositories and [our workflow guide](https://premiere-pro-mcp.com/blog/ai-video-editing-with-premiere-pro/), [our explainer](https://premiere-pro-mcp.com/blog/what-is-a-premiere-pro-mcp-server/), and [their website](https://premiere-mcp.com/). Engine-specific rank and locale were not available; no position inferred.
+- SRC-011: [npm bin mapping](https://docs.npmjs.com/cli/v11/configuring-npm/package-json/#bin), [VS Code configuration](https://code.visualstudio.com/docs/agent-customization/mcp-servers), [Cursor configuration](https://cursor.com/docs/mcp), [Codex configuration](https://developers.openai.com/codex/mcp).
+
+Next actions: refresh changing facts before reusing public comparison claims.
+Owner: maintainer.
+Approval needed: none for these public read-only sources.
+Completion criteria: each material claim points to its source and dated snapshot.

--- a/product-growth-runs/premiere-pro-mcp/2026-09-09/sources.md
+++ b/product-growth-runs/premiere-pro-mcp/2026-09-09/sources.md
@@ -15,6 +15,7 @@ Status: checked during this run; linked moving APIs will change after this date.
 - SRC-009: [Other exact npm window](https://api.npmjs.org/downloads/point/2026-08-31:2026-09-06/adobe-premiere-pro-mcp).
 - SRC-010: Live web search sample, queries `Premiere Pro MCP` and `Adobe Premiere Pro MCP server AI video editing`. Returned both repositories and [our workflow guide](https://premiere-pro-mcp.com/blog/ai-video-editing-with-premiere-pro/), [our explainer](https://premiere-pro-mcp.com/blog/what-is-a-premiere-pro-mcp-server/), and [their website](https://premiere-mcp.com/). Engine-specific rank and locale were not available; no position inferred.
 - SRC-011: [npm bin mapping](https://docs.npmjs.com/cli/v11/configuring-npm/package-json/#bin), [VS Code configuration](https://code.visualstudio.com/docs/agent-customization/mcp-servers), [Cursor configuration](https://cursor.com/docs/mcp), [Codex configuration](https://developers.openai.com/codex/mcp).
+- SRC-012: [GitHub repository search API sample](https://api.github.com/search/repositories?q=premiere%20pro%20mcp&per_page=100&page=1) and [GitHub's best-match semantics](https://docs.github.com/en/rest/search/search#ranking-search-results). Exact query `premiere pro mcp`, unauthenticated, page 1, limit 100; 47 returned, incomplete_results false; ours second, named competitor first at 07:21 UTC.
 
 Next actions: refresh changing facts before reusing public comparison claims.
 Owner: maintainer.

--- a/scripts/competitive-scorecard.mjs
+++ b/scripts/competitive-scorecard.mjs
@@ -1,0 +1,104 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const projects = [
+  { role: "ours", repository: "leancoderkavy/premiere-pro-mcp", package: "premiere-pro-mcp" },
+  { role: "comparison", repository: "hetpatel-11/Adobe_Premiere_Pro_MCP", package: "adobe-premiere-pro-mcp" },
+];
+const count = (value) => Number.isSafeInteger(value) && value >= 0 ? value : null;
+const date = (value) => {
+  if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return Number.isFinite(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value ? value : null;
+};
+
+async function readPublicJson(url, fetcher) {
+  try {
+    const response = await fetcher(url, {
+      headers: { Accept: "application/json", "User-Agent": "premiere-pro-mcp-competitive-scorecard" },
+      signal: AbortSignal.timeout(15000),
+    });
+    if (!response.ok) return { state: "unavailable", reason: `http_${response.status}`, source: url, data: null };
+    return { state: "observed", source: url, data: await response.json() };
+  } catch {
+    return { state: "unavailable", reason: "request_failed", source: url, data: null };
+  }
+}
+
+export async function collectCompetitiveScorecard({ fetcher = fetch, now = () => new Date() } = {}) {
+  const rows = await Promise.all(projects.map(async (project) => {
+    const [github, npm] = await Promise.all([
+      readPublicJson(`https://api.github.com/repos/${project.repository}`, fetcher),
+      readPublicJson(`https://api.npmjs.org/downloads/point/last-week/${project.package}`, fetcher),
+    ]);
+    const validRepo = typeof github.data?.full_name === "string" && github.data.full_name.toLowerCase() === project.repository.toLowerCase();
+    const validPackage = npm.data?.package === project.package;
+    return {
+      ...project,
+      github: {
+        state: validRepo ? "observed" : "unavailable",
+        source: github.source,
+        reason: validRepo ? null : github.reason ?? "unexpected_repository",
+        stars: validRepo ? count(github.data.stargazers_count) : null,
+        forks: validRepo ? count(github.data.forks_count) : null,
+      },
+      npm: {
+        state: validPackage ? "observed" : "unavailable",
+        source: npm.source,
+        reason: validPackage ? null : npm.reason ?? "unexpected_package",
+        downloads: validPackage ? count(npm.data.downloads) : null,
+        start: validPackage ? date(npm.data.start) : null,
+        end: validPackage ? date(npm.data.end) : null,
+      },
+    };
+  }));
+  const [ours, comparison] = rows;
+  const starsComparable = ours.github.stars !== null && comparison.github.stars !== null;
+  const downloadsComparable = ours.npm.downloads !== null && comparison.npm.downloads !== null &&
+    ours.npm.start !== null && ours.npm.end !== null && ours.npm.start <= ours.npm.end &&
+    ours.npm.start === comparison.npm.start && ours.npm.end === comparison.npm.end;
+  return {
+    schemaVersion: "premiere-pro-mcp.competitive-scorecard.v1",
+    observedAt: now().toISOString(),
+    projects: rows,
+    comparison: {
+      starsToLead: starsComparable ? Math.max(0, comparison.github.stars + 1 - ours.github.stars) : null,
+      starLead: starsComparable ? ours.github.stars - comparison.github.stars : null,
+      npmDownloadLead: downloadsComparable ? ours.npm.downloads - comparison.npm.downloads : null,
+      npmWindowsComparable: downloadsComparable,
+    },
+    search: { state: "not_measured", googlePosition: null, githubSearchPosition: null },
+    workflowSuccess: { state: "not_measured", licensedHostRuns: null },
+    boundaries: [
+      "Stars and forks are public repository signals, not active editors or workflow quality.",
+      "npm counts include CI, repeat downloads, and automation; they do not establish unique installs or users.",
+      "The star target changes when either repository gains or loses stars.",
+      "Unknown or failed measurements remain null. Search results require a separately dated query, engine, locale, and method.",
+    ],
+  };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length && (args.length !== 2 || args[0] !== "--output" || !args[1] || args[1].startsWith("--"))) {
+    throw new Error("Usage: node scripts/competitive-scorecard.mjs [--output <new-snapshot.json>]");
+  }
+  const snapshot = await collectCompetitiveScorecard();
+  const json = `${JSON.stringify(snapshot, null, 2)}\n`;
+  if (args.length) {
+    const output = resolve(args[1]);
+    await mkdir(dirname(output), { recursive: true });
+    // Historical evidence must not be silently overwritten.
+    await writeFile(output, json, { flag: "wx" });
+  }
+  process.stdout.write(json);
+  if (snapshot.projects.some((row) => row.github.stars === null || row.github.forks === null || row.npm.downloads === null || row.npm.start === null || row.npm.end === null)) process.exitCode = 1;
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch(() => {
+    console.error("Scorecard failed. Check arguments, network access, and whether the output file already exists; existing snapshots are never replaced.");
+    process.exitCode = 1;
+  });
+}

--- a/scripts/competitive-scorecard.mjs
+++ b/scripts/competitive-scorecard.mjs
@@ -6,6 +6,8 @@ export const projects = [
   { role: "ours", repository: "leancoderkavy/premiere-pro-mcp", package: "premiere-pro-mcp" },
   { role: "comparison", repository: "hetpatel-11/Adobe_Premiere_Pro_MCP", package: "adobe-premiere-pro-mcp" },
 ];
+const githubSearchQuery = "premiere pro mcp";
+const githubSearchUrl = `https://api.github.com/search/repositories?q=${encodeURIComponent(githubSearchQuery)}&per_page=100&page=1`;
 const count = (value) => Number.isSafeInteger(value) && value >= 0 ? value : null;
 const date = (value) => {
   if (typeof value !== "string" || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
@@ -27,7 +29,7 @@ async function readPublicJson(url, fetcher) {
 }
 
 export async function collectCompetitiveScorecard({ fetcher = fetch, now = () => new Date() } = {}) {
-  const rows = await Promise.all(projects.map(async (project) => {
+  const [rows, searchSample] = await Promise.all([Promise.all(projects.map(async (project) => {
     const [github, npm] = await Promise.all([
       readPublicJson(`https://api.github.com/repos/${project.repository}`, fetcher),
       readPublicJson(`https://api.npmjs.org/downloads/point/last-week/${project.package}`, fetcher),
@@ -52,7 +54,28 @@ export async function collectCompetitiveScorecard({ fetcher = fetch, now = () =>
         end: validPackage ? date(npm.data.end) : null,
       },
     };
-  }));
+  })), readPublicJson(githubSearchUrl, fetcher)]);
+  const completeSearch = searchSample.data?.incomplete_results === false &&
+    Array.isArray(searchSample.data?.items) &&
+    searchSample.data.items.every((item) => typeof item?.full_name === "string");
+  const githubSearch = {
+    state: completeSearch ? "observed" : "unavailable",
+    reason: completeSearch ? null : searchSample.reason ?? "incomplete_or_invalid_search",
+    source: githubSearchUrl,
+    query: githubSearchQuery,
+    method: "github_rest_best_match_unauthenticated",
+    page: 1,
+    limit: 100,
+    totalCount: count(searchSample.data?.total_count),
+    returnedCount: completeSearch ? searchSample.data.items.length : null,
+    positions: projects.map(({ role, repository }) => {
+      const index = completeSearch ? searchSample.data.items.findIndex((item) => item.full_name.toLowerCase() === repository.toLowerCase()) : -1;
+      return {
+        role, repository, position: index >= 0 ? index + 1 : null,
+        state: !completeSearch ? "unavailable" : index >= 0 ? "observed" : "not_in_returned_results",
+      };
+    }),
+  };
   const [ours, comparison] = rows;
   const starsComparable = ours.github.stars !== null && comparison.github.stars !== null;
   const downloadsComparable = ours.npm.downloads !== null && comparison.npm.downloads !== null &&
@@ -68,13 +91,14 @@ export async function collectCompetitiveScorecard({ fetcher = fetch, now = () =>
       npmDownloadLead: downloadsComparable ? ours.npm.downloads - comparison.npm.downloads : null,
       npmWindowsComparable: downloadsComparable,
     },
-    search: { state: "not_measured", googlePosition: null, githubSearchPosition: null },
+    search: { google: { state: "not_measured", position: null }, github: githubSearch },
     workflowSuccess: { state: "not_measured", licensedHostRuns: null },
     boundaries: [
       "Stars and forks are public repository signals, not active editors or workflow quality.",
       "npm counts include CI, repeat downloads, and automation; they do not establish unique installs or users.",
       "The star target changes when either repository gains or loses stars.",
       "Unknown or failed measurements remain null. Search results require a separately dated query, engine, locale, and method.",
+      "GitHub API best-match order is one query sample, not a Google rank, GitHub Trending rank, or personalized browser result. Absence from the returned page is not an inferred position.",
     ],
   };
 }
@@ -93,7 +117,7 @@ async function main() {
     await writeFile(output, json, { flag: "wx" });
   }
   process.stdout.write(json);
-  if (snapshot.projects.some((row) => row.github.stars === null || row.github.forks === null || row.npm.downloads === null || row.npm.start === null || row.npm.end === null)) process.exitCode = 1;
+  if (snapshot.search.github.state !== "observed" || snapshot.projects.some((row) => row.github.stars === null || row.github.forks === null || row.npm.downloads === null || row.npm.start === null || row.npm.end === null)) process.exitCode = 1;
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/scripts/generate-marketing-reference.mjs
+++ b/scripts/generate-marketing-reference.mjs
@@ -55,6 +55,7 @@ The hosted endpoint does not automatically pair a visitor to their local Premier
 - Claude setup: ${origin}/blog/claude-desktop-premiere-pro-mcp-setup/
 - Codex setup: ${origin}/blog/codex-premiere-pro-mcp-setup/
 - MCP setup: ${origin}/blog/how-to-set-up-premiere-pro-mcp/
+- Package comparison: ${origin}/blog/premiere-pro-mcp-vs-adobe-premiere-pro-mcp/
 - AI in Premiere: ${origin}/blog/set-up-ai-in-premiere-pro/
 - ChatGPT connection options: ${origin}/blog/chatgpt-premiere-pro-mcp/
 - Workflow automation: ${origin}/blog/premiere-pro-workflow-automation/

--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -1,0 +1,44 @@
+import path from "node:path";
+
+export const CLIENT_CONFIG_TARGETS = ["claude", "cursor", "vscode", "codex"] as const;
+export type ClientConfigTarget = typeof CLIENT_CONFIG_TARGETS[number];
+
+const usage = "Usage: premiere-pro-mcp --print-client-config <claude|cursor|vscode|codex>. Use this action alone.";
+
+/** Resolve this action before any installer, update, or server startup branch. */
+export function parseClientConfigAction(args: string[]): ClientConfigTarget | undefined {
+  if (!args.some((arg) => arg === "--print-client-config" || arg.startsWith("--print-client-config="))) return undefined;
+  if (args.length !== 2 || args[0] !== "--print-client-config" ||
+      !CLIENT_CONFIG_TARGETS.includes(args[1] as ClientConfigTarget)) {
+    throw new Error(usage);
+  }
+  return args[1] as ClientConfigTarget;
+}
+
+/**
+ * Print a mergeable entry for this installed copy, bypassing the shared global
+ * command name. No file/config inspection, environment copying, or host contact.
+ * Paths are intentionally local and must not be included in public diagnostics.
+ */
+export function renderClientConfig(
+  target: ClientConfigTarget,
+  nodeExecutable: string,
+  serverEntrypoint: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (!CLIENT_CONFIG_TARGETS.includes(target)) throw new Error(usage);
+  const paths = platform === "win32" ? path.win32 : path.posix;
+  for (const value of [nodeExecutable, serverEntrypoint]) {
+    if (!paths.isAbsolute(value) || /[\u0000-\u001f\u007f]/u.test(value) || value.includes("${")) {
+      throw new Error("Client configuration requires absolute paths without control characters or client variable expressions.");
+    }
+  }
+  const entry = { command: nodeExecutable, args: [serverEntrypoint] };
+  if (target === "codex") {
+    return `[mcp_servers.premiere-pro-leancoderkavy]\ncommand = ${JSON.stringify(entry.command)}\nargs = ${JSON.stringify(entry.args)}\n`;
+  }
+  const config = target === "vscode"
+    ? { servers: { "premiere-pro-leancoderkavy": { type: "stdio", ...entry } } }
+    : { mcpServers: { "premiere-pro-leancoderkavy": entry } };
+  return `${JSON.stringify(config, null, 2)}\n`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
 } from "./diagnostics.js";
 import { applyDoctorRepairPlan } from "./doctor-repairs.js";
 import { compareVersions, fetchLatestNpmVersion } from "./update.js";
+import { parseClientConfigAction, renderClientConfig } from "./client-config.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -134,6 +135,17 @@ async function runPackageUpdate(apply: boolean): Promise<void> {
 // Handle CLI flags
 const args = process.argv.slice(2);
 
+try {
+  const client = parseClientConfigAction(args);
+  if (client) {
+    process.stdout.write(renderClientConfig(client, process.execPath, __filename));
+    process.exit(0);
+  }
+} catch (error) {
+  console.error(error instanceof Error ? error.message : "Could not generate client configuration.");
+  process.exit(1);
+}
+
 if (args.includes("--help") || args.includes("-h")) {
   console.log(`
 premiere-pro-mcp — MCP server for Adobe Premiere Pro (367 default-profile tools)
@@ -152,6 +164,7 @@ Usage:
   premiere-pro-mcp --doctor --apply-fixes Apply only safe planned local fixes; requires explicit Premiere-closed confirmation where needed
   premiere-pro-mcp --doctor --apply-fixes --confirm-premiere-closed Confirm Premiere is fully closed before a connector repair
   premiere-pro-mcp --support-bundle  Print a privacy-safe, machine-readable support bundle
+  premiere-pro-mcp --print-client-config <claude|cursor|vscode|codex> Print configuration for this installed copy; writes no files
   premiere-pro-mcp --check-update    Check npm for a newer released local server
   premiere-pro-mcp --update          Update an npm global install and refresh the CEP connector
   premiere-pro-mcp --help          Show this help message

--- a/tests/client-config.test.ts
+++ b/tests/client-config.test.ts
@@ -1,0 +1,63 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseClientConfigAction, renderClientConfig } from "../src/client-config.js";
+
+describe("configuration for an exact local installation", () => {
+  it.each(["claude", "cursor"] as const)("prints a %s entry without relying on the global command", (client) => {
+    const node = 'C:\\Program Files\\nodejs\\node.exe';
+    const server = 'C:\\Users\\An Editor\\MCP \\"test"\\dist\\index.js';
+    const config = JSON.parse(renderClientConfig(client, node, server, "win32"));
+    expect(config).toEqual({ mcpServers: { "premiere-pro-leancoderkavy": { command: node, args: [server] } } });
+  });
+
+  it("uses VS Code's servers container and serializes macOS paths as arguments", () => {
+    const config = JSON.parse(renderClientConfig("vscode", "/opt/node/bin/node", "/Users/Editor/MCP & tools/dist/index.js", "darwin"));
+    expect(config).toEqual({ servers: { "premiere-pro-leancoderkavy": {
+      type: "stdio", command: "/opt/node/bin/node", args: ["/Users/Editor/MCP & tools/dist/index.js"],
+    } } });
+  });
+
+  it("escapes Codex TOML paths, including Windows backslashes and quotes", () => {
+    const config = renderClientConfig("codex", "C:\\Program Files\\node.exe", 'C:\\MCP "copy"\\dist\\index.js', "win32");
+    const lines = config.trim().split("\n");
+    expect(lines[0]).toBe("[mcp_servers.premiere-pro-leancoderkavy]");
+    expect(JSON.parse(lines[1].slice("command = ".length))).toBe("C:\\Program Files\\node.exe");
+    expect(JSON.parse(lines[2].slice("args = ".length))).toEqual(['C:\\MCP "copy"\\dist\\index.js']);
+  });
+
+  it.each(["relative/index.js", "/tmp/new\nline/index.js", "/tmp/${input:command}/index.js"])("rejects a path clients could misinterpret: %s", (entry) => {
+    expect(() => renderClientConfig("cursor", "/usr/bin/node", entry, "darwin")).toThrow("absolute paths");
+  });
+
+  it.each([
+    ["--print-client-config"], ["--print-client-config", "unknown"],
+    ["--print-client-config=codex"], ["--print-client-config", "codex", "--install-cep"],
+    ["--update", "--print-client-config", "vscode"], ["--help", "--print-client-config", "claude"],
+  ])("rejects incomplete or combined actions before any mutation: %j", (...args) => {
+    expect(() => parseClientConfigAction(args)).toThrow("Use this action alone");
+  });
+
+  it("leaves existing CLI actions alone", () => {
+    expect(parseClientConfigAction(["--doctor", "--json"])).toBeUndefined();
+    expect(parseClientConfigAction(["--print-client-config", "codex"])).toBe("codex");
+  });
+
+  it("emits clean JSON from the built CLI that can launch the same package", () => {
+    const cli = path.resolve("dist/index.js");
+    const result = spawnSync(process.execPath, [cli, "--print-client-config", "claude"], { encoding: "utf8", timeout: 10000, windowsHide: true });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toBe("");
+    const entry = JSON.parse(result.stdout).mcpServers["premiere-pro-leancoderkavy"];
+    expect(entry).toEqual({ command: process.execPath, args: [cli] });
+    const version = execFileSync(entry.command, [...entry.args, "--version"], { encoding: "utf8", timeout: 10000, windowsHide: true });
+    expect(version.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("exits on a conflicting installer flag without running an installer", () => {
+    const result = spawnSync(process.execPath, [path.resolve("dist/index.js"), "--print-client-config", "claude", "--install-cep"], { encoding: "utf8", timeout: 10000, windowsHide: true });
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("Use this action alone");
+  });
+});

--- a/tests/competitive-scorecard.test.ts
+++ b/tests/competitive-scorecard.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { collectCompetitiveScorecard } from "../scripts/competitive-scorecard.mjs";
+
+const now = () => new Date("2026-09-09T08:00:00Z");
+function publicApi(options: { failGithub?: boolean; mismatchedWindow?: boolean; wrongIdentity?: boolean; missingStars?: boolean } = {}) {
+  return async (url: string) => {
+    const ours = !url.includes("hetpatel") && !url.includes("last-week/adobe-");
+    if (url.includes("api.github.com")) {
+      if (options.failGithub) return { ok: false, status: 403 };
+      return { ok: true, json: async () => ({
+        full_name: options.wrongIdentity ? "someone/else" : ours ? "leancoderkavy/premiere-pro-mcp" : "hetpatel-11/Adobe_Premiere_Pro_MCP",
+        stargazers_count: options.missingStars ? undefined : ours ? 240 : 529,
+        forks_count: ours ? 39 : 110,
+      }) };
+    }
+    return { ok: true, json: async () => ({
+      package: ours ? "premiere-pro-mcp" : "adobe-premiere-pro-mcp",
+      downloads: ours ? 1897 : 1123, start: "2026-08-31",
+      end: options.mismatchedWindow && !ours ? "2026-09-05" : "2026-09-06",
+    }) };
+  };
+}
+
+describe("competitive measurement boundaries", () => {
+  it("requires one more star than the competitor and compares equal npm windows", async () => {
+    const snapshot = await collectCompetitiveScorecard({ fetcher: publicApi(), now });
+    expect(snapshot.comparison).toEqual({ starsToLead: 290, starLead: -289, npmDownloadLead: 774, npmWindowsComparable: true });
+    expect(snapshot.search.googlePosition).toBeNull();
+    expect(snapshot.workflowSuccess.licensedHostRuns).toBeNull();
+  });
+
+  it.each([{ failGithub: true }, { wrongIdentity: true }, { missingStars: true }])("preserves unknown counts instead of inventing zeroes: %j", async (options) => {
+    const snapshot = await collectCompetitiveScorecard({ fetcher: publicApi(options), now });
+    expect(snapshot.projects[0].github.stars).toBeNull();
+    expect(snapshot.comparison.starsToLead).toBeNull();
+    expect(snapshot.comparison.starLead).toBeNull();
+  });
+
+  it("does not compare downloads from unequal date ranges", async () => {
+    const snapshot = await collectCompetitiveScorecard({ fetcher: publicApi({ mismatchedWindow: true }), now });
+    expect(snapshot.comparison.npmWindowsComparable).toBe(false);
+    expect(snapshot.comparison.npmDownloadLead).toBeNull();
+  });
+
+  it("keeps network failures separate from measurements without leaking exception text", async () => {
+    const snapshot = await collectCompetitiveScorecard({ fetcher: async () => { throw new Error("private diagnostics"); }, now });
+    expect(snapshot.projects[0].npm.state).toBe("unavailable");
+    expect(snapshot.projects[0].npm.downloads).toBeNull();
+    expect(JSON.stringify(snapshot)).not.toContain("private diagnostics");
+  });
+});

--- a/tests/competitive-scorecard.test.ts
+++ b/tests/competitive-scorecard.test.ts
@@ -2,9 +2,17 @@ import { describe, expect, it } from "vitest";
 import { collectCompetitiveScorecard } from "../scripts/competitive-scorecard.mjs";
 
 const now = () => new Date("2026-09-09T08:00:00Z");
-function publicApi(options: { failGithub?: boolean; mismatchedWindow?: boolean; wrongIdentity?: boolean; missingStars?: boolean } = {}) {
+function publicApi(options: { failGithub?: boolean; mismatchedWindow?: boolean; wrongIdentity?: boolean; missingStars?: boolean; incompleteSearch?: boolean; missingSearchEntry?: boolean } = {}) {
   return async (url: string) => {
     const ours = !url.includes("hetpatel") && !url.includes("last-week/adobe-");
+    if (url.includes("/search/repositories")) return { ok: true, json: async () => ({
+      incomplete_results: options.incompleteSearch ?? false,
+      total_count: 47,
+      items: [
+        { full_name: "hetpatel-11/Adobe_Premiere_Pro_MCP" },
+        ...(options.missingSearchEntry ? [] : [{ full_name: "leancoderkavy/premiere-pro-mcp" }]),
+      ],
+    }) };
     if (url.includes("api.github.com")) {
       if (options.failGithub) return { ok: false, status: 403 };
       return { ok: true, json: async () => ({
@@ -25,7 +33,8 @@ describe("competitive measurement boundaries", () => {
   it("requires one more star than the competitor and compares equal npm windows", async () => {
     const snapshot = await collectCompetitiveScorecard({ fetcher: publicApi(), now });
     expect(snapshot.comparison).toEqual({ starsToLead: 290, starLead: -289, npmDownloadLead: 774, npmWindowsComparable: true });
-    expect(snapshot.search.googlePosition).toBeNull();
+    expect(snapshot.search.google.position).toBeNull();
+    expect(snapshot.search.github.positions.map((row) => row.position)).toEqual([2, 1]);
     expect(snapshot.workflowSuccess.licensedHostRuns).toBeNull();
   });
 
@@ -40,6 +49,18 @@ describe("competitive measurement boundaries", () => {
     const snapshot = await collectCompetitiveScorecard({ fetcher: publicApi({ mismatchedWindow: true }), now });
     expect(snapshot.comparison.npmWindowsComparable).toBe(false);
     expect(snapshot.comparison.npmDownloadLead).toBeNull();
+  });
+
+  it("withholds all positions when GitHub reports an incomplete search", async () => {
+    const snapshot = await collectCompetitiveScorecard({ fetcher: publicApi({ incompleteSearch: true }), now });
+    expect(snapshot.search.github.state).toBe("unavailable");
+    expect(snapshot.search.github.positions.every((row) => row.position === null)).toBe(true);
+  });
+
+  it("does not invent a rank for a repository outside the returned sample", async () => {
+    const snapshot = await collectCompetitiveScorecard({ fetcher: publicApi({ missingSearchEntry: true }), now });
+    expect(snapshot.search.github.positions[0]).toMatchObject({ position: null, state: "not_in_returned_results" });
+    expect(snapshot.search.github.positions[1].position).toBe(1);
   });
 
   it("keeps network failures separate from measurements without leaking exception text", async () => {

--- a/tests/competitive-scorecard.test.ts
+++ b/tests/competitive-scorecard.test.ts
@@ -4,8 +4,10 @@ import { collectCompetitiveScorecard } from "../scripts/competitive-scorecard.mj
 const now = () => new Date("2026-09-09T08:00:00Z");
 function publicApi(options: { failGithub?: boolean; mismatchedWindow?: boolean; wrongIdentity?: boolean; missingStars?: boolean; incompleteSearch?: boolean; missingSearchEntry?: boolean } = {}) {
   return async (url: string) => {
-    const ours = !url.includes("hetpatel") && !url.includes("last-week/adobe-");
-    if (url.includes("/search/repositories")) return { ok: true, json: async () => ({
+    const requestUrl = new URL(url);
+    const ours = requestUrl.pathname === "/repos/leancoderkavy/premiere-pro-mcp" ||
+      requestUrl.pathname === "/downloads/point/last-week/premiere-pro-mcp";
+    if (requestUrl.hostname === "api.github.com" && requestUrl.pathname === "/search/repositories") return { ok: true, json: async () => ({
       incomplete_results: options.incompleteSearch ?? false,
       total_count: 47,
       items: [
@@ -13,7 +15,7 @@ function publicApi(options: { failGithub?: boolean; mismatchedWindow?: boolean; 
         ...(options.missingSearchEntry ? [] : [{ full_name: "leancoderkavy/premiere-pro-mcp" }]),
       ],
     }) };
-    if (url.includes("api.github.com")) {
+    if (requestUrl.hostname === "api.github.com") {
       if (options.failGithub) return { ok: false, status: 403 };
       return { ok: true, json: async () => ({
         full_name: options.wrongIdentity ? "someone/else" : ours ? "leancoderkavy/premiere-pro-mcp" : "hetpatel-11/Adobe_Premiere_Pro_MCP",


### PR DESCRIPTION
## What does this PR do?

The `premiere-pro-mcp` and `adobe-premiere-pro-mcp` packages both declare the same global command. Add `--print-client-config <claude|cursor|vscode|codex>` to print a client entry using the current Node executable and server entrypoint by absolute path. It writes no configuration, copies no environment values, and rejects combined installer/update actions before they can run.

Add a sourced package comparison and switching guide, linked through the guide index, sitemap and generated references. Add a public GitHub/npm scorecard and dated baselines. The latest snapshot records 241 vs 530 stars, 1,897 vs 1,123 npm downloads for August 31–September 6, and GitHub REST best-match positions 2 vs 1 for the exact query `premiere pro mcp`. Missing/incomplete results stay null; the API sample is not a Google or personalized-browser rank. The execution notes prioritize real workflow evidence and organic adoption.

The helper is explicitly marked as development source: it is absent from published v1.15.0. Generated paths remain local and need refreshing if the installation moves. Real client acceptance and licensed-Premiere workflow performance require separate validation.

## Related Issue

Implements the requested comparison and competitive growth work against `hetpatel-11/Adobe_Premiere_Pro_MCP`.

## Type of Change

- [x] Bug fix / setup improvement
- [x] Documentation
- [x] Other: public measurement tooling

## New Tools Added (if any)

No new MCP tools. Catalog counts are unchanged; this adds a CLI action.

## Validation

- Final commit `135ece83f4449ff94ad8bf0b175d7baf26689c4f`: all 15 PR checks passed. The six Windows/macOS Node 20/22/24 lanes passed; Windows Node 22 verified 171 files and 3,226 tests plus coverage (94.95% statements, 90.63% branches, 96.71% functions, 97.09% lines). CodeQL reports no new alerts. [CI run](https://github.com/leancoderkavy/premiere-pro-mcp/actions/runs/34323758770).
- `npm run check`: 171 test files, 3,224 tests passed, including build and required metadata/documentation checks.
- 24 focused configuration/scorecard tests passed after adding bounded GitHub search measurement; generated configuration launches this package. An independent TOML parser accepted Codex output.
- Landing lint, production build and performance budget passed.
- SEO export verified 25 canonical pages and 428 internal links/anchors, with unique titles/descriptions and valid JSON-LD.
- `npm run pack:check`: package contents and isolated CLI installation passed.
- Playwright against the production HTTP server locally: desktop 1440px and mobile 390px, no horizontal overflow, one H1 and correct canonical, FAQ and setup-guide navigation working, no console errors in the production-server pass.
- `git diff --check` passed.

## Checklist

- [x] Build compiles and existing catalogs remain aligned.
- [x] No duplicate MCP tool names introduced.
- [x] Local configuration output avoids shell commands and secret-bearing settings.
- [x] Public claims cite the other project's inspected commit and distinguish evidence scope.
- [ ] Tested with Premiere Pro: not performed; no host mutation is introduced.

ExtendScript and new MCP-tool registration checklist items do not apply. This draft has not been merged, deployed, or released.
