### PR TITLE
Release v1.15.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "premiere-pro",
       "source": "./claude-plugins/premiere-pro",
       "description": "Inspect, edit, verify, and export local Premiere Pro projects through MCP.",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "category": "creative",
       "tags": ["premiere-pro", "video-editing", "mcp"]
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.15.1] - 2026-09-11
+
+### Fixed
+
+- Use a null destination for UXP project-root file imports, matching the Premiere API contract.
+- Consolidate exported page aliases with permanent redirects and improve homepage accessibility, image delivery, and installation journeys.
+
+### Changed
+
+- Add a searchable tool reference, precise client configuration, and clearer competitive evaluation guidance.
+- Refresh the homepage experiment with Premiere artwork and gallery layouts, with end-to-end journey coverage.
+- Update landing dependencies and comparable GitHub search measurement.
+
+Automated checks do not establish licensed Premiere or After Effects playback or rendered-output verification.
+
 ## [1.15.0] - 2026-09-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -102,15 +102,15 @@ installs it.
 and repository before configuring a client. The new
 [local configuration helper](docs/client-configuration.md) prints Claude, Cursor,
 VS Code, or Codex settings that point directly to this installation. It is a
-development-source feature; the published v1.15.0 package does not include it.
+feature included in v1.15.1 and later.
 
 The current source exposes 369 core tools for supported workflow steps spanning the supported ExtendScript, QE DOM, local media and interchange analysis, revisioned project-context retrieval, safe edit-planning, project-intake preview, review handoff, connection verification, and guarded After Effects MOGRT authoring, batch, library, render-queue, inspection, and Premiere-handoff workflows. A compatible, authenticated UXP panel adds 93 documented, capability-gated tools without replacing the production CEP bridge.
 
 <a id="latest-release"></a>
 
-### Latest release: 1.15.0
+### Latest release: 1.15.1
 
-The published v1.15.0 npm artifact contains **369 core tools**, 367 in its default profile,
+The published v1.15.1 npm artifact contains **369 core tools**, 367 in its default profile,
 and 460 with a compatible UXP connection. The development catalog above can include
 unreleased work. See the [versioned facts and package provenance](https://premiere-pro-mcp.com/facts/).
 
@@ -160,7 +160,7 @@ if the connection is unavailable.
   local Premiere processes. See the generated [supported action catalog](docs/supported-actions.md)
   for individual capability and verification contracts.
 
-See the [v1.15.0 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.15.0)
+See the [v1.15.1 release notes](https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.15.1)
 for complete details. Live installation in Premiere Pro still requires host verification.
 
 ### Current MCP protocol support
@@ -207,9 +207,9 @@ their bins, media rules, and organization rules before a facility uses one.
 
 ### Easiest supported path: Claude Desktop
 
-1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.15.0/premiere-pro-mcp-1.15.0.mcpb).
+1. Download the current [Claude Desktop bundle (`.mcpb`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.15.1/premiere-pro-mcp-1.15.1.mcpb).
 2. In Claude Desktop, open **Settings > Extensions > Advanced settings > Install Extension**, select the downloaded bundle, and restart Claude Desktop.
-3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.15.0/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
+3. Download the separate [signed Premiere connector (`.zxp`)](https://github.com/leancoderkavy/premiere-pro-mcp/releases/download/v1.15.1/MCPBridgeCEP.zxp). Open it with your trusted ZXP installer. If your computer has no ZXP installer, use the npm connector installer in **Advanced setup** below.
 4. Restart Premiere, open a project, then open **Window > Extensions > MCP for Adobe Premiere Pro**.
 5. In Claude, enter: `Safely check my Premiere connection with verify_premiere_connection. Make no changes.`
 
@@ -506,11 +506,11 @@ From a clone of this repository:
 ```bash
 codex plugin marketplace add .
 codex plugin add premiere-pro@premiere-pro-mcp
-npx -y premiere-pro-mcp@1.15.0 --install-cep
+npx -y premiere-pro-mcp@1.15.1 --install-cep
 ```
 
 Restart Premiere Pro and start a new Codex session after installation. The plugin
-launches `premiere-pro-mcp@1.15.0` through `npx`; the separate CEP installation is
+launches `premiere-pro-mcp@1.15.1` through `npx`; the separate CEP installation is
 required because the MCP server communicates with the running Premiere host through
 the local bridge.
 
@@ -541,7 +541,7 @@ For Claude Code, add this repository as a marketplace and install the plugin:
 Then install the Premiere bridge and start a new Claude Code session:
 
 ```bash
-npx -y premiere-pro-mcp@1.15.0 --install-cep
+npx -y premiere-pro-mcp@1.15.1 --install-cep
 ```
 
 The Claude Code package lives in

--- a/after-effects-cep-plugin/CSXS/manifest.xml
+++ b/after-effects-cep-plugin/CSXS/manifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.aftereffects.bridge" ExtensionBundleVersion="1.15.0" ExtensionBundleName="MCP for Adobe After Effects">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.aftereffects.bridge" ExtensionBundleVersion="1.15.1" ExtensionBundleName="MCP for Adobe After Effects">
   <ExtensionList>
-    <Extension Id="com.mcp.aftereffects.bridge.panel" Version="1.15.0"/>
+    <Extension Id="com.mcp.aftereffects.bridge.panel" Version="1.15.1"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/cep-plugin/CSXS/manifest.xml
+++ b/cep-plugin/CSXS/manifest.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.15.0" ExtensionBundleName="MCP for Adobe Premiere Pro">
+<ExtensionManifest Version="7.0" ExtensionBundleId="com.mcp.premiere.bridge" ExtensionBundleVersion="1.15.1" ExtensionBundleName="MCP for Adobe Premiere Pro">
   <ExtensionList>
-    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.15.0"/>
-    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.15.0"/>
+    <Extension Id="com.mcp.premiere.bridge.panel" Version="1.15.1"/>
+    <Extension Id="com.mcp.premiere.bridge.headless" Version="1.15.1"/>
   </ExtensionList>
   <ExecutionEnvironment>
     <HostList>

--- a/cep-plugin/index.html
+++ b/cep-plugin/index.html
@@ -81,7 +81,7 @@
     <section class="update-section" aria-live="polite">
       <div class="update-copy">
         <span class="section-label">MCP updates</span>
-        <strong id="updateTitle">Version 1.15.0</strong>
+        <strong id="updateTitle">Version 1.15.1</strong>
         <span id="updateDetail">Checking the global MCP server and connector release…</span>
       </div>
       <button id="btnUpdate" class="button button-update" onclick="handleUpdateClick()" type="button" aria-describedby="updateDetail" disabled>

--- a/cep-plugin/updater.cjs
+++ b/cep-plugin/updater.cjs
@@ -7,7 +7,7 @@
 })(this, function () {
   "use strict";
 
-  var CURRENT_VERSION = "1.15.0";
+  var CURRENT_VERSION = "1.15.1";
   var PACKAGE_NAME = "premiere-pro-mcp";
   var LATEST_PACKAGE_API = "https://registry.npmjs.org/" + PACKAGE_NAME;
   var LATEST_RELEASE_API =

--- a/claude-desktop/manifest.json
+++ b/claude-desktop/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "premiere-pro-mcp",
   "display_name": "MCP for Adobe Premiere Pro",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Control a local Adobe Premiere Pro project through MCP.",
   "long_description": "Inspect projects, assemble and modify timelines, manage media, effects, audio and captions, and export deliverables through a local bridge to Adobe Premiere Pro.",
   "author": {

--- a/claude-plugins/premiere-pro/.claude-plugin/plugin.json
+++ b/claude-plugins/premiere-pro/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "premiere-pro",
   "displayName": "Premiere Pro MCP",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Inspect, edit, verify, and export local Adobe Premiere Pro projects through MCP.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/claude-plugins/premiere-pro/.mcp.json
+++ b/claude-plugins/premiere-pro/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "premiere-pro": {
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.15.0"]
+      "args": ["-y", "premiere-pro-mcp@1.15.1"]
     }
   }
 }

--- a/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/claude-plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -19,7 +19,7 @@ project state, make only requested changes, and verify the timeline after mutati
    silently fall back to CEP after a failed UXP probe.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.15.0 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.15.1 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/docs/client-configuration.md
+++ b/docs/client-configuration.md
@@ -1,8 +1,6 @@
 # Configure an exact local server installation
 
-Development source feature, added September 9, 2026. The published v1.15.0 package
-does **not** include `--print-client-config`; use a built checkout containing this
-change until a release includes it.
+The `--print-client-config` helper is included in v1.15.1 and later.
 
 The `premiere-pro-mcp` and `adobe-premiere-pro-mcp` npm packages belong to separate
 repositories, but both declare a `premiere-pro-mcp` command. A command name alone

--- a/landing/app/changelog/page.tsx
+++ b/landing/app/changelog/page.tsx
@@ -6,6 +6,22 @@ import { product } from "@/lib/product"
 
 const releases = [
   {
+    version: "1.15.1",
+    date: "2026-09-11",
+    label: "UXP import fix, searchable tools, and clearer setup",
+    groups: [
+      { title: "Fixed", items: [
+        "UXP project-root file imports now use the null destination required by the Premiere API.",
+        "Improved homepage accessibility, image delivery, installation journeys, and canonical page redirects."
+      ] },
+      { title: "Changed", items: [
+        "Searchable tool reference, precise client configuration, and competitive evaluation guidance.",
+        "Updated homepage experiment with Premiere artwork and gallery layouts, backed by end-to-end journey coverage."
+      ] },
+      { title: "Verification scope", items: ["Automated checks do not establish licensed-host playback or rendered-output verification."] }
+    ],
+  },
+  {
     version: "1.15.0",
     date: "2026-09-08",
     label: "Editorial planning, cross-app handoff, and verified editing fixes",

--- a/landing/e2e/homepage.spec.ts
+++ b/landing/e2e/homepage.spec.ts
@@ -34,7 +34,7 @@ for (const variant of ["control", "test"]) {
     expect(response?.headers()["cache-control"]).toContain("no-store")
     await expect(page.locator("h1")).toHaveText(variant === "test" ? /Your vision[\s\S]*timeline/ : /MCP for Adobe Premiere Pro:/)
     await expect.poll(async () => (await state(request)).events.filter(event => event.event === "$experiment_exposure").length).toBe(1)
-    expect(published.version).toBe(manifest.product.version)
+    expect(product.version).toBe(published.version)
     expect(published.coreTools).toBe(manifest.capabilitySurface.registeredCoreTools)
     await expect(page.locator("body")).toContainText(String(published.coreTools))
     await expect(page.locator("body")).toContainText(safeFirstPrompt)

--- a/landing/lib/source-catalog.json
+++ b/landing/lib/source-catalog.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.15.0",
+  "version": "1.15.1",
   "coreTools": 369,
   "defaultProfileTools": 367,
   "uxpAdditionalTools": 93,

--- a/landing/public/llms-full.txt
+++ b/landing/public/llms-full.txt
@@ -13,7 +13,7 @@ Release: https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.15.0
 
 ## Development source, separate from publication
 
-Current source metadata registers 369 core structured MCP tools, 367 in the default profile, and 93 capability-gated tools for 460 connected tools. Source package version: 1.15.0. Main may include changes not in the published package even when its version string is unchanged.
+Current source metadata registers 369 core structured MCP tools, 367 in the default profile, and 93 capability-gated tools for 460 connected tools. Source package version: 1.15.1. Main may include changes not in the published package even when its version string is unchanged.
 
 ## Start a workflow
 

--- a/landing/public/llms.txt
+++ b/landing/public/llms.txt
@@ -13,7 +13,7 @@ Release: https://github.com/leancoderkavy/premiere-pro-mcp/releases/tag/v1.15.0
 
 ## Development source, separate from publication
 
-Current source metadata registers 369 core structured MCP tools, 367 in the default profile, and 93 capability-gated tools for 460 connected tools. Source package version: 1.15.0. Main may include changes not in the published package even when its version string is unchanged.
+Current source metadata registers 369 core structured MCP tools, 367 in the default profile, and 93 capability-gated tools for 460 connected tools. Source package version: 1.15.1. Main may include changes not in the published package even when its version string is unchanged.
 
 ## Start a workflow
 

--- a/landing/public/marketing-facts.json
+++ b/landing/public/marketing-facts.json
@@ -25,7 +25,7 @@
     }
   },
   "developmentSource": {
-    "version": "1.15.0",
+    "version": "1.15.1",
     "coreTools": 369,
     "defaultProfileTools": 367,
     "uxpAdditionalTools": 93,

--- a/landing/public/tool-catalog.json
+++ b/landing/public/tool-catalog.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "evidenceScope": "source_catalog_may_include_unreleased_work",
-  "sourceVersion": "1.15.0",
+  "sourceVersion": "1.15.1",
   "sourcePath": "docs/supported-actions.md",
   "sourceSha256": "37832b4cc93726dda3c8964a200a520ccd0aa426ff5451dfded0657d758de7d9",
   "hostVerification": "not_established_by_catalogs",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "premiere-pro-mcp",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "premiere-pro-mcp",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/node": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "premiere-pro-mcp",
   "mcpName": "io.github.leancoderkavy/premiere-pro",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "MCP server for Adobe Premiere Pro with 369 core AI video editing tools, a guarded After Effects MOGRT studio, and a capability-aware UXP bridge for supported Premiere workflows.",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/premiere-pro/.codex-plugin/plugin.json
+++ b/plugins/premiere-pro/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "premiere-pro",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Plan, execute, verify, and export video edits in Adobe Premiere Pro through the Premiere Pro MCP server.",
   "author": {
     "name": "Premiere Pro MCP contributors",

--- a/plugins/premiere-pro/.mcp.json
+++ b/plugins/premiere-pro/.mcp.json
@@ -4,7 +4,7 @@
       "title": "Premiere Pro MCP",
       "description": "Inspect and edit a local Adobe Premiere Pro project through the Premiere Pro MCP bridge.",
       "command": "npx",
-      "args": ["-y", "premiere-pro-mcp@1.15.0"]
+      "args": ["-y", "premiere-pro-mcp@1.15.1"]
     }
   }
 }

--- a/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
+++ b/plugins/premiere-pro/skills/edit-premiere-project/SKILL.md
@@ -19,7 +19,7 @@ project state, make only requested changes, and verify the timeline after mutati
    silently fall back to CEP after a failed UXP probe.
 3. If `ping` fails, stop editing and tell the user to:
    - Open or restart Premiere Pro.
-   - Install the bridge with `npx -y premiere-pro-mcp@1.15.0 --install-cep` if needed.
+   - Install the bridge with `npx -y premiere-pro-mcp@1.15.1 --install-cep` if needed.
    - Open **Window > Extensions > MCP Bridge** and confirm it reports **Running**.
 4. Call `get_premiere_state` and inspect the active sequence before planning changes.
 5. Do not claim that a project, sequence, or export exists until a live tool result confirms it.

--- a/public-product-manifest.json
+++ b/public-product-manifest.json
@@ -10,7 +10,7 @@
     "name": "MCP for Adobe Premiere Pro",
     "mcpName": "io.github.leancoderkavy/premiere-pro",
     "npmPackage": "premiere-pro-mcp",
-    "version": "1.15.0",
+    "version": "1.15.1",
     "repository": "https://github.com/leancoderkavy/premiere-pro-mcp",
     "homepage": "https://premiere-pro-mcp.com/",
     "license": "MIT",

--- a/registry/server.json
+++ b/registry/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/leancoderkavy/premiere-pro-mcp",
     "source": "github"
   },
-  "version": "1.15.0",
+  "version": "1.15.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "premiere-pro-mcp",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "transport": {
         "type": "stdio"
       }

--- a/release-metadata.json
+++ b/release-metadata.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.15.0",
+  "version": "1.15.1",
   "coreTools": 369,
   "defaultProfileTools": 367,
   "uxpAdditionalTools": 93,

--- a/uxp-plugin/manifest.json
+++ b/uxp-plugin/manifest.json
@@ -2,7 +2,7 @@
   "manifestVersion": 5,
   "id": "com.ppmcp.premiere.uxp",
   "name": "MCP for Adobe Premiere Pro",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "main": "index.html",
   "host": { "app": "premierepro", "minVersion": "25.6.0" },
   "entrypoints": [


### PR DESCRIPTION
Prepare v1.15.1 with the merged UXP root-import fix, searchable tool reference, client configuration helper, and homepage accessibility and gallery improvements. Align all distribution manifests and add release notes while retaining verified v1.15.0 website publication facts until npm publication succeeds.

Correct the homepage test to compare displayed facts with published metadata, allowing source metadata to advance during release preparation.

Validation: npm run check (3,265 tests), package contents and isolated CLI install, landing lint/build/performance budgets, and SEO export (27 canonical pages).

Browser validation: all 35 Playwright tests passed.

